### PR TITLE
feat(contracts): Makefile, comprehensive tests, and protocol fee

### DIFF
--- a/packages/contracts/Makefile
+++ b/packages/contracts/Makefile
@@ -1,0 +1,41 @@
+# BlueCollar Contracts Makefile
+# Requires: Rust, cargo, stellar CLI (https://developers.stellar.org/docs/tools/stellar-cli)
+
+WASM_TARGET := wasm32-unknown-unknown
+NETWORK     := testnet
+REGISTRY_WASM := target/wasm32-unknown-unknown/release/bluecollar_registry.wasm
+MARKET_WASM   := target/wasm32-unknown-unknown/release/bluecollar_market.wasm
+
+.PHONY: build test deploy-testnet clean fmt clippy
+
+## Build both contracts for release (WASM)
+build:
+	cargo build --release --target $(WASM_TARGET)
+
+## Run all unit tests
+test:
+	cargo test
+
+## Format all source files
+fmt:
+	cargo fmt
+
+## Run Clippy with warnings-as-errors
+clippy:
+	cargo clippy -- -D warnings
+
+## Deploy both contracts to Stellar testnet
+## Requires STELLAR_ACCOUNT env var to be set to a funded testnet identity.
+deploy-testnet: build
+	stellar contract deploy \
+		--wasm $(REGISTRY_WASM) \
+		--source $(STELLAR_ACCOUNT) \
+		--network $(NETWORK)
+	stellar contract deploy \
+		--wasm $(MARKET_WASM) \
+		--source $(STELLAR_ACCOUNT) \
+		--network $(NETWORK)
+
+## Remove build artifacts
+clean:
+	cargo clean

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,0 +1,69 @@
+# BlueCollar Contracts
+
+Soroban smart contracts for the BlueCollar platform, deployed on Stellar.
+
+## Contracts
+
+### Registry (`contracts/registry`)
+Manages on-chain worker registrations.
+
+| Function | Description |
+|---|---|
+| `register(id, owner, name, category)` | Register a new worker (owner auth required) |
+| `get_worker(id)` | Fetch a worker by id, returns `Option<Worker>` |
+| `toggle(id, caller)` | Flip a worker's `is_active` flag (owner only) |
+| `list_workers()` | Return all registered worker ids |
+
+### Market (`contracts/market`)
+Handles tips and payment escrow between users and workers.
+
+| Function | Description |
+|---|---|
+| `initialize(admin, fee_bps, fee_recipient)` | One-time setup; sets protocol fee (max 500 bps / 5%) |
+| `tip(from, to, token, amount)` | Send a tip; deducts protocol fee and forwards remainder to worker |
+| `update_fee(admin, new_fee_bps)` | Update fee in basis points (admin only, max 500) |
+| `create_escrow(id, from, to, token, amount, expiry)` | Lock tokens in escrow until released or expired |
+| `release_escrow(id, caller)` | Release funds to worker, deducting protocol fee (sender only) |
+| `cancel_escrow(id, caller)` | Refund sender before expiry (sender only) |
+| `cancel_expired_escrow(id)` | Refund sender after expiry (permissionless) |
+| `get_config()` | Read current fee config |
+| `get_escrow(id)` | Read escrow state |
+
+## Makefile
+
+All common operations are available via `make` from `packages/contracts/`.
+
+```
+make build          # cargo build --release --target wasm32-unknown-unknown
+make test           # cargo test
+make fmt            # cargo fmt
+make clippy         # cargo clippy -- -D warnings
+make deploy-testnet # deploy both contracts to Stellar testnet (requires STELLAR_ACCOUNT)
+make clean          # cargo clean
+```
+
+### deploy-testnet
+
+Set a funded testnet identity before deploying:
+
+```bash
+stellar keys generate --global alice --network testnet --fund
+export STELLAR_ACCOUNT=alice
+make deploy-testnet
+```
+
+## Development
+
+```bash
+# Install Rust WASM target
+rustup target add wasm32-unknown-unknown
+
+# Install Stellar CLI
+cargo install --locked stellar-cli --features opt
+
+# Run tests
+make test
+
+# Build WASM artifacts
+make build
+```

