### PR TITLE
feat(app): add responsive Navbar with auth state, role-based dropdown…

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,9 +9,15 @@
     "start": "next start"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@stellar/freighter-api": "^6.0.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.6.0",
     "next": "^14.2.0",
     "react": "^18.3.0",
-    "react-dom": "^18.3.0"
+    "react-dom": "^18.3.0",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/app/src/components/Navbar.tsx
+++ b/packages/app/src/components/Navbar.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+import { Menu, Wallet, ChevronDown, User } from "lucide-react";
+import * as Dialog from "@radix-ui/react-dialog";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { useAuth } from "@/hooks/useAuth";
+import { useWallet } from "@/hooks/useWallet";
+import { cn } from "@/lib/utils";
+
+const NAV_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/workers", label: "Workers" },
+  { href: "/about", label: "About" },
+];
+
+function NavLink({ href, label }: { href: string; label: string }) {
+  const pathname = usePathname();
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "text-sm font-medium transition-colors hover:text-blue-600",
+        pathname === href ? "text-blue-600 font-semibold" : "text-gray-600"
+      )}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export default function Navbar() {
+  const { user, logout } = useAuth();
+  const { address, connecting, connect } = useWallet();
+  const router = useRouter();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const shortAddress = address
+    ? `${address.slice(0, 4)}…${address.slice(-4)}`
+    : null;
+
+  return (
+    <nav className="sticky top-0 z-50 w-full border-b bg-white/90 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
+        {/* Brand */}
+        <Link href="/" className="text-xl font-bold text-blue-600">
+          BlueCollar
+        </Link>
+
+        {/* Desktop nav */}
+        <div className="hidden items-center gap-6 md:flex">
+          {NAV_LINKS.map((l) => (
+            <NavLink key={l.href} {...l} />
+          ))}
+        </div>
+
+        {/* Desktop actions */}
+        <div className="hidden items-center gap-3 md:flex">
+          {/* Wallet */}
+          <button
+            onClick={connect}
+            disabled={connecting}
+            className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60"
+          >
+            <Wallet size={15} />
+            {shortAddress ?? (connecting ? "Connecting…" : "Connect Wallet")}
+          </button>
+
+          {/* Auth */}
+          {user ? (
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger asChild>
+                <button className="flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium hover:bg-gray-50">
+                  <User size={15} />
+                  {user.firstName}
+                  <ChevronDown size={13} />
+                </button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  align="end"
+                  sideOffset={6}
+                  className="z-50 min-w-[160px] rounded-md border bg-white p-1 shadow-md text-sm"
+                >
+                  <DropdownMenu.Item
+                    onSelect={() => router.push("/profile")}
+                    className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none"
+                  >
+                    Profile
+                  </DropdownMenu.Item>
+                  {(user.role === "curator" || user.role === "admin") && (
+                    <DropdownMenu.Item
+                      onSelect={() => router.push("/dashboard")}
+                      className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none"
+                    >
+                      Dashboard
+                    </DropdownMenu.Item>
+                  )}
+                  <DropdownMenu.Separator className="my-1 h-px bg-gray-100" />
+                  <DropdownMenu.Item
+                    onSelect={logout}
+                    className="cursor-pointer rounded px-3 py-2 text-red-600 hover:bg-red-50 outline-none"
+                  >
+                    Logout
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+          ) : (
+            <>
+              <Link
+                href="/login"
+                className="rounded-md px-3 py-1.5 text-sm font-medium hover:bg-gray-100"
+              >
+                Login
+              </Link>
+              <Link
+                href="/register"
+                className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Register
+              </Link>
+            </>
+          )}
+        </div>
+
+        {/* Mobile hamburger */}
+        <Dialog.Root open={mobileOpen} onOpenChange={setMobileOpen}>
+          <Dialog.Trigger asChild>
+            <button className="md:hidden p-2 rounded-md hover:bg-gray-100">
+              <Menu size={22} />
+            </button>
+          </Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+            <Dialog.Content className="fixed right-0 top-0 z-50 h-full w-72 bg-white p-6 shadow-xl flex flex-col gap-6">
+              <Dialog.Title className="text-lg font-bold text-blue-600">
+                BlueCollar
+              </Dialog.Title>
+
+              {/* Mobile nav links */}
+              <div className="flex flex-col gap-4">
+                {NAV_LINKS.map((l) => (
+                  <NavLink key={l.href} {...l} />
+                ))}
+              </div>
+
+              <hr />
+
+              {/* Mobile wallet */}
+              <button
+                onClick={connect}
+                disabled={connecting}
+                className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50 disabled:opacity-60"
+              >
+                <Wallet size={15} />
+                {shortAddress ?? (connecting ? "Connecting…" : "Connect Wallet")}
+              </button>
+
+              {/* Mobile auth */}
+              {user ? (
+                <div className="flex flex-col gap-2">
+                  <Link href="/profile" className="rounded px-3 py-2 text-sm hover:bg-gray-100">
+                    Profile
+                  </Link>
+                  {(user.role === "curator" || user.role === "admin") && (
+                    <Link href="/dashboard" className="rounded px-3 py-2 text-sm hover:bg-gray-100">
+                      Dashboard
+                    </Link>
+                  )}
+                  <button
+                    onClick={logout}
+                    className="rounded px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50"
+                  >
+                    Logout
+                  </button>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  <Link
+                    href="/login"
+                    className="rounded-md border px-3 py-2 text-center text-sm font-medium hover:bg-gray-100"
+                  >
+                    Login
+                  </Link>
+                  <Link
+                    href="/register"
+                    className="rounded-md bg-blue-600 px-3 py-2 text-center text-sm font-medium text-white hover:bg-blue-700"
+                  >
+                    Register
+                  </Link>
+                </div>
+              )}
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+      </div>
+    </nav>
+  );
+}

