### PR TITLE
Add GitHub Actions CI for contracts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Contracts Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: cargo build --release (wasm32)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/contracts/target
+          key: cargo-build-${{ runner.os }}-${{ hashFiles('packages/contracts/**/Cargo.toml', 'packages/contracts/**/Cargo.lock') }}
+          restore-keys: |
+            cargo-build-${{ runner.os }}-
+
+      - name: Build release WASM
+        run: cargo build --release --target wasm32-unknown-unknown
+        working-directory: packages/contracts

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,34 @@
+name: Contracts Clippy
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (with clippy)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Cache Cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/contracts/target
+          key: cargo-clippy-${{ runner.os }}-${{ hashFiles('packages/contracts/**/Cargo.toml', 'packages/contracts/**/Cargo.lock') }}
+          restore-keys: |
+            cargo-clippy-${{ runner.os }}-
+
+      - name: Run Clippy
+        run: cargo clippy -- -D warnings
+        working-directory: packages/contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Contracts Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/contracts/target
+          key: cargo-test-${{ runner.os }}-${{ hashFiles('packages/contracts/**/Cargo.toml', 'packages/contracts/**/Cargo.lock') }}
+          restore-keys: |
+            cargo-test-${{ runner.os }}-
+
+      - name: Run tests
+        run: cargo test
+        working-directory: packages/contracts


### PR DESCRIPTION
## Summary

Adds three focused GitHub Actions workflows for the `packages/contracts` Rust/WASM package.

this pr Closes #120 

## Workflows added

- `test.yml` — runs `cargo test` on every push and PR
- `build.yml` — runs `cargo build --release --target wasm32-unknown-unknown` to verify the WASM target compiles cleanly
- `clippy.yml` — runs `cargo clippy -- -D warnings` to enforce lint hygiene

## Caching

All three workflows cache the Cargo registry (`~/.cargo/registry`, `~/.cargo/git`) and the `packages/contracts/target` directory using `actions/cache@v4`. Cache keys are scoped per workflow and keyed on `Cargo.toml`/`Cargo.lock` hashes to ensure correctness while maximising hit rate.

## Notes

- Triggers on all branches (not just `main`) so contributors get feedback on feature branches before merge
- Complements the existing `ci.yml` contract jobs which act as the main gate on `main`
- `clippy` component is explicitly declared in the toolchain install step
