### PR TITLE
feat(#263): add loading skeletons for all pages

### DIFF
--- a/packages/app/src/app/[locale]/dashboard/bookmarks/loading.tsx
+++ b/packages/app/src/app/[locale]/dashboard/bookmarks/loading.tsx
@@ -1,0 +1,5 @@
+import { BookmarksSkeleton } from "@/components/Skeleton";
+
+export default function BookmarksLoading() {
+  return <BookmarksSkeleton />;
+}

--- a/packages/app/src/app/[locale]/dashboard/bookmarks/page.tsx
+++ b/packages/app/src/app/[locale]/dashboard/bookmarks/page.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Loader2, Bookmark } from "lucide-react";
+import { Bookmark } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { getMyBookmarks } from "@/lib/api";
 import WorkerCard from "@/components/WorkerCard";
+import { BookmarksSkeleton } from "@/components/Skeleton";
 import type { Worker } from "@/types";
 
 export default function SavedWorkersPage() {
@@ -30,11 +31,7 @@ export default function SavedWorkersPage() {
   }, [authLoading, user]);
 
   if (authLoading || loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Loader2 size={28} className="animate-spin text-blue-500" />
-      </div>
-    );
+    return <BookmarksSkeleton />;
   }
 
   return (

--- a/packages/app/src/app/[locale]/dashboard/loading.tsx
+++ b/packages/app/src/app/[locale]/dashboard/loading.tsx
@@ -1,0 +1,16 @@
+import { DashboardTableSkeleton } from "@/components/Skeleton";
+
+export default function DashboardLoading() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10">
+      <div className="mb-8 flex items-center justify-between">
+        <div className="flex flex-col gap-2">
+          <div className="h-7 w-36 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
+          <div className="h-4 w-48 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+        </div>
+        <div className="h-10 w-40 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700" />
+      </div>
+      <DashboardTableSkeleton />
+    </div>
+  );
+}

--- a/packages/app/src/app/[locale]/dashboard/page.tsx
+++ b/packages/app/src/app/[locale]/dashboard/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { cn } from "@/lib/utils";
+import { DashboardTableSkeleton } from "@/components/Skeleton";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
 
@@ -115,8 +116,8 @@ export default function DashboardPage() {
   // ── Loading / auth guard ──────────────────────────────────────────────────
   if (authLoading || (!user && !authLoading)) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Loader2 size={28} className="animate-spin text-blue-500" />
+      <div className="mx-auto max-w-6xl px-4 py-10">
+        <DashboardTableSkeleton />
       </div>
     );
   }
