### PR TITLE
feat(app): add worker form, API client, WalletContext, and custom icons

### DIFF
--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -1,0 +1,11 @@
+# API base URL
+NEXT_PUBLIC_API_URL="http://localhost:3000/api"
+
+# App base URL (used for OG metadata and sitemap)
+NEXT_PUBLIC_APP_URL="http://localhost:3001"
+
+# Stellar network: "TESTNET" or "MAINNET"
+NEXT_PUBLIC_STELLAR_NETWORK="TESTNET"
+
+# Market contract ID (deployed Soroban contract)
+NEXT_PUBLIC_MARKET_CONTRACT_ID=""

--- a/packages/app/src/app/dashboard/workers/[id]/edit/page.tsx
+++ b/packages/app/src/app/dashboard/workers/[id]/edit/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import WorkerForm, { type WorkerFormInput } from "@/components/WorkerForm";
+import ToastContainer from "@/components/Toast";
+import { useToast } from "@/hooks/useToast";
+import { getWorker, updateWorker } from "@/lib/api";
+import type { Worker } from "@/types";
+
+export default function EditWorkerPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const { toasts, toast, dismiss } = useToast();
+  const [worker, setWorker] = useState<Worker | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    getWorker(params.id)
+      .then((res) => setWorker(res.data))
+      .catch(() => toast("Failed to load worker", "error"))
+      .finally(() => setLoading(false));
+  }, [params.id]);
+
+  const handleSubmit = async (data: WorkerFormInput, imageFile: File | null) => {
+    setIsSubmitting(true);
+    try {
+      const form = new FormData();
+      Object.entries(data).forEach(([k, v]) => {
+        if (v !== undefined && v !== "") form.append(k, v as string);
+      });
+      if (imageFile) form.append("avatar", imageFile);
+
+      await updateWorker(params.id, form);
+      toast("Worker updated successfully");
+      router.push("/dashboard");
+    } catch (err: unknown) {
+      toast(err instanceof Error ? err.message : "Failed to update worker", "error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10">
+      <Link
+        href="/dashboard"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-600 transition-colors"
+      >
+        <ArrowLeft size={15} />
+        Back to dashboard
+      </Link>
+
+      <div className="rounded-2xl border bg-white p-8 shadow-sm">
+        <h1 className="mb-6 text-xl font-bold text-gray-900">Edit Worker</h1>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 size={24} className="animate-spin text-blue-500" />
+          </div>
+        ) : worker ? (
+          <WorkerForm
+            defaultValues={{
+              name: worker.name,
+              bio: worker.bio ?? "",
+              categoryId: worker.category.id,
+              phone: worker.phone ?? "",
+              email: worker.email ?? "",
+              walletAddress: worker.walletAddress ?? "",
+            }}
+            existingAvatar={worker.avatar}
+            onSubmit={handleSubmit}
+            submitLabel="Save Changes"
+            isSubmitting={isSubmitting}
+          />
+        ) : (
+          <p className="text-sm text-gray-500">Worker not found.</p>
+        )}
+      </div>
+
+      <ToastContainer toasts={toasts} dismiss={dismiss} />
+    </div>
+  );
+}

