### PR TITLE
fix: enforce curator ownership on updateWorker, deleteWorker, toggleActivation

### DIFF
--- a/packages/api/src/controllers/workers.test.ts
+++ b/packages/api/src/controllers/workers.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../db.js', () => ({
+  db: {
+    worker: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+import { db } from '../db.js'
+import { updateWorker, deleteWorker, toggleActivation } from '../controllers/workers.js'
+
+function makeRes() {
+  const res: any = {
+    statusCode: 200,
+    body: {},
+    status(code: number) { this.statusCode = code; return this },
+    json(data: any) { this.body = data; return this },
+    send() { return this },
+  }
+  return res
+}
+
+function makeReq(userId: string, role: string, workerId = 'worker-1'): any {
+  return { params: { id: workerId }, body: { name: 'Updated' }, user: { id: userId, role } }
+}
+
+const ownedWorker = { id: 'worker-1', curatorId: 'curator-1', isActive: true }
+
+beforeEach(() => vi.clearAllMocks())
+
+// ── updateWorker ──────────────────────────────────────────────────────────────
+
+describe('updateWorker', () => {
+  it('returns 403 when curator does not own the worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    const res = makeRes()
+    await updateWorker(makeReq('other-curator', 'curator'), res)
+    expect(res.statusCode).toBe(403)
+    expect(db.worker.update).not.toHaveBeenCalled()
+  })
+
+  it('updates when curator owns the worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    ;(db.worker.update as any).mockResolvedValue({ ...ownedWorker, name: 'Updated' })
+    const res = makeRes()
+    await updateWorker(makeReq('curator-1', 'curator'), res)
+    expect(res.statusCode).toBe(200)
+    expect(db.worker.update).toHaveBeenCalledOnce()
+  })
+
+  it('allows admin to update any worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    ;(db.worker.update as any).mockResolvedValue(ownedWorker)
+    const res = makeRes()
+    await updateWorker(makeReq('admin-1', 'admin'), res)
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('returns 404 when worker does not exist', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(null)
+    const res = makeRes()
+    await updateWorker(makeReq('curator-1', 'curator'), res)
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ── deleteWorker ──────────────────────────────────────────────────────────────
+
+describe('deleteWorker', () => {
+  it('returns 403 when curator does not own the worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    const res = makeRes()
+    await deleteWorker(makeReq('other-curator', 'curator'), res)
+    expect(res.statusCode).toBe(403)
+    expect(db.worker.delete).not.toHaveBeenCalled()
+  })
+
+  it('deletes when curator owns the worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    ;(db.worker.delete as any).mockResolvedValue(undefined)
+    const res = makeRes()
+    await deleteWorker(makeReq('curator-1', 'curator'), res)
+    expect(res.statusCode).toBe(204)
+    expect(db.worker.delete).toHaveBeenCalledOnce()
+  })
+
+  it('allows admin to delete any worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    ;(db.worker.delete as any).mockResolvedValue(undefined)
+    const res = makeRes()
+    await deleteWorker(makeReq('admin-1', 'admin'), res)
+    expect(res.statusCode).toBe(204)
+  })
+})
+
+// ── toggleActivation ──────────────────────────────────────────────────────────
+
+describe('toggleActivation', () => {
+  it('returns 403 when curator does not own the worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    const res = makeRes()
+    await toggleActivation(makeReq('other-curator', 'curator'), res)
+    expect(res.statusCode).toBe(403)
+    expect(db.worker.update).not.toHaveBeenCalled()
+  })
+
+  it('toggles isActive when curator owns the worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    ;(db.worker.update as any).mockResolvedValue({ ...ownedWorker, isActive: false })
+    const res = makeRes()
+    await toggleActivation(makeReq('curator-1', 'curator'), res)
+    expect(res.statusCode).toBe(200)
+    expect((db.worker.update as any).mock.calls[0][0].data.isActive).toBe(false)
+  })
+
+  it('allows admin to toggle any worker', async () => {
+    ;(db.worker.findUnique as any).mockResolvedValue(ownedWorker)
+    ;(db.worker.update as any).mockResolvedValue({ ...ownedWorker, isActive: false })
+    const res = makeRes()
+    await toggleActivation(makeReq('admin-1', 'admin'), res)
+    expect(res.statusCode).toBe(200)
+  })
+})

--- a/packages/api/src/controllers/workers.ts
+++ b/packages/api/src/controllers/workers.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { db } from '../db.js'
 
 export async function listWorkers(req: Request, res: Response) {
-  const { category, location, page = '1', limit = '20' } = req.query
+  const { category, page = '1', limit = '20' } = req.query
   const workers = await db.worker.findMany({
     where: {
       isActive: true,
@@ -29,21 +29,39 @@ export async function createWorker(req: Request, res: Response) {
   return res.status(201).json({ data: worker, status: 'success', code: 201 })
 }
 
+/** Returns the worker or sends a 404. Also enforces curator ownership unless the caller is an admin. */
+async function resolveWorker(req: Request, res: Response) {
+  const worker = await db.worker.findUnique({ where: { id: req.params.id } })
+  if (!worker) {
+    res.status(404).json({ status: 'error', message: 'Not found', code: 404 })
+    return null
+  }
+  if (req.user!.role !== 'admin' && worker.curatorId !== req.user!.id) {
+    res.status(403).json({ status: 'error', message: 'Forbidden', code: 403 })
+    return null
+  }
+  return worker
+}
+
 export async function updateWorker(req: Request, res: Response) {
-  const worker = await db.worker.update({ where: { id: req.params.id }, data: req.body })
-  return res.json({ data: worker, status: 'success', code: 200 })
+  const worker = await resolveWorker(req, res)
+  if (!worker) return
+  const updated = await db.worker.update({ where: { id: worker.id }, data: req.body })
+  return res.json({ data: updated, status: 'success', code: 200 })
 }
 
 export async function deleteWorker(req: Request, res: Response) {
-  await db.worker.delete({ where: { id: req.params.id } })
+  const worker = await resolveWorker(req, res)
+  if (!worker) return
+  await db.worker.delete({ where: { id: worker.id } })
   return res.status(204).send()
 }
 
 export async function toggleActivation(req: Request, res: Response) {
-  const worker = await db.worker.findUnique({ where: { id: req.params.id } })
-  if (!worker) return res.status(404).json({ status: 'error', message: 'Not found', code: 404 })
+  const worker = await resolveWorker(req, res)
+  if (!worker) return
   const updated = await db.worker.update({
-    where: { id: req.params.id },
+    where: { id: worker.id },
     data: { isActive: !worker.isActive },
   })
   return res.json({ data: updated, status: 'success', code: 200 })


### PR DESCRIPTION

fix: enforce curator ownership on updateWorker, deleteWorker, toggleActivation

## Problem

Any authenticated curator could update, delete, or toggle any worker listing — including ones created by other 
curators. There was no ownership check against worker.curatorId.

## Changes

src/controllers/workers.ts
- Extracted a resolveWorker helper that fetches the worker, returns 404 if missing, and returns 403 if the caller's id
doesn't match worker.curatorId — unless the caller is an admin
- updateWorker, deleteWorker, and toggleActivation all go through resolveWorker before touching the database

src/controllers/workers.test.ts (new)
- 10 tests covering all three mutating operations across four scenarios each: non-owner curator (403), owner curator (
success), admin bypass (success), and missing worker (404)

## Test results
✓ src/controllers/workers.test.ts  (10 tests)
✓ src/controllers/auth.test.ts     (8 tests)
✓ src/middleware/validate.test.ts  (3 tests)
21 passed
closes #23