@@ -150,9 +151,7 @@ export default function DashboardPage() {
       {/* Table */}
       <div className="rounded-xl border bg-white shadow-sm overflow-hidden">
         {loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Loader2 size={24} className="animate-spin text-blue-500" />
-          </div>
+          <DashboardTableSkeleton />
         ) : workers.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-20 text-center">
             <p className="text-gray-500 font-medium">No workers yet</p>

--- a/packages/app/src/app/[locale]/page.tsx
+++ b/packages/app/src/app/[locale]/page.tsx
@@ -1,9 +1,10 @@
+import { Suspense } from 'react'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
 import Hero from '@/features/landing-page/Hero'
-import Categories from '@/features/landing-page/Categories'
+import Categories, { CategoriesSkeleton } from '@/features/landing-page/Categories'
 import HowItWorks from '@/features/landing-page/HowItWorks'
-import FeaturedWorkers from '@/features/landing-page/FeaturedWorkers'
+import FeaturedWorkers, { FeaturedWorkersSkeleton } from '@/features/landing-page/FeaturedWorkers'
 
 export default function HomePage() {
   return (
@@ -11,8 +12,12 @@ export default function HomePage() {
       <Navbar />
       <main>
         <Hero />
-        <Categories />
-        <FeaturedWorkers />
+        <Suspense fallback={<CategoriesSkeleton />}>
+          <Categories />
+        </Suspense>
+        <Suspense fallback={<FeaturedWorkersSkeleton />}>
+          <FeaturedWorkers />
+        </Suspense>
         <HowItWorks />
       </main>
       <Footer />

--- a/packages/app/src/app/dashboard/admin/loading.tsx
+++ b/packages/app/src/app/dashboard/admin/loading.tsx
@@ -1,0 +1,5 @@
+import { AdminDashboardSkeleton } from "@/components/Skeleton";
+
+export default function AdminLoading() {
+  return <AdminDashboardSkeleton />;
+}

--- a/packages/app/src/app/dashboard/admin/page.tsx
+++ b/packages/app/src/app/dashboard/admin/page.tsx
@@ -6,6 +6,7 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Responsive
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/useToast";
 import { formatDate } from "@/lib/utils";
+import { AdminDashboardSkeleton } from "@/components/Skeleton";
 
 interface Stats {
   totalWorkers: number;
@@ -70,7 +71,7 @@ export default function AdminDashboard() {
   }, [user, router, toast]);
 
   if (!user || user.role !== "admin") return null;
-  if (isLoading) return <div className="p-8 text-center">Loading...</div>;
+  if (isLoading) return <AdminDashboardSkeleton />;
   if (!stats) return <div className="p-8 text-center">Failed to load stats</div>;
 
   return (

--- a/packages/app/src/components/Skeleton.tsx
+++ b/packages/app/src/components/Skeleton.tsx
@@ -6,13 +6,13 @@ interface Props {
 
 export default function Skeleton({ className }: Props) {
   return (
-    <div className={cn("animate-pulse rounded-md bg-gray-200", className)} />
+    <div className={cn("animate-pulse rounded-md bg-gray-200 dark:bg-gray-700", className)} />
   );
 }
 
 export function WorkerCardSkeleton() {
   return (
-    <div className="flex flex-col gap-4 rounded-xl border bg-white p-5 shadow-sm">
+    <div className="flex flex-col gap-4 rounded-xl border bg-white dark:bg-gray-900 dark:border-gray-800 p-5 shadow-sm">
       <div className="flex items-center gap-3">
         <Skeleton className="h-14 w-14 rounded-full" />
         <div className="flex flex-col gap-2 flex-1">
@@ -32,7 +32,7 @@ export function WorkerProfileSkeleton() {
   return (
     <div className="mx-auto max-w-2xl px-4 py-10">
       <Skeleton className="mb-6 h-4 w-28" />
-      <div className="rounded-2xl border bg-white p-8 shadow-sm">
+      <div className="rounded-2xl border bg-white dark:bg-gray-900 dark:border-gray-800 p-8 shadow-sm">
         <div className="flex items-center gap-5">
           <Skeleton className="h-20 w-20 rounded-full shrink-0" />
           <div className="flex flex-col gap-2 flex-1">
@@ -50,13 +50,110 @@ export function WorkerProfileSkeleton() {
           <Skeleton className="h-4 w-48" />
           <Skeleton className="h-4 w-32" />
         </div>
-        <div className="mt-8 border-t pt-6 flex items-center justify-between">
+        <div className="mt-8 border-t dark:border-gray-800 pt-6 flex items-center justify-between">
           <div className="flex flex-col gap-2">
             <Skeleton className="h-4 w-36" />
             <Skeleton className="h-3 w-48" />
           </div>
           <Skeleton className="h-9 w-24 rounded-lg" />
         </div>
+      </div>
+    </div>
+  );
+}
+
+export function DashboardTableSkeleton() {
+  return (
+    <div className="rounded-xl border bg-white dark:bg-gray-900 dark:border-gray-800 shadow-sm overflow-hidden">
+      <div className="border-b dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50 px-5 py-3.5 flex gap-8">
+        {["w-16", "w-20", "w-14", "w-20", "w-12"].map((w, i) => (
+          <Skeleton key={i} className={`h-3 ${w}`} />
+        ))}
+      </div>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-8 px-5 py-4 border-b last:border-b-0 dark:border-gray-800">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="h-4 w-24" />
+          <div className="ml-auto flex gap-2">
+            <Skeleton className="h-7 w-7 rounded-md" />
+            <Skeleton className="h-7 w-7 rounded-md" />
+            <Skeleton className="h-7 w-7 rounded-md" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function CategoryGridSkeleton() {
+  return (
+    <section className="px-4 py-12">
+      <Skeleton className="mx-auto mb-8 h-7 w-48" />
+      <div className="mx-auto max-w-6xl grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex flex-col items-center gap-2 rounded-xl border bg-white dark:bg-gray-900 dark:border-gray-800 p-5">
+            <Skeleton className="h-10 w-10 rounded-full" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-3 w-14 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function AdminDashboardSkeleton() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-10">
+      <Skeleton className="mb-8 h-8 w-52" />
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-800 p-6">
+            <Skeleton className="h-4 w-28 mb-3" />
+            <Skeleton className="h-9 w-16" />
+          </div>
+        ))}
+      </div>
+      <div className="rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-800 p-6 mb-8">
+        <Skeleton className="h-5 w-36 mb-4" />
+        <Skeleton className="h-64 w-full rounded-md" />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {[0, 1].map((i) => (
+          <div key={i} className="rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-800 p-6">
+            <Skeleton className="h-5 w-48 mb-4" />
+            {Array.from({ length: 4 }).map((_, j) => (
+              <div key={j} className="flex justify-between py-3 border-b last:border-b-0 dark:border-gray-800">
+                <div className="flex flex-col gap-1.5">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+                <Skeleton className="h-3 w-16" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function BookmarksSkeleton() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10">
+      <div className="mb-8 flex items-center gap-3">
+        <Skeleton className="h-6 w-6 rounded" />
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-6 w-36" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+      </div>
+      <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <WorkerCardSkeleton key={i} />
+        ))}
       </div>
     </div>
   );

--- a/packages/app/src/features/landing-page/Categories.tsx
+++ b/packages/app/src/features/landing-page/Categories.tsx
@@ -37,17 +37,19 @@ export default async function Categories() {
 
 export function CategoriesSkeleton() {
   return (
-    <section>
-      <h2>Browse by Category</h2>
-      <div className="categories-grid">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="category-card skeleton" aria-hidden="true">
-            <span className="category-icon skeleton-box" />
-            <span className="category-name skeleton-box" />
-            <span className="category-badge skeleton-box" />
-          </div>
-        ))}
+    <section className="px-4 py-12">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 h-7 w-48 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex flex-col items-center gap-2 rounded-xl border bg-white dark:bg-gray-900 dark:border-gray-800 p-5" aria-hidden="true">
+              <div className="h-10 w-10 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+              <div className="h-4 w-20 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+              <div className="h-3 w-14 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+            </div>
+          ))}
+        </div>
       </div>
     </section>
-  )
+  );
 }

--- a/packages/app/src/features/landing-page/FeaturedWorkers.tsx
+++ b/packages/app/src/features/landing-page/FeaturedWorkers.tsx
@@ -17,6 +17,28 @@ async function getFeaturedWorkers(): Promise<Worker[]> {
   return json.data;
 }
 
+export function FeaturedWorkersSkeleton() {
+  return (
+    <section className="px-4 py-16 max-w-6xl mx-auto">
+      <div className="h-8 w-48 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5 flex flex-col gap-4">
+            <div className="flex items-center gap-4">
+              <div className="w-14 h-14 rounded-full animate-pulse bg-gray-200 dark:bg-gray-700 shrink-0" />
+              <div className="flex flex-col gap-2 flex-1">
+                <div className="h-4 w-28 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+                <div className="h-3 w-16 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+              </div>
+            </div>
+            <div className="mt-auto h-9 w-full animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export default async function FeaturedWorkers() {
   const workers = await getFeaturedWorkers()
 


### PR DESCRIPTION
## Summary

Closes #263

Replaces all generic loading spinners with content-aware skeleton screens that match the actual layout of each page.

## Changes

### `Skeleton.tsx`
- Added `dark:` support to all existing skeletons (`WorkerCardSkeleton`, `WorkerProfileSkeleton`)
- New: `DashboardTableSkeleton` — mirrors the table header + 5 rows with action buttons
- New: `CategoryGridSkeleton` — 8-cell grid matching the category card layout
- New: `AdminDashboardSkeleton` — stat cards + chart placeholder + two activity panels
- New: `BookmarksSkeleton` — header + 6 worker card skeletons

### `Categories.tsx`
- Fixed `CategoriesSkeleton`: was using non-existent CSS class names (`categories-grid`, `skeleton-box`), replaced with proper Tailwind classes matching the real category card layout

### `FeaturedWorkers.tsx`
- Exported `FeaturedWorkersSkeleton` matching the featured worker card layout (avatar, name, category badge, CTA button)

### Home page (`[locale]/page.tsx`)
- Wrapped `<Categories>` and `<FeaturedWorkers>` in `<Suspense>` with their respective skeleton fallbacks

### New `loading.tsx` files
- `[locale]/dashboard/loading.tsx` — uses `DashboardTableSkeleton`
- `[locale]/dashboard/bookmarks/loading.tsx` — uses `BookmarksSkeleton`
- `dashboard/admin/loading.tsx` — uses `AdminDashboardSkeleton`

### Inline spinner replacements
- `DashboardPage`: auth guard + table loading state → `DashboardTableSkeleton`
- `SavedWorkersPage`: auth + data loading state → `BookmarksSkeleton`
- `AdminDashboard`: `Loading...` text → `AdminDashboardSkeleton`

> Workers list and worker profile pages already had `loading.tsx` files wired up — no changes needed there.