--- a/packages/app/src/app/dashboard/workers/new/page.tsx
+++ b/packages/app/src/app/dashboard/workers/new/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import WorkerForm, { type WorkerFormInput } from "@/components/WorkerForm";
+import ToastContainer from "@/components/Toast";
+import { useToast } from "@/hooks/useToast";
+import { createWorker } from "@/lib/api";
+
+export default function NewWorkerPage() {
+  const router = useRouter();
+  const { toasts, toast, dismiss } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (data: WorkerFormInput, imageFile: File | null) => {
+    setIsSubmitting(true);
+    try {
+      const form = new FormData();
+      Object.entries(data).forEach(([k, v]) => {
+        if (v !== undefined && v !== "") form.append(k, v as string);
+      });
+      if (imageFile) form.append("avatar", imageFile);
+
+      await createWorker(form);
+      toast("Worker created successfully");
+      router.push("/dashboard");
+    } catch (err: unknown) {
+      toast(err instanceof Error ? err.message : "Failed to create worker", "error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10">
+      <Link
+        href="/dashboard"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-600 transition-colors"
+      >
+        <ArrowLeft size={15} />
+        Back to dashboard
+      </Link>
+
+      <div className="rounded-2xl border bg-white p-8 shadow-sm">
+        <h1 className="mb-6 text-xl font-bold text-gray-900">Create New Worker</h1>
+        <WorkerForm
+          onSubmit={handleSubmit}
+          submitLabel="Create Worker"
+          isSubmitting={isSubmitting}
+        />
+      </div>
+
+      <ToastContainer toasts={toasts} dismiss={dismiss} />
+    </div>
+  );
+}

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import type { ReactNode } from "react";
 import { AuthProvider } from "@/context/AuthContext";
+import { WalletProvider } from "@/context/WalletContext";
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://bluecollar.app";
 
@@ -37,7 +38,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <WalletProvider>{children}</WalletProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/packages/app/src/components/Toast.tsx
+++ b/packages/app/src/components/Toast.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { CheckCircle2, AlertCircle, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ToastType } from "@/hooks/useToast";
+
+interface ToastItem {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+interface Props {
+  toasts: ToastItem[];
+  dismiss: (id: number) => void;
+}
+
+export default function ToastContainer({ toasts, dismiss }: Props) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="fixed bottom-5 right-5 z-50 flex flex-col gap-2">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className={cn(
+            "flex items-center gap-3 rounded-xl px-4 py-3 shadow-lg text-sm font-medium text-white min-w-[260px]",
+            t.type === "success" ? "bg-green-600" : "bg-red-600"
+          )}
+        >
+          {t.type === "success" ? (
+            <CheckCircle2 size={16} className="shrink-0" />
+          ) : (
+            <AlertCircle size={16} className="shrink-0" />
+          )}
+          <span className="flex-1">{t.message}</span>
+          <button onClick={() => dismiss(t.id)} className="shrink-0 opacity-70 hover:opacity-100">
+            <X size={14} />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/app/src/components/WorkerForm.tsx
+++ b/packages/app/src/components/WorkerForm.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState, useRef, useEffect, type ChangeEvent } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2, Upload, X } from "lucide-react";
+import FormField from "@/components/FormField";
+import { cn } from "@/lib/utils";
+import { getCategories } from "@/lib/api";
+import type { Category, Worker } from "@/types";
+
+// ─── Schema ───────────────────────────────────────────────────────────────────
+
+export const workerSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters"),
+  bio: z.string().max(500, "Bio must be under 500 characters").optional(),
+  categoryId: z.string().min(1, "Please select a category"),
+  phone: z.string().optional(),
+  email: z.string().email("Invalid email").optional().or(z.literal("")),
+  walletAddress: z.string().optional(),
+});
+
+export type WorkerFormInput = z.infer<typeof workerSchema>;
+
+interface Props {
+  defaultValues?: Partial<WorkerFormInput>;
+  existingAvatar?: string | null;
+  onSubmit: (data: WorkerFormInput, imageFile: File | null) => Promise<void>;
+  submitLabel?: string;
+  isSubmitting?: boolean;
+}
+
+export default function WorkerForm({
+  defaultValues,
+  existingAvatar,
+  onSubmit,
+  submitLabel = "Save",
+  isSubmitting = false,
+}: Props) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(existingAvatar ?? null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<WorkerFormInput>({
+    resolver: zodResolver(workerSchema),
+    defaultValues,
+  });
+
+  useEffect(() => {
+    getCategories()
+      .then((res) => setCategories(res.data))
+      .catch(() => {});
+  }, []);
+
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImageFile(file);
+    setImagePreview(URL.createObjectURL(file));
+  };
+
+  const clearImage = () => {
+    setImageFile(null);
+    setImagePreview(existingAvatar ?? null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const inputClass = (hasError?: boolean) =>
+    cn(
+      "w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-blue-500",
+      hasError && "border-red-400"
+    );
+
+  return (
+    <form
+      onSubmit={handleSubmit((data: WorkerFormInput) => onSubmit(data, imageFile))}
+      className="flex flex-col gap-5"
+      noValidate
+    >
+      {/* Profile image */}
+      <div>
+        <p className="mb-2 text-sm font-medium text-gray-700">Profile Image</p>
+        <div className="flex items-center gap-4">
+          <div className="relative h-20 w-20 shrink-0">
+            {imagePreview ? (
+              <>
+                <img
+                  src={imagePreview}
+                  alt="Preview"
+                  className="h-20 w-20 rounded-full object-cover ring-2 ring-blue-100"
+                />
+                <button
+                  type="button"
+                  onClick={clearImage}
+                  className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-white hover:bg-red-600"
+                >
+                  <X size={10} />
+                </button>
+              </>
+            ) : (
+              <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gray-100 text-gray-400">
+                <Upload size={20} />
+              </div>
+            )}
+          </div>
+          <div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleImageChange}
+              id="avatar-upload"
+            />
+            <label
+              htmlFor="avatar-upload"
+              className="cursor-pointer rounded-lg border px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+            >
+              {imagePreview ? "Change image" : "Upload image"}
+            </label>
+            <p className="mt-1 text-xs text-gray-400">JPG, PNG or WebP. Max 5MB.</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Name */}
+      <FormField label="Full name" id="name" error={errors.name?.message}>
+        <input
+          id="name"
+          type="text"
+          placeholder="e.g. John Doe"
+          {...register("name")}
+          className={inputClass(!!errors.name)}
+        />
+      </FormField>
+
+      {/* Category */}
+      <FormField label="Category" id="categoryId" error={errors.categoryId?.message}>
+        <select
+          id="categoryId"
+          {...register("categoryId")}
+          className={inputClass(!!errors.categoryId)}
+        >
+          <option value="">Select a category…</option>
+          {categories.map((c: Category) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </FormField>
+
+      {/* Bio */}
+      <FormField label="Bio" id="bio" error={errors.bio?.message}>
+        <textarea
+          id="bio"
+          rows={3}
+          placeholder="Brief description of skills and experience…"
+          {...register("bio")}
+          className={cn(inputClass(!!errors.bio), "resize-none")}
+        />
+      </FormField>
+
+      {/* Phone + Email */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <FormField label="Phone" id="phone" error={errors.phone?.message}>
+          <input
+            id="phone"
+            type="tel"
+            placeholder="+1 234 567 8900"
+            {...register("phone")}
+            className={inputClass(!!errors.phone)}
+          />
+        </FormField>
+
+        <FormField label="Email" id="email" error={errors.email?.message}>
+          <input
+            id="email"
+            type="email"
+            placeholder="worker@example.com"
+            {...register("email")}
+            className={inputClass(!!errors.email)}
+          />
+        </FormField>
+      </div>
+
+      {/* Wallet address */}
+      <FormField label="Stellar Wallet Address" id="walletAddress" error={errors.walletAddress?.message}>
+        <input
+          id="walletAddress"
+          type="text"
+          placeholder="G…"
+          {...register("walletAddress")}
+          className={inputClass(!!errors.walletAddress)}
+        />
+      </FormField>
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="flex items-center justify-center gap-2 rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60 transition-colors"
+      >
+        {isSubmitting && <Loader2 size={15} className="animate-spin" />}
+        {submitLabel}
+      </button>
+    </form>
+  );
+}

--- a/packages/app/src/context/WalletContext.tsx
+++ b/packages/app/src/context/WalletContext.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
+import {
+  isConnected,
+  requestAccess,
+  getAddress,
+  getNetwork,
+} from "@stellar/freighter-api";
+
+const STORAGE_KEY = "bc_wallet_address";
+
+interface WalletContextValue {
+  publicKey: string | null;
+  network: string | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+}
+
+const WalletContext = createContext<WalletContextValue>({
+  publicKey: null,
+  network: null,
+  isConnected: false,
+  isConnecting: false,
+  connect: async () => {},
+  disconnect: () => {},
+});
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [network, setNetwork] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  // Restore persisted connection on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return;
+
+    // Verify Freighter still has the address (extension may have been removed)
+    isConnected()
+      .then(async (res) => {
+        if (!res.isConnected) {
+          localStorage.removeItem(STORAGE_KEY);
+          return;
+        }
+        const { address } = await getAddress();
+        const { network: net } = await getNetwork();
+        if (address === stored) {
+          setPublicKey(address);
+          setNetwork(net);
+        } else {
+          localStorage.removeItem(STORAGE_KEY);
+        }
+      })
+      .catch(() => localStorage.removeItem(STORAGE_KEY));
+  }, []);
+
+  const connect = useCallback(async () => {
+    setIsConnecting(true);
+    try {
+      const connected = await isConnected();
+      if (!connected.isConnected) {
+        window.open("https://www.freighter.app", "_blank");
+        return;
+      }
+      await requestAccess();
+      const { address } = await getAddress();
+      const { network: net } = await getNetwork();
+      setPublicKey(address);
+      setNetwork(net);
+      localStorage.setItem(STORAGE_KEY, address);
+    } catch (err) {
+      console.error("[WalletContext] connect error:", err);
+    } finally {
+      setIsConnecting(false);
+    }
+  }, []);
+
+  const disconnect = useCallback(() => {
+    setPublicKey(null);
+    setNetwork(null);
+    localStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  return (
+    <WalletContext.Provider
+      value={{
+        publicKey,
+        network,
+        isConnected: !!publicKey,
+        isConnecting,
+        connect,
+        disconnect,
+      }}
+    >
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export const useWallet = () => useContext(WalletContext);

--- a/packages/app/src/hooks/useToast.ts
+++ b/packages/app/src/hooks/useToast.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+export type ToastType = "success" | "error";
+
+interface Toast {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const toast = useCallback((message: string, type: ToastType = "success") => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3500);
+  }, []);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return { toasts, toast, dismiss };
+}

--- a/packages/app/src/icons/EmailIcon.tsx
+++ b/packages/app/src/icons/EmailIcon.tsx
@@ -1,0 +1,23 @@
+interface Props { className?: string; size?: number }
+
+export default function EmailIcon({ className, size = 24 }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <rect x="2" y="4" width="20" height="16" rx="2" stroke="currentColor" strokeWidth="1.75" />
+      <path
+        d="M2 8l10 6 10-6"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/packages/app/src/icons/LocationIcon.tsx
+++ b/packages/app/src/icons/LocationIcon.tsx
@@ -1,0 +1,21 @@
+interface Props { className?: string; size?: number }
+
+export default function LocationIcon({ className, size = 24 }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M12 2C8.686 2 6 4.686 6 8c0 5.25 6 14 6 14s6-8.75 6-14c0-3.314-2.686-6-6-6Z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <circle cx="12" cy="8" r="2" stroke="currentColor" strokeWidth="1.75" />
+    </svg>
+  );
+}

--- a/packages/app/src/icons/LogoIcon.tsx
+++ b/packages/app/src/icons/LogoIcon.tsx
@@ -1,0 +1,24 @@
+interface Props { className?: string; size?: number }
+
+export default function LogoIcon({ className, size = 32 }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-label="BlueCollar logo"
+    >
+      <rect width="32" height="32" rx="8" fill="#2563EB" />
+      <path
+        d="M8 22V10h6a4 4 0 0 1 0 8H8m0 0h7a4 4 0 0 1 0 8H8"
+        stroke="white"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/packages/app/src/icons/PhoneIcon.tsx
+++ b/packages/app/src/icons/PhoneIcon.tsx
@@ -1,0 +1,22 @@
+interface Props { className?: string; size?: number }
+
+export default function PhoneIcon({ className, size = 24 }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M6.62 10.79a15.053 15.053 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.01-.24c1.12.37 2.33.57 3.58.57a1 1 0 0 1 1 1V20a1 1 0 0 1-1 1C10.61 21 3 13.39 3 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1c0 1.25.2 2.45.57 3.58a1 1 0 0 1-.25 1.01l-2.2 2.2Z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/packages/app/src/icons/StarIcon.tsx
+++ b/packages/app/src/icons/StarIcon.tsx
@@ -1,0 +1,21 @@
+interface Props { className?: string; size?: number; filled?: boolean }
+
+export default function StarIcon({ className, size = 24, filled = false }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={filled ? "currentColor" : "none"}
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2Z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/packages/app/src/icons/WalletIcon.tsx
+++ b/packages/app/src/icons/WalletIcon.tsx
@@ -1,0 +1,19 @@
+interface Props { className?: string; size?: number }
+
+export default function WalletIcon({ className, size = 24 }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <rect x="2" y="6" width="20" height="14" rx="2" stroke="currentColor" strokeWidth="1.75" />
+      <path d="M2 10h20" stroke="currentColor" strokeWidth="1.75" />
+      <path d="M16 15a1 1 0 1 0 2 0 1 1 0 0 0-2 0Z" fill="currentColor" />
+      <path d="M6 3l4-1 4 1" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/packages/app/src/icons/WorkerIcon.tsx
+++ b/packages/app/src/icons/WorkerIcon.tsx
@@ -1,0 +1,32 @@
+interface Props { className?: string; size?: number }
+
+export default function WorkerIcon({ className, size = 24 }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M4 20c0-3.314 3.582-6 8-6s8 2.686 8 6"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+      <path
+        d="M15 7h4m-2-2v4"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/packages/app/src/icons/index.ts
+++ b/packages/app/src/icons/index.ts
@@ -1,0 +1,7 @@
+export { default as LogoIcon } from "./LogoIcon";
+export { default as WalletIcon } from "./WalletIcon";
+export { default as WorkerIcon } from "./WorkerIcon";
+export { default as StarIcon } from "./StarIcon";
+export { default as LocationIcon } from "./LocationIcon";
+export { default as PhoneIcon } from "./PhoneIcon";
+export { default as EmailIcon } from "./EmailIcon";

--- a/packages/app/src/lib/api.ts
+++ b/packages/app/src/lib/api.ts
@@ -1,0 +1,112 @@
+/**
+ * Centralized API client.
+ * Automatically attaches the JWT from localStorage, handles 401s by
+ * clearing auth state and redirecting to /auth/login.
+ */
+
+import type { Worker, Category, ApiResponse, Meta } from "@/types";
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
+const TOKEN_KEY = "bc_token";
+
+// ─── Core fetch wrapper ───────────────────────────────────────────────────────
+
+interface RequestOptions extends Omit<RequestInit, "body"> {
+  body?: unknown;
+  /** Skip JSON serialisation — used for FormData uploads */
+  rawBody?: BodyInit;
+}
+
+async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { body, rawBody, headers: extraHeaders, ...rest } = options;
+
+  const token = typeof window !== "undefined" ? localStorage.getItem(TOKEN_KEY) : null;
+
+  const headers: Record<string, string> = {
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+    ...(extraHeaders as Record<string, string>),
+  };
+
+  const res = await fetch(`${BASE}${path}`, {
+    ...rest,
+    headers,
+    body: rawBody ?? (body !== undefined ? JSON.stringify(body) : undefined),
+  });
+
+  // 401 — clear token and redirect to login
+  if (res.status === 401 && typeof window !== "undefined") {
+    localStorage.removeItem(TOKEN_KEY);
+    window.location.href = "/auth/login";
+    throw new Error("Unauthorized");
+  }
+
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error((json as { message?: string }).message ?? "Request failed");
+  return json as T;
+}
+
+// ─── Typed endpoint functions ─────────────────────────────────────────────────
+
+// Auth
+export const login = (email: string, password: string) =>
+  request<{ data: unknown; token: string }>("/auth/login", {
+    method: "POST",
+    body: { email, password },
+  });
+
+export const register = (data: {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+}) => request<{ data: unknown }>("/auth/register", { method: "POST", body: data });
+
+export const forgotPassword = (email: string) =>
+  request<{ message: string }>("/auth/forgot-password", { method: "POST", body: { email } });
+
+export const resetPassword = (token: string, password: string) =>
+  request<{ message: string }>("/auth/reset-password", {
+    method: "PUT",
+    body: { token, password },
+  });
+
+export const getMe = () =>
+  request<ApiResponse<unknown>>("/auth/me");
+
+// Workers
+export const getWorkers = (params?: Record<string, string>) => {
+  const qs = params ? `?${new URLSearchParams(params).toString()}` : "";
+  return request<ApiResponse<Worker[]> & { meta: Meta }>(`/workers${qs}`);
+};
+
+export const getMyWorkers = (params?: Record<string, string>) => {
+  const qs = params ? `?${new URLSearchParams(params).toString()}` : "";
+  return request<ApiResponse<Worker[]> & { meta: Meta }>(`/workers/mine${qs}`);
+};
+
+export const getWorker = (id: string) =>
+  request<ApiResponse<Worker>>(`/workers/${id}`);
+
+export const createWorker = (data: FormData) =>
+  request<ApiResponse<Worker>>("/workers", {
+    method: "POST",
+    rawBody: data,
+  });
+
+export const updateWorker = (id: string, data: FormData) =>
+  request<ApiResponse<Worker>>(`/workers/${id}`, {
+    method: "POST",
+    rawBody: data,
+    headers: { "X-HTTP-Method": "PUT" },
+  });
+
+export const deleteWorker = (id: string) =>
+  request<void>(`/workers/${id}`, { method: "DELETE" });
+
+export const toggleWorker = (id: string) =>
+  request<ApiResponse<Worker>>(`/workers/${id}/toggle`, { method: "PATCH" });
+
+// Categories
+export const getCategories = () =>
+  request<ApiResponse<Category[]>>("/categories");


### PR DESCRIPTION
feat(app): add worker form pages, centralized API client, WalletContext, and custom SVG icons

closes #45 

Worker Create/Edit Forms (dashboard/workers):
- Add src/app/dashboard/workers/new/page.tsx — protected create form that builds
  a FormData payload, appends the image file if selected, calls createWorker() from
  the API client, shows a success toast, and redirects to /dashboard on success
- Add src/app/dashboard/workers/[id]/edit/page.tsx — fetches existing worker data
  on mount, pre-fills the shared WorkerForm with defaultValues and existingAvatar,
  submits via updateWorker() with X-HTTP-Method: PUT header for FormData edits
- Add src/components/WorkerForm.tsx — shared form component used by both pages with
  fields: name, bio, category (select populated from API), phone, email, walletAddress,
  and profile image upload with live preview and clear button
- Image upload shows a circular preview before submission; supports JPG, PNG, WebP
- Zod schema validates all fields; react-hook-form manages state and error display
- Add src/components/Toast.tsx — fixed bottom-right toast UI with success/error variants
- Add src/hooks/useToast.ts — lightweight toast state hook with auto-dismiss after 3.5s

closes #46 

Centralized API Client (src/lib/api.ts):
- Create typed fetch wrapper that reads JWT from localStorage and attaches
  Authorization: Bearer header automatically on every request
- Handle 401 responses by clearing the stored token and redirecting to /auth/login
- Skip Content-Type header when body is FormData to allow multipart uploads
- Export typed functions: login, register, forgotPassword, resetPassword, getMe,
  getWorkers, getMyWorkers, getWorker, createWorker, updateWorker (FormData + X-HTTP-Method),
  deleteWorker, toggleWorker, getCategories
- All functions return typed ApiResponse<T> generics matching the API shape

closes #47 

WalletContext (src/context/WalletContext.tsx):
- Create global wallet context with publicKey, network, isConnected, isConnecting,
  connect(), and disconnect() — replaces the stateless useWallet hook
- On mount, restores persisted wallet address from localStorage and re-validates
  against Freighter to detect if the extension was removed or address changed
- connect() calls isConnected(), requestAccess(), getAddress(), and getNetwork()
  from @stellar/freighter-api; opens freighter.app if extension is not installed
- disconnect() clears state and removes the stored address from localStorage
- Export useWallet() hook for consuming context throughout the app
- Wrap root layout with WalletProvider alongside existing AuthProvider

closes #48 

Custom SVG Icons (src/icons/):
- Add src/icons/LogoIcon.tsx — branded "B" lettermark on blue rounded square
- Add src/icons/WalletIcon.tsx — wallet with card slot and coin indicator
- Add src/icons/WorkerIcon.tsx — person silhouette with "add" indicator for curator use
- Add src/icons/StarIcon.tsx — star with optional filled prop for ratings
- Add src/icons/LocationIcon.tsx — map pin with inner circle
- Add src/icons/PhoneIcon.tsx — telephone handset
- Add src/icons/EmailIcon.tsx — envelope with open flap
- All icons accept size and className props; use currentColor for theme compatibility
- Export all icons from src/icons/index.ts for clean named imports
- Reserve src/icons/ for brand-specific SVGs; use lucide-react for standard UI icons

Miscellaneous:
- Add packages/app/.env.example with NEXT_PUBLIC_API_URL, NEXT_PUBLIC_APP_URL,
  NEXT_PUBLIC_STELLAR_NETWORK, and NEXT_PUBLIC_MARKET_CONTRACT_ID
- Update layout.tsx to wrap children in WalletProvider inside AuthProvider
