### PR TITLE
feat(app): add utils, SEO metadata, skeleton loaders, and error boundaries

### DIFF
--- a/packages/app/public/og-image.svg
+++ b/packages/app/public/og-image.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#1d4ed8"/>
+  <text x="600" y="280" font-family="system-ui, sans-serif" font-size="72" font-weight="700" fill="white" text-anchor="middle">BlueCollar</text>
+  <text x="600" y="370" font-family="system-ui, sans-serif" font-size="32" fill="#bfdbfe" text-anchor="middle">Find Skilled Workers Near You</text>
+  <text x="600" y="430" font-family="system-ui, sans-serif" font-size="22" fill="#93c5fd" text-anchor="middle">Powered by Stellar</text>
+</svg>

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -1,16 +1,39 @@
-import type { Metadata } from 'next'
-import { GeistSans } from 'geist/font/sans'
-import { GeistMono } from 'geist/font/mono'
-import './globals.css'
+import type { Metadata } from "next";
+import "./globals.css";
 import type { ReactNode } from "react";
 import { AuthProvider } from "@/context/AuthContext";
 
-export const metadata: Metadata = {
-  title: 'BlueCollar — Find Skilled Workers Near You',
-  description: 'Connect with trusted local tradespeople on a decentralised Stellar-powered platform.',
-}
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://bluecollar.app";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export const metadata: Metadata = {
+  metadataBase: new URL(BASE_URL),
+  title: {
+    default: "BlueCollar — Find Skilled Workers Near You",
+    template: "%s | BlueCollar",
+  },
+  description:
+    "Connect with trusted local tradespeople on a decentralised Stellar-powered platform.",
+  keywords: ["skilled workers", "tradespeople", "Stellar", "blockchain", "local services"],
+  openGraph: {
+    type: "website",
+    siteName: "BlueCollar",
+    title: "BlueCollar — Find Skilled Workers Near You",
+    description:
+      "Connect with trusted local tradespeople on a decentralised Stellar-powered platform.",
+    url: BASE_URL,
+    images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "BlueCollar" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "BlueCollar — Find Skilled Workers Near You",
+    description:
+      "Connect with trusted local tradespeople on a decentralised Stellar-powered platform.",
+    images: ["/og-image.png"],
+  },
+  robots: { index: true, follow: true },
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>

--- a/packages/app/src/app/robots.ts
+++ b/packages/app/src/app/robots.ts
@@ -1,0 +1,9 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://bluecollar.app";
+  return {
+    rules: { userAgent: "*", allow: "/", disallow: ["/dashboard/", "/auth/"] },
+    sitemap: `${base}/sitemap.xml`,
+  };
+}

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from "next";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
+const BASE = process.env.NEXT_PUBLIC_APP_URL ?? "https://bluecollar.app";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: BASE, lastModified: new Date(), changeFrequency: "weekly", priority: 1 },
+    { url: `${BASE}/workers`, lastModified: new Date(), changeFrequency: "daily", priority: 0.9 },
+  ];
+
+  try {
+    const res = await fetch(`${API}/workers?limit=200`, { next: { revalidate: 3600 } });
+    if (!res.ok) return staticRoutes;
+    const json = await res.json();
+    const workerRoutes: MetadataRoute.Sitemap = (json.data ?? []).map(
+      (w: { id: string; updatedAt?: string }) => ({
+        url: `${BASE}/workers/${w.id}`,
+        lastModified: w.updatedAt ? new Date(w.updatedAt) : new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      })
+    );
+    return [...staticRoutes, ...workerRoutes];
+  } catch {
+    return staticRoutes;
+  }
+}

--- a/packages/app/src/app/workers/[id]/error.tsx
+++ b/packages/app/src/app/workers/[id]/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+export default function WorkerProfileError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      title="Couldn't load this profile"
+      description="There was a problem fetching this worker's profile. Please try again."
+    />
+  );
+}

--- a/packages/app/src/app/workers/[id]/loading.tsx
+++ b/packages/app/src/app/workers/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { WorkerProfileSkeleton } from "@/components/Skeleton";
+
+export default function WorkerProfileLoading() {
+  return <WorkerProfileSkeleton />;
+}

--- a/packages/app/src/app/workers/[id]/page.tsx
+++ b/packages/app/src/app/workers/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { BadgeCheck, MapPin, Mail, Phone, ArrowLeft } from "lucide-react";
 import Link from "next/link";
