### PR TITLE
test: setup vitest

### DIFF
--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -1,6 +1,8 @@
 # Database connection
 # PostgreSQL database URL (e.g., postgresql://user:password@localhost:5432/bluecollar)
 DATABASE_URL="postgresql://user:password@localhost:5432/bluecollar"
+# Separate database used only when running tests (never points at production data)
+TEST_DATABASE_URL="postgresql://user:password@localhost:5432/bluecollar_test"
 
 # JWT Authentication
 # Secret key used for signing JSON Web Tokens

--- a/packages/api/testSetup.ts
+++ b/packages/api/testSetup.ts
@@ -1,6 +1,28 @@
-import { afterAll } from 'vitest'
-import { db } from './src/db.js'
+import { beforeAll, afterAll, afterEach } from 'vitest'
+import { execSync } from 'child_process'
+import { PrismaClient } from '@prisma/client'
+
+// Point Prisma at the test database before the client is instantiated
+process.env.DATABASE_URL = process.env.TEST_DATABASE_URL
+
+const db = new PrismaClient()
+
+beforeAll(async () => {
+  execSync('prisma migrate deploy', { stdio: 'inherit' })
+})
+
+afterEach(async () => {
+  // Delete in FK-safe order: dependents before parents
+  await db.$transaction([
+    db.worker.deleteMany(),
+    db.user.deleteMany(),
+    db.category.deleteMany(),
+    db.location.deleteMany(),
+  ])
+})
 
 afterAll(async () => {
   await db.$disconnect()
 })
+
+export { db }

--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
     },
-    include: ['src/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+    include: ['src/__tests__/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
This PR closes #128

feat: set up Vitest with test database for API integration tests (#128)

Summary
Rewrites testSetup.ts to redirect DATABASE_URL to TEST_DATABASE_URL at load time, run prisma migrate deploy before the suite, and truncate all tables between tests in FK-safe order via $transaction
Narrows vitest.config.ts include to src/__tests__/**/*.test.ts only
Adds TEST_DATABASE_URL to .env.example