--- a/packages/app/src/hooks/useAuth.tsx
+++ b/packages/app/src/hooks/useAuth.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState, useEffect, createContext, useContext } from "react";
+
+interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: "user" | "curator" | "admin";
+}
+
+interface AuthContextValue {
+  user: User | null;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({ user: null, logout: () => {} });
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    // Replace with real session fetch
+    const stored = localStorage.getItem("bc_user");
+    if (stored) setUser(JSON.parse(stored));
+  }, []);
+
+  const logout = () => {
+    localStorage.removeItem("bc_user");
+    setUser(null);
+  };
+
+  return <AuthContext.Provider value={{ user, logout }}>{children}</AuthContext.Provider>;
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/packages/app/src/hooks/useWallet.ts
+++ b/packages/app/src/hooks/useWallet.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { isConnected, getAddress, requestAccess } from "@stellar/freighter-api";
+
+export function useWallet() {
+  const [address, setAddress] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
+
+  const connect = useCallback(async () => {
+    setConnecting(true);
+    try {
+      const connected = await isConnected();
+      if (!connected) {
+        alert("Freighter wallet not found. Please install the extension.");
+        return;
+      }
+      await requestAccess();
+      const { address: addr } = await getAddress();
+      setAddress(addr);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setConnecting(false);
+    }
+  }, []);
+
+  return { address, connecting, connect };
+}

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Closes #36


## feat(app): Responsive Navbar with auth awareness and Freighter wallet connection

### Summary
Implements the application's primary navigation bar as a fully responsive, auth-aware component.

### Changes
- **src/components/Navbar.tsx** — Main navbar with logo, nav links, auth controls, and wallet button
- **src/hooks/useAuth.tsx** — Auth context + useAuth hook exposing current user and logout
- **src/hooks/useWallet.ts** — Freighter wallet hook (connect, address, connecting state)
- **src/lib/utils.ts** — cn() utility (clsx + tailwind-merge)
- **tsconfig.json** — Added @/* path alias for clean imports

### Behaviour
- Active route is highlighted via usePathname()
- Logged-out state shows Login and Register buttons
- Logged-in state shows an avatar dropdown with Profile, Dashboard (curator/admin only), and Logout
- **Connect Wallet** triggers Freighter; once connected, displays a shortened wallet address
- On mobile, all links and actions collapse into a slide-out sheet (Radix Dialog)

### Notes
- useAuth currently reads from localStorage as a placeholder — swap the useEffect for a real session fetch once the API auth flow is integrated
- Requires Tailwind CSS to be configured in the app (not in scope for this PR)