### PR TITLE
feat: add security policy and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Many skilled workers lack a platform to help them get noticed. Meanwhile, countl
 - [License](#license)
 - [Quick Start Guide](packages/api/QUICK_START_GUIDE.md)
 - [API Documentation](packages/api/DOCUMENTATION.json)
+- [Security Policy](packages/api/SECURITY.md)
 
 ---
 

--- a/packages/api/SECURITY.md
+++ b/packages/api/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in BlueCollar, please **do not** open a public GitHub issue.
+
+Instead, report it responsibly by emailing:
+
+**security@bluecollar.dev**
+
+Please include:
+- A clear description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fix (optional)
+
+## What to Expect
+
+- Acknowledgement within **48 hours**
+- A status update within **7 days**
+- Credit in the release notes (if desired) once the issue is resolved
+
+## Scope
+
+This policy covers the BlueCollar API, smart contracts, and frontend app hosted under this repository.
+
+## Out of Scope
+
+- Vulnerabilities in third-party dependencies (report those upstream)
+- Social engineering attacks
+- Denial of service attacks


### PR DESCRIPTION

Title: feat: add security policy

Body:

## Summary
Adds a responsible disclosure security policy to the BlueCollar project.

## Changes
- `packages/api/SECURITY.md` — new file describing how to report vulnerabilities, expected response timeline, scope, and a dedicated security email placeholder (`security@bluecollar.dev`)
- `README.md` — added link to the security policy in the Table of Contents

## Why
The project lacked any guidance for reporting security vulnerabilities. This brings it in line with standard open-source security practices.

## Testing
No code changes — documentation only.

closes #28