### PR TITLE
feat(#265): add worker profile image zoom/lightbox

### DIFF
--- a/packages/app/src/app/[locale]/workers/[id]/page.tsx
+++ b/packages/app/src/app/[locale]/workers/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { BadgeCheck, MapPin, Mail, Phone, ArrowLeft, QrCode } from "lucide-react";
+import { BadgeCheck, MapPin, Mail, Phone, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import TipModal from "@/components/TipModal";
 import TransactionHistory from "@/components/TransactionHistory";
@@ -9,6 +9,7 @@ import StarRating from "@/components/StarRating";
 import ReviewCard from "@/components/ReviewCard";
 import ReviewForm from "@/components/ReviewForm";
 import QRCodeButton from "@/components/QRCodeButton";
+import ZoomableAvatar from "@/components/ZoomableAvatar";
 import type { Worker, ApiResponse, Review } from "@/types";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
@@ -79,10 +80,10 @@ export default async function WorkerProfilePage({
         {/* Avatar + name */}
         <div className="flex items-start gap-5">
           {worker.avatar ? (
-            <img
+            <ZoomableAvatar
               src={worker.avatar}
               alt={worker.name}
-              className="h-20 w-20 rounded-full object-cover ring-2 ring-blue-100"
+              className="h-20 w-20 rounded-full object-cover ring-2 ring-blue-100 cursor-zoom-in"
             />
           ) : (
             <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 font-bold text-2xl">

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -56,3 +56,13 @@
     color: hsl(var(--foreground));
   }
 }
+
+@layer utilities {
+  @keyframes fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  .animate-fade-in {
+    animation: fade-in 0.2s ease;
+  }
+}

--- a/packages/app/src/components/ImageLightbox.tsx
+++ b/packages/app/src/components/ImageLightbox.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { X, ZoomIn, ZoomOut, RotateCcw } from "lucide-react";
+
+interface Props {
+  src: string;
+  alt: string;
+  onClose: () => void;
+}
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 4;
+const ZOOM_STEP = 0.75;
+
+export default function ImageLightbox({ src, alt, onClose }: Props) {
+  const [loaded, setLoaded] = useState(false);
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const dragging = useRef(false);
+  const dragStart = useRef({ x: 0, y: 0 });
+  const offsetAtDragStart = useRef({ x: 0, y: 0 });
+
+  // ESC to close
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Prevent body scroll while open
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = prev; };
+  }, []);
+
+  const reset = useCallback(() => { setScale(1); setOffset({ x: 0, y: 0 }); }, []);
+
+  const zoom = useCallback((delta: number) => {
+    setScale((s) => {
+      const next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, s + delta));
+      if (next === MIN_SCALE) setOffset({ x: 0, y: 0 });
+      return next;
+    });
+  }, []);
+
+  // Wheel zoom
+  const onWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    zoom(e.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP);
+  };
+
+  // Mouse drag
+  const onMouseDown = (e: React.MouseEvent) => {
+    if (scale === 1) return;
+    dragging.current = true;
+    dragStart.current = { x: e.clientX, y: e.clientY };
+    offsetAtDragStart.current = offset;
+  };
+  const onMouseMove = (e: React.MouseEvent) => {
+    if (!dragging.current) return;
+    setOffset({
+      x: offsetAtDragStart.current.x + (e.clientX - dragStart.current.x),
+      y: offsetAtDragStart.current.y + (e.clientY - dragStart.current.y),
+    });
+  };
+  const onMouseUp = () => { dragging.current = false; };
+
+  // Touch pinch-zoom + drag
+  const lastTouchDist = useRef<number | null>(null);
+  const onTouchStart = (e: React.TouchEvent) => {
+    if (e.touches.length === 2) {
+      lastTouchDist.current = Math.hypot(
+        e.touches[1].clientX - e.touches[0].clientX,
+        e.touches[1].clientY - e.touches[0].clientY
+      );
+    } else if (e.touches.length === 1 && scale > 1) {
+      dragging.current = true;
+      dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+      offsetAtDragStart.current = offset;
+    }
+  };
+  const onTouchMove = (e: React.TouchEvent) => {
+    if (e.touches.length === 2 && lastTouchDist.current !== null) {
+      const dist = Math.hypot(
+        e.touches[1].clientX - e.touches[0].clientX,
+        e.touches[1].clientY - e.touches[0].clientY
+      );
+      const delta = (dist - lastTouchDist.current) / 80;
+      zoom(delta);
+      lastTouchDist.current = dist;
+    } else if (e.touches.length === 1 && dragging.current) {
+      setOffset({
+        x: offsetAtDragStart.current.x + (e.touches[0].clientX - dragStart.current.x),
+        y: offsetAtDragStart.current.y + (e.touches[0].clientY - dragStart.current.y),
+      });
+    }
+  };
+  const onTouchEnd = () => {
+    dragging.current = false;
+    lastTouchDist.current = null;
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Full size image: ${alt}`}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 animate-fade-in"
+      onClick={onClose}
+    >
+      {/* Controls */}
+      <div
+        className="absolute top-4 right-4 flex items-center gap-2 z-10"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={() => zoom(ZOOM_STEP)}
+          disabled={scale >= MAX_SCALE}
+          aria-label="Zoom in"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20 disabled:opacity-40 transition-colors"
+        >
+          <ZoomIn size={18} />
+        </button>
+        <button
+          onClick={() => zoom(-ZOOM_STEP)}
+          disabled={scale <= MIN_SCALE}
+          aria-label="Zoom out"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20 disabled:opacity-40 transition-colors"
+        >
+          <ZoomOut size={18} />
+        </button>
+        <button
+          onClick={reset}
+          aria-label="Reset zoom"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+        >
+          <RotateCcw size={16} />
+        </button>
+        <button
+          onClick={onClose}
+          aria-label="Close image viewer"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      {/* Loading spinner */}
+      {!loaded && (
+        <div className="absolute inset-0 flex items-center justify-center" aria-hidden="true">
+          <div className="h-10 w-10 rounded-full border-2 border-white/20 border-t-white animate-spin" />
+        </div>
+      )}
+
+      {/* Image */}
+      <div
+        className="relative max-h-screen max-w-screen overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+        onWheel={onWheel}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={onMouseUp}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        style={{ cursor: scale > 1 ? "grab" : "default" }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={src}
+          alt={alt}
+          onLoad={() => setLoaded(true)}
+          className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain select-none transition-opacity duration-300"
+          style={{
+            opacity: loaded ? 1 : 0,
+            transform: `scale(${scale}) translate(${offset.x / scale}px, ${offset.y / scale}px)`,
+            transition: dragging.current ? "none" : "transform 0.15s ease",
+          }}
+          draggable={false}
+        />
+      </div>
+
+      {/* Hint */}
+      {loaded && scale === 1 && (
+        <p className="absolute bottom-4 left-1/2 -translate-x-1/2 text-xs text-white/50 select-none">
+          Scroll or pinch to zoom · ESC to close
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/ZoomableAvatar.tsx
+++ b/packages/app/src/components/ZoomableAvatar.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import ImageLightbox from "./ImageLightbox";
+
+interface Props {
+  src: string;
+  alt: string;
+  className?: string;
+}
+
+export default function ZoomableAvatar({ src, alt, className }: Props) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={`View full size photo of ${alt}`}
+        className="rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={src} alt={alt} className={className} />
+      </button>
+      {open && <ImageLightbox src={src} alt={alt} onClose={() => setOpen(false)} />}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #265

Adds a fullscreen image lightbox to the worker profile page, allowing users to view the profile photo at full size with zoom and pan.

## New files

### `ImageLightbox.tsx`
Self-contained lightbox rendered in a portal-like fixed overlay.

| Feature | Implementation |
|---|---|
| Zoom in/out buttons | ±0.75x steps, clamped 1×–4× |
| Mouse wheel zoom | `onWheel` — scroll up = zoom in |
| Pinch-to-zoom | Two-finger touch distance delta |
| Pan when zoomed | Mouse drag + single-finger touch drag |
| Reset button | Restores 1× scale and centered offset |
| ESC to close | `keydown` listener, cleaned up on unmount |
| Backdrop click | Clicking outside the image closes the modal |
| Loading state | Spinner shown until `onLoad` fires; image fades in |
| Body scroll lock | `overflow: hidden` on `body` while open, restored on unmount |
| Hint text | "Scroll or pinch to zoom · ESC to close" shown at 1× |

### `ZoomableAvatar.tsx`
Thin `"use client"` wrapper so the server-rendered profile page can stay async. Renders the avatar as a `<button>` and mounts `ImageLightbox` on click.

## Modified files

### `workers/[id]/page.tsx`
- Import `ZoomableAvatar` instead of a plain `<img>`
- Added `cursor-zoom-in` class to signal the image is interactive
- Removed unused `QrCode` icon import

### `globals.css`
- Added `@keyframes fade-in` + `.animate-fade-in` utility for the backdrop entrance

## Accessibility
- `role="dialog"`, `aria-modal="true"`, `aria-label` on the overlay
- `aria-label` on every control button (Zoom in, Zoom out, Reset zoom, Close)
- Avatar trigger is a `<button>` with descriptive `aria-label`
- `focus-visible:ring` on the avatar button for keyboard users
- ESC key closes the dialog (standard modal keyboard contract)