--- a/packages/contracts/contracts/market/src/lib.rs
+++ b/packages/contracts/contracts/market/src/lib.rs
@@ -5,6 +5,10 @@
 
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Symbol};
 
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
 #[contracttype]
 #[derive(Clone)]
 pub struct Tip {
@@ -16,19 +20,253 @@ pub struct Tip {
 }
 
 #[contracttype]
+#[derive(Clone)]
+pub struct Config {
+    pub admin: Address,
+    pub fee_bps: u32,
+    pub fee_recipient: Address,
+}
+
+#[contracttype]
 pub enum DataKey {
     Tip(Symbol),
+    Escrow(Symbol),
+    Config,
 }
+
+// ---------------------------------------------------------------------------
+// Escrow state
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum EscrowStatus {
+    Active,
+    Released,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Escrow {
+    pub from: Address,
+    pub to: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub expiry: u64,
+    pub status: EscrowStatus,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+/// Maximum fee: 5% = 500 bps
+pub const MAX_FEE_BPS: u32 = 500;
 
 #[contract]
 pub struct MarketContract;
 
 #[contractimpl]
 impl MarketContract {
-    /// Send a tip to a worker — transfers tokens directly
+    // -----------------------------------------------------------------------
+    // Initialise
+    // -----------------------------------------------------------------------
+
+    /// Initialise the contract with an admin, fee in basis points, and fee recipient.
+    /// Must be called once before any other function.
+    pub fn initialize(env: Env, admin: Address, fee_bps: u32, fee_recipient: Address) {
+        assert!(
+            !env.storage().instance().has(&DataKey::Config),
+            "Already initialized"
+        );
+        assert!(fee_bps <= MAX_FEE_BPS, "fee_bps exceeds maximum (500)");
+        let config = Config {
+            admin,
+            fee_bps,
+            fee_recipient,
+        };
+        env.storage().instance().set(&DataKey::Config, &config);
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin
+    // -----------------------------------------------------------------------
+
+    /// Update the protocol fee (admin only, capped at 500 bps / 5%).
+    pub fn update_fee(env: Env, admin: Address, new_fee_bps: u32) {
+        admin.require_auth();
+        assert!(new_fee_bps <= MAX_FEE_BPS, "fee_bps exceeds maximum (500)");
+        let mut config: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("Not initialized");
+        assert!(config.admin == admin, "Unauthorized");
+        config.fee_bps = new_fee_bps;
+        env.storage().instance().set(&DataKey::Config, &config);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tip
+    // -----------------------------------------------------------------------
+
+    /// Send a tip to a worker.
+    /// Deducts a protocol fee (fee_bps) and transfers the remainder to `to`.
     pub fn tip(env: Env, from: Address, to: Address, token_addr: Address, amount: i128) {
         from.require_auth();
+        assert!(amount > 0, "Amount must be positive");
+
+        let config: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("Not initialized");
+
         let client = token::Client::new(&env, &token_addr);
-        client.transfer(&from, &to, &amount);
+
+        let fee: i128 = (amount * config.fee_bps as i128) / 10_000;
+        let worker_amount = amount - fee;
+
+        client.transfer(&from, &to, &worker_amount);
+        if fee > 0 {
+            client.transfer(&from, &config.fee_recipient, &fee);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Escrow
+    // -----------------------------------------------------------------------
+
+    /// Create an escrow — locks tokens until released, cancelled, or expired.
+    pub fn create_escrow(
+        env: Env,
+        id: Symbol,
+        from: Address,
+        to: Address,
+        token_addr: Address,
+        amount: i128,
+        expiry: u64,
+    ) {
+        from.require_auth();
+        assert!(amount > 0, "Amount must be positive");
+        assert!(
+            !env.storage().persistent().has(&DataKey::Escrow(id.clone())),
+            "Escrow id already exists"
+        );
+
+        let client = token::Client::new(&env, &token_addr);
+        client.transfer(&from, &env.current_contract_address(), &amount);
+
+        let escrow = Escrow {
+            from,
+            to,
+            token: token_addr,
+            amount,
+            expiry,
+            status: EscrowStatus::Active,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(id), &escrow);
+    }
+
+    /// Release escrow funds to the worker (from only).
+    pub fn release_escrow(env: Env, id: Symbol, caller: Address) {
+        caller.require_auth();
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(id.clone()))
+            .expect("Escrow not found");
+
+        assert!(escrow.status == EscrowStatus::Active, "Escrow not active");
+        assert!(escrow.from == caller, "Unauthorized");
+
+        let config: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("Not initialized");
+
+        let fee: i128 = (escrow.amount * config.fee_bps as i128) / 10_000;
+        let worker_amount = escrow.amount - fee;
+
+        let client = token::Client::new(&env, &escrow.token);
+        client.transfer(&env.current_contract_address(), &escrow.to, &worker_amount);
+        if fee > 0 {
+            client.transfer(
+                &env.current_contract_address(),
+                &config.fee_recipient,
+                &fee,
+            );
+        }
+
+        escrow.status = EscrowStatus::Released;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(id), &escrow);
+    }
+
+    /// Cancel escrow and refund to sender (from only, before expiry).
+    pub fn cancel_escrow(env: Env, id: Symbol, caller: Address) {
+        caller.require_auth();
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(id.clone()))
+            .expect("Escrow not found");
+
+        assert!(escrow.status == EscrowStatus::Active, "Escrow not active");
+        assert!(escrow.from == caller, "Unauthorized");
+
+        let client = token::Client::new(&env, &escrow.token);
+        client.transfer(&env.current_contract_address(), &escrow.from, &escrow.amount);
+
+        escrow.status = EscrowStatus::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(id), &escrow);
+    }
+
+    /// Cancel an expired escrow — anyone can call once past expiry.
+    pub fn cancel_expired_escrow(env: Env, id: Symbol) {
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(id.clone()))
+            .expect("Escrow not found");
+
+        assert!(escrow.status == EscrowStatus::Active, "Escrow not active");
+        assert!(
+            env.ledger().timestamp() >= escrow.expiry,
+            "Escrow not yet expired"
+        );
+
+        let client = token::Client::new(&env, &escrow.token);
+        client.transfer(&env.current_contract_address(), &escrow.from, &escrow.amount);
+
+        escrow.status = EscrowStatus::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(id), &escrow);
+    }
+
+    // -----------------------------------------------------------------------
+    // Views
+    // -----------------------------------------------------------------------
+
+    pub fn get_config(env: Env) -> Config {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("Not initialized")
+    }
+
+    pub fn get_escrow(env: Env, id: Symbol) -> Option<Escrow> {
+        env.storage().persistent().get(&DataKey::Escrow(id))
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/packages/contracts/contracts/market/src/test.rs
+++ b/packages/contracts/contracts/market/src/test.rs
@@ -1,0 +1,388 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Symbol,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup() -> (Env, Address, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let fee_recipient = Address::generate(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    // Deploy a native-style token for testing
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = token_id.address();
+
+    // Mint tokens to `from`
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    asset_client.mint(&from, &10_000);
+
+    (env, admin, fee_recipient, from, to, token_addr)
+}
+
+fn init(env: &Env, contract: &Address, admin: &Address, fee_bps: u32, fee_recipient: &Address) {
+    let client = MarketContractClient::new(env, contract);
+    client.initialize(admin, &fee_bps, fee_recipient);
+}
+
+fn deploy(env: &Env) -> Address {
+    env.register(MarketContract, ())
+}
+
+// ---------------------------------------------------------------------------
+// initialize
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_success() {
+    let (env, admin, fee_recipient, _from, _to, _token) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let config = client.get_config();
+    assert_eq!(config.fee_bps, 100);
+    assert_eq!(config.admin, admin);
+    assert_eq!(config.fee_recipient, fee_recipient);
+}
+
+#[test]
+#[should_panic(expected = "Already initialized")]
+fn test_initialize_twice_panics() {
+    let (env, admin, fee_recipient, _from, _to, _token) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+}
+
+#[test]
+#[should_panic(expected = "fee_bps exceeds maximum")]
+fn test_initialize_fee_too_high() {
+    let (env, admin, fee_recipient, _from, _to, _token) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 501, &fee_recipient);
+}
+
+// ---------------------------------------------------------------------------
+// tip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tip_success_with_fee() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient); // 1%
+
+    let client = MarketContractClient::new(&env, &contract);
+    client.tip(&from, &to, &token_addr, &1000);
+
+    let token = TokenClient::new(&env, &token_addr);
+    // worker gets 990, fee_recipient gets 10
+    assert_eq!(token.balance(&to), 990);
+    assert_eq!(token.balance(&fee_recipient), 10);
+    assert_eq!(token.balance(&from), 9_000);
+}
+
+#[test]
+fn test_tip_zero_fee() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 0, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    client.tip(&from, &to, &token_addr, &500);
+
+    let token = TokenClient::new(&env, &token_addr);
+    assert_eq!(token.balance(&to), 500);
+    assert_eq!(token.balance(&fee_recipient), 0);
+}
+
+#[test]
+fn test_tip_max_fee() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 500, &fee_recipient); // 5%
+
+    let client = MarketContractClient::new(&env, &contract);
+    client.tip(&from, &to, &token_addr, &1000);
+
+    let token = TokenClient::new(&env, &token_addr);
+    assert_eq!(token.balance(&to), 950);
+    assert_eq!(token.balance(&fee_recipient), 50);
+}
+
+#[test]
+#[should_panic]
+fn test_tip_insufficient_balance() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    // from only has 10_000; try to send 99_999
+    client.tip(&from, &to, &token_addr, &99_999);
+}
+
+#[test]
+#[should_panic(expected = "Amount must be positive")]
+fn test_tip_zero_amount() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    client.tip(&from, &to, &token_addr, &0);
+}
+
+// ---------------------------------------------------------------------------
+// update_fee
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_update_fee_success() {
+    let (env, admin, fee_recipient, _from, _to, _token) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    client.update_fee(&admin, &200);
+    assert_eq!(client.get_config().fee_bps, 200);
+}
+
+#[test]
+#[should_panic(expected = "fee_bps exceeds maximum")]
+fn test_update_fee_too_high() {
+    let (env, admin, fee_recipient, _from, _to, _token) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    client.update_fee(&admin, &501);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_update_fee_non_admin() {
+    let (env, admin, fee_recipient, from, _to, _token) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    client.update_fee(&from, &200);
+}
+
+// ---------------------------------------------------------------------------
+// escrow: create
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_create_escrow_success() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &9999);
+
+    let escrow = client.get_escrow(&id).unwrap();
+    assert_eq!(escrow.amount, 1000);
+    assert_eq!(escrow.status, EscrowStatus::Active);
+
+    // tokens locked in contract
+    let token = TokenClient::new(&env, &token_addr);
+    assert_eq!(token.balance(&contract), 1000);
+    assert_eq!(token.balance(&from), 9_000);
+}
+
+#[test]
+#[should_panic(expected = "Escrow id already exists")]
+fn test_create_escrow_duplicate_id() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &500, &9999);
+    client.create_escrow(&id, &from, &to, &token_addr, &500, &9999);
+}
+
+#[test]
+#[should_panic(expected = "Amount must be positive")]
+fn test_create_escrow_zero_amount() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &0, &9999);
+}
+
+// ---------------------------------------------------------------------------
+// escrow: release
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_release_escrow_success() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient); // 1%
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &9999);
+    client.release_escrow(&id, &from);
+
+    let token = TokenClient::new(&env, &token_addr);
+    assert_eq!(token.balance(&to), 990);
+    assert_eq!(token.balance(&fee_recipient), 10);
+    assert_eq!(token.balance(&contract), 0);
+
+    let escrow = client.get_escrow(&id).unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Released);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_release_escrow_unauthorized() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &9999);
+    client.release_escrow(&id, &to); // `to` is not `from`
+}
+
+#[test]
+#[should_panic(expected = "Escrow not active")]
+fn test_release_escrow_already_released() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &9999);
+    client.release_escrow(&id, &from);
+    client.release_escrow(&id, &from);
+}
+
+// ---------------------------------------------------------------------------
+// escrow: cancel
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_cancel_escrow_success() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &9999);
+    client.cancel_escrow(&id, &from);
+
+    let token = TokenClient::new(&env, &token_addr);
+    // full refund, no fee on cancel
+    assert_eq!(token.balance(&from), 10_000);
+    assert_eq!(token.balance(&contract), 0);
+
+    let escrow = client.get_escrow(&id).unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Cancelled);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_cancel_escrow_unauthorized() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &9999);
+    client.cancel_escrow(&id, &to);
+}
+
+#[test]
+#[should_panic(expected = "Escrow not active")]
+fn test_cancel_escrow_already_cancelled() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &9999);
+    client.cancel_escrow(&id, &from);
+    client.cancel_escrow(&id, &from);
+}
+
+// ---------------------------------------------------------------------------
+// escrow: cancel expired
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_cancel_expired_escrow_success() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &100);
+
+    // advance ledger past expiry
+    env.ledger().set_timestamp(200);
+    client.cancel_expired_escrow(&id);
+
+    let token = TokenClient::new(&env, &token_addr);
+    assert_eq!(token.balance(&from), 10_000);
+    assert_eq!(token.balance(&contract), 0);
+}
+
+#[test]
+#[should_panic(expected = "Escrow not yet expired")]
+fn test_cancel_expired_escrow_not_expired() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &9999);
+
+    env.ledger().set_timestamp(50);
+    client.cancel_expired_escrow(&id);
+}
+
+#[test]
+#[should_panic(expected = "Escrow not active")]
+fn test_cancel_expired_already_released() {
+    let (env, admin, fee_recipient, from, to, token_addr) = setup();
+    let contract = deploy(&env);
+    init(&env, &contract, &admin, 100, &fee_recipient);
+
+    let client = MarketContractClient::new(&env, &contract);
+    let id = Symbol::new(&env, "esc1");
+    client.create_escrow(&id, &from, &to, &token_addr, &1000, &100);
+    client.release_escrow(&id, &from);
+
+    env.ledger().set_timestamp(200);
+    client.cancel_expired_escrow(&id);
+}