@@ -11,6 +12,24 @@ async function fetchWorker(id: string): Promise<Worker | null> {
   if (!res.ok) return null;
   const json: ApiResponse<Worker> = await res.json();
   return json.data;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string };
+}): Promise<Metadata> {
+  const worker = await fetchWorker(params.id);
+  if (!worker) return { title: "Worker Not Found" };
+  return {
+    title: worker.name,
+    description: worker.bio ?? `View ${worker.name}'s profile on BlueCollar.`,
+    openGraph: {
+      title: `${worker.name} | BlueCollar`,
+      description: worker.bio ?? `View ${worker.name}'s profile on BlueCollar.`,
+      images: worker.avatar ? [{ url: worker.avatar }] : [{ url: "/og-image.png" }],
+    },
+  };
 }
 
 export default async function WorkerProfilePage({

--- a/packages/app/src/app/workers/error.tsx
+++ b/packages/app/src/app/workers/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+export default function WorkersError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      error={error}
+      reset={reset}
+      title="Couldn't load workers"
+      description="There was a problem fetching the worker listings. Please try again."
+    />
+  );
+}

--- a/packages/app/src/app/workers/loading.tsx
+++ b/packages/app/src/app/workers/loading.tsx
@@ -1,0 +1,30 @@
+import { WorkerCardSkeleton } from "@/components/Skeleton";
+
+export default function WorkersLoading() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-10">
+      <div className="mb-8 h-8 w-40 animate-pulse rounded-md bg-gray-200" />
+      <div className="flex flex-col gap-8 lg:flex-row">
+        {/* Sidebar skeleton */}
+        <aside className="w-full shrink-0 lg:w-60">
+          <div className="flex flex-col gap-5 rounded-xl border bg-white p-5 shadow-sm">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex flex-col gap-2">
+                <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
+                <div className="h-9 w-full animate-pulse rounded-md bg-gray-200" />
+              </div>
+            ))}
+            <div className="h-9 w-full animate-pulse rounded-md bg-gray-200" />
+          </div>
+        </aside>
+
+        {/* Grid skeleton */}
+        <div className="flex-1 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <WorkerCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/app/workers/page.tsx
+++ b/packages/app/src/app/workers/page.tsx
@@ -1,6 +1,16 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import WorkerCard from "@/components/WorkerCard";
 import type { Worker, Category, ApiResponse, Meta } from "@/types";
+
+export const metadata: Metadata = {
+  title: "Browse Workers",
+  description: "Find skilled tradespeople near you — plumbers, electricians, carpenters and more.",
+  openGraph: {
+    title: "Browse Workers | BlueCollar",
+    description: "Find skilled tradespeople near you.",
+  },
+};
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
 

--- a/packages/app/src/components/ErrorBoundary.tsx
+++ b/packages/app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+
+interface Props {
+  error: Error & { digest?: string };
+  reset: () => void;
+  title?: string;
+  description?: string;
+}
+
+export default function ErrorBoundary({
+  error,
+  reset,
+  title = "Something went wrong",
+  description = "An unexpected error occurred. Please try again.",
+}: Props) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[40vh] flex-col items-center justify-center px-4 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-red-50 mb-4">
+        <AlertTriangle size={24} className="text-red-500" />
+      </div>
+      <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+      <p className="mt-1 text-sm text-gray-500 max-w-sm">{description}</p>
+      <button
+        onClick={reset}
+        className="mt-5 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/packages/app/src/components/Skeleton.tsx
+++ b/packages/app/src/components/Skeleton.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@/lib/utils";
+
+interface Props {
+  className?: string;
+}
+
+export default function Skeleton({ className }: Props) {
+  return (
+    <div className={cn("animate-pulse rounded-md bg-gray-200", className)} />
+  );
+}
+
+export function WorkerCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border bg-white p-5 shadow-sm">
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-14 w-14 rounded-full" />
+        <div className="flex flex-col gap-2 flex-1">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-20 rounded-full" />
+        </div>
+      </div>
+      <Skeleton className="h-3 w-full" />
+      <Skeleton className="h-3 w-4/5" />
+      <Skeleton className="h-3 w-24" />
+      <Skeleton className="mt-auto h-8 w-full rounded-md" />
+    </div>
+  );
+}
+
+export function WorkerProfileSkeleton() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10">
+      <Skeleton className="mb-6 h-4 w-28" />
+      <div className="rounded-2xl border bg-white p-8 shadow-sm">
+        <div className="flex items-center gap-5">
+          <Skeleton className="h-20 w-20 rounded-full shrink-0" />
+          <div className="flex flex-col gap-2 flex-1">
+            <Skeleton className="h-6 w-40" />
+            <Skeleton className="h-4 w-24 rounded-full" />
+          </div>
+        </div>
+        <div className="mt-6 flex flex-col gap-2">
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-5/6" />
+          <Skeleton className="h-3 w-4/6" />
+        </div>
+        <div className="mt-6 flex flex-col gap-3">
+          <Skeleton className="h-4 w-36" />
+          <Skeleton className="h-4 w-48" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="mt-8 border-t pt-6 flex items-center justify-between">
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+          <Skeleton className="h-9 w-24 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -1,6 +1,35 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+// Class merging
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+// Format a date string or Date object to a readable string
+export function formatDate(date: string | Date, opts?: Intl.DateTimeFormatOptions): string {
+  return new Date(date).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    ...opts,
+  });
+}
+
+// Truncate a string to maxLength, appending ellipsis if needed
+export function truncate(str: string, maxLength: number): string {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength).trimEnd() + "…";
+}
+
+// Show first 4 and last 4 chars of a wallet address: GABC…WXYZ
+export function formatWalletAddress(address: string): string {
+  if (address.length <= 8) return address;
+  return `${address.slice(0, 4)}…${address.slice(-4)}`;
+}
+
+// Convert stroops (1 XLM = 10,000,000 stroops) to a formatted XLM string
+export function formatXLM(stroops: number | bigint): string {
+  const xlm = Number(stroops) / 10_000_000;
+  return `${xlm.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 7 })} XLM`;
 }


