### PR TITLE
feat: add method-override middleware for spoofed PUT file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,13 @@ Base URL: `http://localhost:3000/api`
 | `DELETE` | `/workers/:id` | Delete a worker | Curator |
 | `PATCH` | `/workers/:id/toggle` | Toggle active status | Curator |
 
-> **Note on file uploads:** Use `POST` with the `X-HTTP-Method: PUT` header to update resources that include file uploads (e.g. profile images). Standard `PUT` does not support `multipart/form-data`.
+> **Method spoofing for file uploads:** HTML forms and `multipart/form-data` requests only support `GET`/`POST`. To update a worker with a file upload, send a `POST` request with the header `X-HTTP-Method: PUT`. The API uses the [`method-override`](https://www.npmjs.com/package/method-override) middleware to rewrite the request method to `PUT` before it reaches the route handler, so the update route behaves identically to a standard `PUT`.
+>
+> ```
+> POST /api/workers/:id
+> Content-Type: multipart/form-data
+> X-HTTP-Method: PUT
+> ```
 
 ### Admin
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,12 @@
   "prisma": {
     "seed": "tsx src/database/seed.ts"
   },
-  "keywords": ["skilled-workers", "stellar", "decentralized", "marketplace"],
+  "keywords": [
+    "skilled-workers",
+    "stellar",
+    "decentralized",
+    "marketplace"
+  ],
   "license": "MIT",
   "dependencies": {
     "@prisma/client": "^7.2.0",
@@ -24,6 +29,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
+    "method-override": "^3.0.0",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.9",
     "passport": "^0.7.0",
@@ -38,6 +44,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "latest",
     "@types/jsonwebtoken": "^9.0.9",
+    "@types/method-override": "^3.0.0",
     "@types/multer": "^1",
     "@types/node": "^22.0.0",
     "@types/nodemailer": "^6",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,7 @@
 // Entry point for BlueCollar API
 import express from 'express'
 import cors from 'cors'
+import methodOverride from 'method-override'
 import passport from './config/passport.js'
 import authRoutes from './routes/auth.js'
 import categoryRoutes from './routes/categories.js'
@@ -12,6 +13,7 @@ const PORT = process.env.PORT || 3000
 app.use(cors())
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
+app.use(methodOverride('X-HTTP-Method'))
 app.use(passport.initialize())
 
 app.use('/api/auth', authRoutes)

--- a/packages/api/src/routes/workers.ts
+++ b/packages/api/src/routes/workers.ts
@@ -16,7 +16,7 @@ const router = Router()
 router.get('/', listWorkers)
 router.get('/:id', showWorker)
 router.post('/', authenticate, authorize('curator'), validate(createWorkerRules), createWorker)
-router.post('/:id', authenticate, authorize('curator'), updateWorker) // method-spoofed PUT
+router.put('/:id', authenticate, authorize('curator'), updateWorker)
 router.delete('/:id', authenticate, authorize('curator'), deleteWorker)
 router.patch('/:id/toggle', authenticate, authorize('curator'), toggleActivation)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
+      method-override:
+        specifier: ^3.0.0
+        version: 3.0.0
       multer:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.2
@@ -62,6 +65,9 @@ importers:
       '@types/jsonwebtoken':
         specifier: ^9.0.9
         version: 9.0.10
+      '@types/method-override':
+        specifier: ^3.0.0
+        version: 3.0.0(@types/express@5.0.6)
       '@types/multer':
         specifier: ^1
         version: 1.4.13
@@ -883,6 +889,11 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
+  '@types/method-override@3.0.0':
+    resolution: {integrity: sha512-7XFHR6j7JljprBpzzRZatakUXm1kEGAM3PL/GSsGRHtDvOAKYCdmnXX/5YSl1eQrpJymGs9tRekSWEGaG+Ntjw==}
+    peerDependencies:
+      '@types/express': '*'
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1113,6 +1124,14 @@ packages:
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@3.1.0:
+    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -1456,6 +1475,10 @@ packages:
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  method-override@3.0.0:
+    resolution: {integrity: sha512-IJ2NNN/mSl9w3kzWB92rcdHpz+HjkxhDJWNDBqSlas+zQdP8wBiJzITPg08M/k2uVvMow7Sk41atndNtt/PHSA==}
+    engines: {node: '>= 0.10'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -2610,6 +2633,10 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 22.19.15
 
+  '@types/method-override@3.0.0(@types/express@5.0.6)':
+    dependencies:
+      '@types/express': 5.0.6
+
   '@types/ms@2.1.0': {}
 
   '@types/multer@1.4.13':
@@ -2873,6 +2900,10 @@ snapshots:
   csstype@3.2.3: {}
 
   debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  debug@3.1.0:
     dependencies:
       ms: 2.0.0
 
@@ -3260,6 +3291,15 @@ snapshots:
   merge-descriptors@1.0.3: {}
 
   merge-stream@2.0.0: {}
+
+  method-override@3.0.0:
+    dependencies:
+      debug: 3.1.0
+      methods: 1.1.2
+      parseurl: 1.3.3
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   methods@1.1.2: {}
 


### PR DESCRIPTION
feat: add method-override middleware for spoofed PUT file uploads

## Problem

The README documented a POST + X-HTTP-Method: PUT pattern for file upload updates, but the middleware to actually 
rewrite the method was never wired up. The worker update route was also registered as router.post instead of 
router.put, so the spoofing would have had no effect even if the middleware existed.

## Changes

- Installed method-override and @types/method-override
- Added app.use(methodOverride('X-HTTP-Method')) in src/index.ts (before routes)
- Changed worker update route from router.post('/:id') → router.put('/:id') so it correctly handles the rewritten 
method
- Updated README with the full request format for the spoofed PUT pattern

## Usage

POST /api/workers/:id
Content-Type: multipart/form-data
X-HTTP-Method: PUT

closes #21