### PR TITLE
Add LICENSE file to contracts package

### DIFF
--- a/packages/contracts/LICENSE
+++ b/packages/contracts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 BlueCollar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/contracts/contracts/market/Cargo.toml
+++ b/packages/contracts/contracts/market/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bluecollar-market"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 crate-type = ["cdylib"]

--- a/packages/contracts/contracts/registry/Cargo.toml
+++ b/packages/contracts/contracts/registry/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bluecollar-registry"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary

The `packages/contracts` Rust package had no license, inconsistent with the MIT license used in the reference Artisyn contracts repo.

this pr Closes #121 

## Changes

- Added `packages/contracts/LICENSE` with the standard MIT license text (copyright 2026 BlueCollar)
- Added `license = "MIT"` to the `[package]` section of `contracts/market/Cargo.toml`
- Added `license = "MIT"` to the `[package]` section of `contracts/registry/Cargo.toml`

## Notes

The workspace-level `Cargo.toml` does not carry a license field — this is intentional, as `license` is a per-package metadata field in Cargo and must be declared on each crate individually.