### PR DESCRIPTION
feat(app): add shared utils, SEO metadata, skeleton loaders, and error boundaries

closes #49 

Shared Utilities (src/lib/utils.ts):
- Add cn() using clsx + tailwind-merge for conditional class merging
- Add formatDate() to format Date/string to locale-friendly string with Intl options
- Add truncate() to clip strings to a max length with ellipsis
- Add formatWalletAddress() to shorten Stellar addresses to first 4 + last 4 chars
- Add formatXLM() to convert stroops (1 XLM = 10,000,000) to a readable XLM string
- clsx and tailwind-merge were already installed; no new deps needed

closes #50 

SEO Metadata (layout.tsx, workers pages):
- Add metadataBase, title template ("%s | BlueCollar"), and fallback title in layout.tsx
- Add full OpenGraph object with siteName, description, url, and og-image.png reference
- Add Twitter card metadata with summary_large_image type
- Add robots directive (index: true, follow: true) at root level
- Implement static metadata export on workers listing page with title and OG fields
- Implement async generateMetadata() on worker profile page — fetches worker by ID
  and returns dynamic title, description, and avatar as OG image with fallback
- Add src/app/robots.ts using Next.js MetadataRoute.Robots — disallows /dashboard/ and /auth/
- Add src/app/sitemap.ts using Next.js MetadataRoute.Sitemap — includes static routes
  (home, /workers) and dynamically fetches all worker IDs for individual profile URLs
  with 1-hour revalidation; falls back to static routes on fetch failure
- Add public/og-image.svg as a 1200×630 branded placeholder (replace with PNG for production)

closes #51 

Skeleton Loaders (src/components/Skeleton.tsx, loading files):
- Create base Skeleton component using animate-pulse and bg-gray-200 with cn() support
- Create WorkerCardSkeleton matching the WorkerCard layout: avatar circle, name, category
  badge, bio lines, location line, and CTA button placeholder
- Create WorkerProfileSkeleton matching the full profile page layout: large avatar, name,
  category, bio paragraph, contact details, and tip section with button
- Add src/app/workers/loading.tsx rendering 6 WorkerCardSkeleton components in a
  responsive grid alongside a sidebar skeleton — shown automatically by Next.js during fetch
- Add src/app/workers/[id]/loading.tsx rendering WorkerProfileSkeleton — shown during
  individual profile fetch

closes #52 

Error Boundaries (src/components/ErrorBoundary.tsx, error files):
- Create reusable ErrorBoundary client component accepting error, reset, title, description
  props — logs error to console, shows AlertTriangle icon, message, and "Try Again" button
  that calls reset() to re-trigger the failed server component render
- Add src/app/workers/error.tsx wrapping ErrorBoundary with workers-specific copy
- Add src/app/workers/[id]/error.tsx wrapping ErrorBoundary with profile-specific copy
- Both error files are "use client" as required by Next.js App Router error boundaries
