### PR TITLE
feat: add vitest config, test setup, and coverage script

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,10 +9,11 @@
     "dev": "tsx src/index.ts",
     "build": "tsc",
     "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
     "seed": "tsx src/database/seed.ts",
-    "seed:reset": "tsx src/database/seed.ts --reset"
+    "seed:reset": "tsx src/database/seed.ts --reset",
     "admin:create": "tsx src/commands/create-admin.ts",
     "db:reset": "tsx src/commands/reset-db.ts"
   },

--- a/packages/api/testSetup.ts
+++ b/packages/api/testSetup.ts
@@ -1,0 +1,6 @@
+import { afterAll } from 'vitest'
+import { db } from './src/db.js'
+
+afterAll(async () => {
+  await db.$disconnect()
+})

--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    setupFiles: ['./testSetup.ts'],
+    coverage: {
+      provider: 'v8',
+    },
+    include: ['src/__tests__/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
Title: feat: add vitest config, test setup, and coverage script

Body:

## Summary
Adds proper Vitest configuration, a global test setup file, and a coverage script to the API package.

## Changes
- `vitest.config.ts` — configures test environment (node), setup file, v8 coverage provider, and include pattern (`src/__tests__/**/*.test.ts`)
- `testSetup.ts` — tears down the Prisma database connection after all tests via `afterAll`
- `package.json` — added `test:coverage` script (`vitest run --coverage`), fixed missing comma in scripts

## Why
The project lacked a Vitest config, meaning tests ran with defaults and coverage was unavailable. This aligns the setup with standard practice and makes CI coverage reporting possible.

## Usage
- `pnpm test` — run tests in watch mode
- `pnpm test:coverage` — run tests once and generate coverage report

closes #30