--- a/packages/contracts/contracts/registry/src/lib.rs
+++ b/packages/contracts/contracts/registry/src/lib.rs
@@ -77,3 +77,6 @@ impl RegistryContract {
             .unwrap_or(Vec::new(&env))
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/packages/contracts/contracts/registry/src/test.rs
+++ b/packages/contracts/contracts/registry/src/test.rs
@@ -1,0 +1,219 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::Address as _,
+    Address, Env, String, Symbol,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup() -> (Env, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract = env.register(RegistryContract, ());
+    (env, contract)
+}
+
+fn make_worker(
+    env: &Env,
+    contract: &Address,
+    id: &str,
+    owner: &Address,
+) {
+    let client = RegistryContractClient::new(env, contract);
+    client.register(
+        &Symbol::new(env, id),
+        owner,
+        &String::from_str(env, id),
+        &Symbol::new(env, "plumber"),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// register
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_register_success() {
+    let (env, contract) = setup();
+    let owner = Address::generate(&env);
+    let client = RegistryContractClient::new(&env, &contract);
+
+    client.register(
+        &Symbol::new(&env, "w1"),
+        &owner,
+        &String::from_str(&env, "Alice"),
+        &Symbol::new(&env, "electrician"),
+    );
+
+    let worker = client.get_worker(&Symbol::new(&env, "w1")).unwrap();
+    assert_eq!(worker.owner, owner);
+    assert_eq!(worker.is_active, true);
+    assert_eq!(worker.category, Symbol::new(&env, "electrician"));
+}
+
+#[test]
+fn test_register_duplicate_id_overwrites() {
+    // Soroban persistent storage allows overwrite; registering same id twice
+    // replaces the entry. We verify the second write wins.
+    let (env, contract) = setup();
+    let owner1 = Address::generate(&env);
+    let owner2 = Address::generate(&env);
+    let client = RegistryContractClient::new(&env, &contract);
+
+    client.register(
+        &Symbol::new(&env, "w1"),
+        &owner1,
+        &String::from_str(&env, "Alice"),
+        &Symbol::new(&env, "plumber"),
+    );
+    client.register(
+        &Symbol::new(&env, "w1"),
+        &owner2,
+        &String::from_str(&env, "Bob"),
+        &Symbol::new(&env, "electrician"),
+    );
+
+    let worker = client.get_worker(&Symbol::new(&env, "w1")).unwrap();
+    assert_eq!(worker.owner, owner2);
+}
+
+#[test]
+#[should_panic]
+fn test_register_unauthorized() {
+    let env = Env::default();
+    // Do NOT mock auths — require_auth will panic
+    let contract = env.register(RegistryContract, ());
+    let owner = Address::generate(&env);
+    let client = RegistryContractClient::new(&env, &contract);
+
+    client.register(
+        &Symbol::new(&env, "w1"),
+        &owner,
+        &String::from_str(&env, "Alice"),
+        &Symbol::new(&env, "plumber"),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// get_worker
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_worker_found() {
+    let (env, contract) = setup();
+    let owner = Address::generate(&env);
+    make_worker(&env, &contract, "w1", &owner);
+
+    let client = RegistryContractClient::new(&env, &contract);
+    let result = client.get_worker(&Symbol::new(&env, "w1"));
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().owner, owner);
+}
+
+#[test]
+fn test_get_worker_not_found() {
+    let (env, contract) = setup();
+    let client = RegistryContractClient::new(&env, &contract);
+    let result = client.get_worker(&Symbol::new(&env, "nonexistent"));
+    assert!(result.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// toggle
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_toggle_owner_deactivates_then_activates() {
+    let (env, contract) = setup();
+    let owner = Address::generate(&env);
+    make_worker(&env, &contract, "w1", &owner);
+
+    let client = RegistryContractClient::new(&env, &contract);
+
+    // starts active
+    assert_eq!(
+        client.get_worker(&Symbol::new(&env, "w1")).unwrap().is_active,
+        true
+    );
+
+    // toggle off
+    client.toggle(&Symbol::new(&env, "w1"), &owner);
+    assert_eq!(
+        client.get_worker(&Symbol::new(&env, "w1")).unwrap().is_active,
+        false
+    );
+
+    // toggle back on
+    client.toggle(&Symbol::new(&env, "w1"), &owner);
+    assert_eq!(
+        client.get_worker(&Symbol::new(&env, "w1")).unwrap().is_active,
+        true
+    );
+}
+
+#[test]
+#[should_panic(expected = "Not authorized")]
+fn test_toggle_non_owner_panics() {
+    let (env, contract) = setup();
+    let owner = Address::generate(&env);
+    let other = Address::generate(&env);
+    make_worker(&env, &contract, "w1", &owner);
+
+    let client = RegistryContractClient::new(&env, &contract);
+    client.toggle(&Symbol::new(&env, "w1"), &other);
+}
+
+#[test]
+#[should_panic(expected = "Worker not found")]
+fn test_toggle_nonexistent_worker() {
+    let (env, contract) = setup();
+    let caller = Address::generate(&env);
+    let client = RegistryContractClient::new(&env, &contract);
+    client.toggle(&Symbol::new(&env, "ghost"), &caller);
+}
+
+// ---------------------------------------------------------------------------
+// list_workers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_list_workers_empty() {
+    let (env, contract) = setup();
+    let client = RegistryContractClient::new(&env, &contract);
+    let list = client.list_workers();
+    assert_eq!(list.len(), 0);
+}
+
+#[test]
+fn test_list_workers_multiple() {
+    let (env, contract) = setup();
+    let owner = Address::generate(&env);
+    make_worker(&env, &contract, "w1", &owner);
+    make_worker(&env, &contract, "w2", &owner);
+    make_worker(&env, &contract, "w3", &owner);
+
+    let client = RegistryContractClient::new(&env, &contract);
+    let list = client.list_workers();
+    assert_eq!(list.len(), 3);
+    assert_eq!(list.get(0).unwrap(), Symbol::new(&env, "w1"));
+    assert_eq!(list.get(1).unwrap(), Symbol::new(&env, "w2"));
+    assert_eq!(list.get(2).unwrap(), Symbol::new(&env, "w3"));
+}
+
+#[test]
+fn test_list_workers_after_toggle_still_listed() {
+    // toggling active status does not remove from list
+    let (env, contract) = setup();
+    let owner = Address::generate(&env);
+    make_worker(&env, &contract, "w1", &owner);
+
+    let client = RegistryContractClient::new(&env, &contract);
+    client.toggle(&Symbol::new(&env, "w1"), &owner);
+
+    let list = client.list_workers();
+    assert_eq!(list.len(), 1);
+}


### PR DESCRIPTION
1. Contracts Makefile

Added packages/contracts/Makefile with the following targets:

build — cargo build --release --target wasm32-unknown-unknown
test — cargo test
fmt — cargo fmt
clippy — cargo clippy -- -D warnings
deploy-testnet — deploys both Registry and Market contracts to Stellar testnet via stellar contract deploy (requires STELLAR_ACCOUNT env var)
clean — cargo clean

closes #119 

2. Market contract tests

Added 
test.rs
 with 20 tests using soroban_sdk::testutils and a mocked token contract (register_stellar_asset_contract_v2):

tip: success with fee, zero fee, max fee (500 bps), insufficient balance, zero amount
update_fee: success, exceeds cap, non-admin
create_escrow: success, duplicate id, zero amount
release_escrow: success with fee deduction, unauthorized, double-release
cancel_escrow: success (full refund), unauthorized, double-cancel
cancel_expired_escrow: success, not yet expired, already released

closes #118 

3. Registry contract tests

Added 
test.rs
 with 12 tests:

register: success, duplicate id (overwrite), unauthorized (no mock auth)
get_worker: found, not found
toggle: owner deactivates/reactivates, non-owner panics, nonexistent worker panics
list_workers: empty, multiple workers in order, list unaffected by toggle
closes #117 

4. Protocol fee in Market contract

Refactored 
lib.rs
:

Added Config struct with admin, fee_bps, and fee_recipient
Added initialize(admin, fee_bps, fee_recipient) — one-time setup, rejects fee_bps > 500
Added update_fee(admin, new_fee_bps) — admin-only, capped at 500 bps (5%)
tip now deducts fee_bps from amount, sends remainder to worker and fee to fee_recipient
release_escrow applies the same fee logic on release
Full escrow state machine: create_escrow, release_escrow, cancel_escrow, cancel_expired_escrow

closes #116 