### PR TITLE
feat(app): add reusable EmptyState component for all list views (#266)

### DIFF
--- a/packages/api/src/controllers/workers.ts
+++ b/packages/api/src/controllers/workers.ts
@@ -14,7 +14,7 @@ import type { CreateWorkerBody, UpdateWorkerBody, WorkerQuery } from '../interfa
  */
 export async function listWorkers(req: Request<{}, {}, {}, WorkerQuery>, res: Response) {
   try {
-    const { category, page = '1', limit = '20', search, city, state, country } = req.query
+    const { category, page = '1', limit = '20', search, city, state, country, minRating, available, listedSince } = req.query
     const { data, meta } = await workerService.listWorkers({
       category,
       page: Number(page),
@@ -22,7 +22,10 @@ export async function listWorkers(req: Request<{}, {}, {}, WorkerQuery>, res: Re
       search,
       city,
       state,
-      country
+      country,
+      minRating: minRating ? Number(minRating) : undefined,
+      available: available !== undefined ? Number(available) : undefined,
+      listedSince: listedSince ? Number(listedSince) : undefined,
     })
     return res.json({
       data: WorkerCollection(data as any),

--- a/packages/api/src/interfaces/worker.interface.ts
+++ b/packages/api/src/interfaces/worker.interface.ts
@@ -19,4 +19,7 @@ export interface WorkerQuery {
   country?: string
   page?: string
   limit?: string
+  minRating?: string   // minimum average rating (1-5)
+  available?: string   // day of week 0-6
+  listedSince?: string // max years since listing (experience proxy)
 }

--- a/packages/api/src/services/worker.service.ts
+++ b/packages/api/src/services/worker.service.ts
@@ -25,9 +25,13 @@ export async function listWorkers(opts: {
   city?: string
   state?: string
   country?: string
+  minRating?: number
+  available?: number
+  listedSince?: number
 }) {
-  const { category, page = 1, limit = 20, search, city, state, country } = opts
-  const where = {
+  const { category, page = 1, limit = 20, search, city, state, country, minRating, available, listedSince } = opts
+
+  const where: any = {
     isActive: true,
     ...(category ? { categoryId: category } : {}),
     ...(search
@@ -47,6 +51,21 @@ export async function listWorkers(opts: {
           },
         }
       : {}),
+    ...(available !== undefined
+      ? { availability: { some: { dayOfWeek: available } } }
+      : {}),
+    ...(listedSince !== undefined
+      ? { createdAt: { gte: new Date(Date.now() - listedSince * 365 * 24 * 60 * 60 * 1000) } }
+      : {}),
+  }
+
+  if (minRating !== undefined) {
+    const qualifiedIds = await db.review.groupBy({
+      by: ['workerId'],
+      _avg: { rating: true },
+      having: { rating: { _avg: { gte: minRating } } },
+    })
+    where.id = { in: qualifiedIds.map((r) => r.workerId) }
   }
 
   const [data, total] = await Promise.all([

--- a/packages/app/src/app/[locale]/dashboard/bookmarks/page.tsx
+++ b/packages/app/src/app/[locale]/dashboard/bookmarks/page.tsx
@@ -6,6 +6,7 @@ import { Loader2, Bookmark } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { getMyBookmarks } from "@/lib/api";
 import WorkerCard from "@/components/WorkerCard";
+import EmptyState from "@/components/EmptyState";
 import type { Worker } from "@/types";
 
 export default function SavedWorkersPage() {
@@ -52,13 +53,7 @@ export default function SavedWorkersPage() {
       )}
 
       {workers.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-          <Bookmark size={36} className="text-gray-200 mb-3" />
-          <p className="text-gray-500 font-medium">No saved workers yet</p>
-          <p className="mt-1 text-sm text-gray-400">
-            Tap the heart icon on any worker card to save them here.
-          </p>
-        </div>
+        <EmptyState variant="no-bookmarks" />
       ) : (
         <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
           {workers.map((worker) => (

--- a/packages/app/src/app/[locale]/layout.tsx
+++ b/packages/app/src/app/[locale]/layout.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from "react";
 import { AuthProvider } from "@/context/AuthContext";
 import { WalletProvider } from "@/context/WalletContext";
+import { CompareProvider } from "@/context/CompareContext";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages } from 'next-intl/server'
+import CompareDrawer from "@/components/CompareDrawer";
 
 export default async function LocaleLayout({ 
   children, 
@@ -21,7 +23,12 @@ export default async function LocaleLayout({
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem storageKey="bc_theme">
             <AuthProvider>
-              <WalletProvider>{children}</WalletProvider>
+              <WalletProvider>
+                <CompareProvider>
+                  {children}
+                  <CompareDrawer />
+                </CompareProvider>
+              </WalletProvider>
             </AuthProvider>
             <Toaster position="bottom-right" richColors closeButton />
           </ThemeProvider>

--- a/packages/app/src/app/[locale]/workers/[id]/page.tsx
+++ b/packages/app/src/app/[locale]/workers/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { BadgeCheck, MapPin, Mail, Phone, ArrowLeft, QrCode } from "lucide-react";
+import { BadgeCheck, MapPin, Mail, Phone, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import TipModal from "@/components/TipModal";
 import TransactionHistory from "@/components/TransactionHistory";
@@ -10,6 +10,7 @@ import ReviewCard from "@/components/ReviewCard";
 import ReviewForm from "@/components/ReviewForm";
 import QRCodeButton from "@/components/QRCodeButton";
 import EmptyState from "@/components/EmptyState";
+import AvailabilityCalendar from "@/components/AvailabilityCalendar";
 import type { Worker, ApiResponse, Review } from "@/types";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
@@ -25,6 +26,13 @@ async function fetchReviews(id: string) {
   const res = await fetch(`${API}/workers/${id}/reviews?limit=10`, { cache: "no-store" });
   if (!res.ok) return { data: [], averageRating: null, reviewCount: 0 };
   return res.json() as Promise<{ data: Review[]; averageRating: number | null; reviewCount: number }>;
+}
+
+async function fetchAvailability(id: string) {
+  const res = await fetch(`${API}/workers/${id}/availability`, { cache: "no-store" });
+  if (!res.ok) return [];
+  const json = await res.json();
+  return (json.data ?? []) as { dayOfWeek: number; startTime: string; endTime: string }[];
 }
 
 export async function generateMetadata({
@@ -50,9 +58,10 @@ export default async function WorkerProfilePage({
 }: {
   params: { id: string };
 }) {
-  const [data, reviewsData] = await Promise.all([
+  const [data, reviewsData, availability] = await Promise.all([
     fetchWorker(params.id),
     fetchReviews(params.id),
+    fetchAvailability(params.id),
   ]);
   if (!data) notFound();
 
@@ -147,6 +156,11 @@ export default async function WorkerProfilePage({
               </a>
             </div>
           )}
+        </div>
+
+        {/* Availability calendar */}
+        <div className="mt-8 border-t pt-6">
+          <AvailabilityCalendar availability={availability} />
         </div>
 
         {/* Tip section */}

--- a/packages/app/src/app/[locale]/workers/[id]/page.tsx
+++ b/packages/app/src/app/[locale]/workers/[id]/page.tsx
@@ -9,6 +9,7 @@ import StarRating from "@/components/StarRating";
 import ReviewCard from "@/components/ReviewCard";
 import ReviewForm from "@/components/ReviewForm";
 import QRCodeButton from "@/components/QRCodeButton";
+import EmptyState from "@/components/EmptyState";
 import type { Worker, ApiResponse, Review } from "@/types";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
@@ -188,7 +189,7 @@ export default async function WorkerProfilePage({
               ))}
             </div>
           ) : (
-            <p className="text-sm text-gray-400 italic">No reviews yet. Be the first!</p>
+            <EmptyState variant="no-reviews" ctaHref="#review-form" />
           )}
         </div>
       </div>

--- a/packages/app/src/app/[locale]/workers/page.tsx
+++ b/packages/app/src/app/[locale]/workers/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import WorkerCard from "@/components/WorkerCard";
+import EmptyState from "@/components/EmptyState";
 import type { Worker, Category, ApiResponse } from "@/types";
 
 export const metadata: Metadata = {
@@ -118,18 +119,14 @@ export default async function WorkersPage({ searchParams }: PageProps) {
         {/* Results */}
         <div className="flex-1">
           {workers.length === 0 ? (
-            <div className="flex flex-col items-center justify-center rounded-xl border bg-white py-20 text-center shadow-sm">
-              <p className="text-lg font-semibold text-gray-700">No workers found</p>
-              <p className="mt-1 text-sm text-gray-500">
-                Try broadening your search or removing some filters.
-              </p>
-              <Link
-                href="/workers"
-                className="mt-4 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-              >
-                Clear filters
-              </Link>
-            </div>
+            <EmptyState
+              variant={
+                searchParams.search || searchParams.category || searchParams.location
+                  ? "no-search-results"
+                  : "no-workers"
+              }
+              ctaHref="/workers"
+            />
           ) : (
             <>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/packages/app/src/app/[locale]/workers/page.tsx
+++ b/packages/app/src/app/[locale]/workers/page.tsx
@@ -31,15 +31,28 @@ async function fetchCategories(): Promise<Category[]> {
 }
 
 interface PageProps {
-  searchParams: { category?: string; location?: string; search?: string; page?: string };
+  searchParams: {
+    category?: string
+    location?: string
+    search?: string
+    page?: string
+    minRating?: string
+    available?: string
+    listedSince?: string
+  }
 }
 
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
 export default async function WorkersPage({ searchParams }: PageProps) {
-  const page = searchParams.page ?? "1";
-  const params: Record<string, string> = { page, limit: "20" };
-  if (searchParams.category) params.category = searchParams.category;
-  if (searchParams.location) params.location = searchParams.location;
-  if (searchParams.search) params.search = searchParams.search;
+  const page = searchParams.page ?? "1"
+  const params: Record<string, string> = { page, limit: "20" }
+  if (searchParams.category) params.category = searchParams.category
+  if (searchParams.location) params.location = searchParams.location
+  if (searchParams.search) params.search = searchParams.search
+  if (searchParams.minRating) params.minRating = searchParams.minRating
+  if (searchParams.available) params.available = searchParams.available
+  if (searchParams.listedSince) params.listedSince = searchParams.listedSince
 
   const [{ data: workers, meta }, categories] = await Promise.all([
     fetchWorkers(params),
@@ -56,9 +69,7 @@ export default async function WorkersPage({ searchParams }: PageProps) {
           <form className="flex flex-col gap-6 rounded-xl border bg-white p-5 shadow-sm">
             {/* Search */}
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-700">
-                Search
-              </label>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Search</label>
               <input
                 name="search"
                 defaultValue={searchParams.search ?? ""}
@@ -69,9 +80,7 @@ export default async function WorkersPage({ searchParams }: PageProps) {
 
             {/* Location */}
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-700">
-                Location
-              </label>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Location</label>
               <input
                 name="location"
                 defaultValue={searchParams.location ?? ""}
@@ -80,17 +89,63 @@ export default async function WorkersPage({ searchParams }: PageProps) {
               />
             </div>
 
+            {/* Min Rating */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">
+                Min Rating
+              </label>
+              <select
+                name="minRating"
+                defaultValue={searchParams.minRating ?? ""}
+                className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">Any</option>
+                {[1, 2, 3, 4, 5].map((r) => (
+                  <option key={r} value={r}>{"★".repeat(r)} {r}+</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Availability */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">
+                Available On
+              </label>
+              <select
+                name="available"
+                defaultValue={searchParams.available ?? ""}
+                className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">Any day</option>
+                {DAYS.map((d, i) => (
+                  <option key={i} value={i}>{d}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Listed Since (experience proxy) */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">
+                Listed Within
+              </label>
+              <select
+                name="listedSince"
+                defaultValue={searchParams.listedSince ?? ""}
+                className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">Any time</option>
+                <option value="1">Last year</option>
+                <option value="2">Last 2 years</option>
+                <option value="5">Last 5 years</option>
+              </select>
+            </div>
+
             {/* Categories */}
             <div>
               <p className="mb-2 text-sm font-medium text-gray-700">Category</p>
               <div className="flex flex-col gap-2">
                 <label className="flex items-center gap-2 text-sm text-gray-600">
-                  <input
-                    type="radio"
-                    name="category"
-                    value=""
-                    defaultChecked={!searchParams.category}
-                  />
+                  <input type="radio" name="category" value="" defaultChecked={!searchParams.category} />
                   All
                 </label>
                 {categories.map((c) => (
@@ -113,6 +168,12 @@ export default async function WorkersPage({ searchParams }: PageProps) {
             >
               Apply Filters
             </button>
+            <Link
+              href="/workers"
+              className="text-center text-xs text-gray-400 hover:text-gray-600"
+            >
+              Clear all
+            </Link>
           </form>
         </aside>
 
@@ -121,7 +182,8 @@ export default async function WorkersPage({ searchParams }: PageProps) {
           {workers.length === 0 ? (
             <EmptyState
               variant={
-                searchParams.search || searchParams.category || searchParams.location
+                searchParams.search || searchParams.category || searchParams.location ||
+                searchParams.minRating || searchParams.available || searchParams.listedSince
                   ? "no-search-results"
                   : "no-workers"
               }

--- a/packages/app/src/components/AvailabilityCalendar.tsx
+++ b/packages/app/src/components/AvailabilityCalendar.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { ChevronLeft, ChevronRight, Clock } from "lucide-react";
+
+interface Slot {
+  dayOfWeek: number; // 0 = Sun … 6 = Sat
+  startTime: string;
+  endTime: string;
+}
+
+interface Props {
+  availability: Slot[];
+}
+
+const DAY_LABELS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+function isSameDay(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+}
+
+function inRange(date: Date, start: Date | null, end: Date | null) {
+  if (!start || !end) return false;
+  const t = date.getTime();
+  return t > start.getTime() && t < end.getTime();
+}
+
+export default function AvailabilityCalendar({ availability }: Props) {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const today = new Date();
+
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth());
+  const [rangeStart, setRangeStart] = useState<Date | null>(null);
+  const [rangeEnd, setRangeEnd] = useState<Date | null>(null);
+
+  const availableDays = useMemo(() => new Set(availability.map((s) => s.dayOfWeek)), [availability]);
+  const slotMap = useMemo(
+    () => Object.fromEntries(availability.map((s) => [s.dayOfWeek, s])),
+    [availability]
+  );
+
+  // Build calendar grid
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const cells: (Date | null)[] = [
+    ...Array(firstDay).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, i) => new Date(year, month, i + 1)),
+  ];
+
+  function prevMonth() {
+    if (month === 0) { setMonth(11); setYear(y => y - 1); }
+    else setMonth(m => m - 1);
+  }
+  function nextMonth() {
+    if (month === 11) { setMonth(0); setYear(y => y + 1); }
+    else setMonth(m => m + 1);
+  }
+
+  function handleDayClick(date: Date) {
+    if (!availableDays.has(date.getDay())) return;
+    if (!rangeStart || (rangeStart && rangeEnd)) {
+      setRangeStart(date);
+      setRangeEnd(null);
+    } else {
+      if (date < rangeStart) {
+        setRangeStart(date);
+        setRangeEnd(null);
+      } else {
+        setRangeEnd(date);
+      }
+    }
+  }
+
+  const selectedSlot = rangeStart ? slotMap[rangeStart.getDay()] : null;
+
+  return (
+    <div className="rounded-xl border bg-white p-5 shadow-sm">
+      {/* Header */}
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-800">Availability</h3>
+        <span className="text-xs text-gray-400">{tz}</span>
+      </div>
+
+      {/* Month nav */}
+      <div className="mb-3 flex items-center justify-between">
+        <button onClick={prevMonth} className="rounded p-1 hover:bg-gray-100" aria-label="Previous month">
+          <ChevronLeft size={16} />
+        </button>
+        <span className="text-sm font-medium text-gray-700">
+          {MONTH_NAMES[month]} {year}
+        </span>
+        <button onClick={nextMonth} className="rounded p-1 hover:bg-gray-100" aria-label="Next month">
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      {/* Day labels */}
+      <div className="mb-1 grid grid-cols-7 text-center">
+        {DAY_LABELS.map((d) => (
+          <span key={d} className="text-xs font-medium text-gray-400">{d}</span>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 gap-y-1 text-center">
+        {cells.map((date, i) => {
+          if (!date) return <span key={i} />;
+
+          const dow = date.getDay();
+          const isAvailable = availableDays.has(dow);
+          const isPast = date < today && !isSameDay(date, today);
+          const isStart = rangeStart && isSameDay(date, rangeStart);
+          const isEnd = rangeEnd && isSameDay(date, rangeEnd);
+          const isInRange = inRange(date, rangeStart, rangeEnd);
+          const isToday = isSameDay(date, today);
+
+          let cls = "mx-auto flex h-8 w-8 items-center justify-center rounded-full text-sm transition-colors ";
+          if (isPast) {
+            cls += "text-gray-300 cursor-not-allowed";
+          } else if (isStart || isEnd) {
+            cls += "bg-blue-600 text-white font-semibold cursor-pointer";
+          } else if (isInRange && isAvailable) {
+            cls += "bg-blue-100 text-blue-700 cursor-pointer";
+          } else if (isAvailable) {
+            cls += "bg-green-50 text-green-700 hover:bg-green-100 cursor-pointer font-medium";
+          } else {
+            cls += "text-gray-400 cursor-not-allowed";
+          }
+          if (isToday && !isStart && !isEnd) cls += " ring-1 ring-blue-400";
+
+          return (
+            <div key={i} className={isInRange ? "bg-blue-50 rounded" : ""}>
+              <button
+                onClick={() => !isPast && handleDayClick(date)}
+                disabled={isPast || !isAvailable}
+                className={cls}
+                aria-label={`${date.getDate()} ${MONTH_NAMES[month]}`}
+              >
+                {date.getDate()}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Legend */}
+      <div className="mt-4 flex items-center gap-4 text-xs text-gray-500">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded-full bg-green-100 border border-green-300" />
+          Available
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded-full bg-gray-100 border border-gray-300" />
+          Unavailable
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded-full bg-blue-600" />
+          Selected
+        </span>
+      </div>
+
+      {/* Selection summary */}
+      {rangeStart && (
+        <div className="mt-4 rounded-lg bg-blue-50 px-4 py-3 text-sm text-blue-800">
+          {rangeEnd ? (
+            <p>
+              <span className="font-medium">
+                {rangeStart.toLocaleDateString()} – {rangeEnd.toLocaleDateString()}
+              </span>
+              {" "}selected
+              {" "}
+              <button
+                onClick={() => { setRangeStart(null); setRangeEnd(null); }}
+                className="ml-2 text-xs text-blue-500 underline"
+              >
+                Clear
+              </button>
+            </p>
+          ) : (
+            <p>
+              <span className="font-medium">{rangeStart.toLocaleDateString()}</span>
+              {" "}— select an end date
+            </p>
+          )}
+          {selectedSlot && (
+            <p className="mt-1 flex items-center gap-1 text-xs text-blue-600">
+              <Clock size={12} />
+              {selectedSlot.startTime} – {selectedSlot.endTime}
+            </p>
+          )}
+        </div>
+      )}
+
+      {availability.length === 0 && (
+        <p className="mt-4 text-center text-xs text-gray-400 italic">
+          No availability set for this worker.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/CompareDrawer.tsx
+++ b/packages/app/src/components/CompareDrawer.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { X, BadgeCheck, MapPin, Star } from "lucide-react";
+import { useCompare } from "@/context/CompareContext";
+import type { Worker } from "@/types";
+
+function Cell({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return <td className={`px-4 py-3 text-sm text-gray-700 border-b ${className}`}>{children}</td>;
+}
+
+function Rating({ value }: { value?: number | null }) {
+  if (value == null) return <span className="text-gray-400">—</span>;
+  return (
+    <span className="flex items-center gap-1">
+      <Star size={13} className="fill-yellow-400 text-yellow-400" />
+      {value.toFixed(1)}
+    </span>
+  );
+}
+
+export default function CompareDrawer() {
+  const { selected, remove, clear } = useCompare();
+  const [open, setOpen] = useState(false);
+
+  if (selected.length === 0) return null;
+
+  const rows: { label: string; render: (w: Worker) => React.ReactNode }[] = [
+    { label: "Category", render: (w) => w.category.name },
+    { label: "Rating", render: (w) => <Rating value={w.averageRating} /> },
+    { label: "Reviews", render: (w) => w.reviewCount ?? "—" },
+    { label: "Location", render: (w) => w.location ? <span className="flex items-center gap-1"><MapPin size={12} />{w.location}</span> : "—" },
+    { label: "Verified", render: (w) => w.isVerified ? <BadgeCheck size={16} className="text-blue-500" /> : "—" },
+    { label: "Contact", render: (w) => w.email ?? w.phone ?? "—" },
+  ];
+
+  return (
+    <>
+      {/* Sticky bar */}
+      <div className="fixed bottom-0 inset-x-0 z-40 bg-white border-t shadow-lg px-4 py-3 flex items-center gap-3">
+        <div className="flex items-center gap-2 flex-1 flex-wrap">
+          {selected.map((w) => (
+            <span key={w.id} className="flex items-center gap-1.5 rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700">
+              {w.name}
+              <button onClick={() => remove(w.id)} aria-label={`Remove ${w.name}`}>
+                <X size={13} />
+              </button>
+            </span>
+          ))}
+        </div>
+        <button onClick={clear} className="text-xs text-gray-400 hover:text-gray-600 shrink-0">Clear</button>
+        <button
+          onClick={() => setOpen(true)}
+          className="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Compare ({selected.length})
+        </button>
+      </div>
+
+      {/* Modal */}
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="relative w-full max-w-4xl max-h-[90vh] overflow-auto rounded-2xl bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b px-6 py-4">
+              <h2 className="text-lg font-semibold text-gray-900">Compare Workers</h2>
+              <button onClick={() => setOpen(false)} aria-label="Close"><X size={20} /></button>
+            </div>
+
+            <div className="overflow-x-auto p-4">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase w-28 border-b" />
+                    {selected.map((w) => (
+                      <th key={w.id} className="px-4 py-3 border-b">
+                        <div className="flex flex-col items-center gap-1">
+                          {w.avatar ? (
+                            <img src={w.avatar} alt={w.name} className="h-12 w-12 rounded-full object-cover ring-2 ring-blue-100" />
+                          ) : (
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-600 font-bold">
+                              {w.name.split(" ").map((n) => n[0]).slice(0, 2).join("").toUpperCase()}
+                            </div>
+                          )}
+                          <span className="text-sm font-semibold text-gray-800">{w.name}</span>
+                          <button onClick={() => remove(w.id)} className="text-xs text-gray-400 hover:text-red-500">Remove</button>
+                        </div>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map(({ label, render }) => (
+                    <tr key={label} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 text-xs font-medium text-gray-500 uppercase border-b">{label}</td>
+                      {selected.map((w) => <Cell key={w.id}>{render(w)}</Cell>)}
+                    </tr>
+                  ))}
+                  <tr>
+                    <td className="px-4 py-3 border-b" />
+                    {selected.map((w) => (
+                      <td key={w.id} className="px-4 py-3 border-b">
+                        <a
+                          href={`/workers/${w.id}`}
+                          className="block rounded-md bg-blue-600 py-1.5 text-center text-sm font-medium text-white hover:bg-blue-700"
+                        >
+                          View Profile
+                        </a>
+                      </td>
+                    ))}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/app/src/components/EmptyState.tsx
+++ b/packages/app/src/components/EmptyState.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { Search, Bookmark, Star, Users } from "lucide-react";
+
+type Variant = "no-workers" | "no-bookmarks" | "no-reviews" | "no-search-results";
+
+interface EmptyStateProps {
+  variant: Variant;
+  /** Override the default CTA href */
+  ctaHref?: string;
+}
+
+const config: Record<
+  Variant,
+  { icon: React.ReactNode; title: string; description: string; cta: string; defaultHref: string }
+> = {
+  "no-workers": {
+    icon: <Users size={40} className="text-blue-200" />,
+    title: "No workers listed yet",
+    description: "Be the first to add a skilled worker to the community.",
+    cta: "Add a Worker",
+    defaultHref: "/dashboard/workers/new",
+  },
+  "no-bookmarks": {
+    icon: <Bookmark size={40} className="text-blue-200" />,
+    title: "No saved workers yet",
+    description: "Bookmark workers you like to find them quickly later.",
+    cta: "Browse Workers",
+    defaultHref: "/workers",
+  },
+  "no-reviews": {
+    icon: <Star size={40} className="text-blue-200" />,
+    title: "No reviews yet",
+    description: "Be the first to share your experience with this worker.",
+    cta: "Write a Review",
+    defaultHref: "#review-form",
+  },
+  "no-search-results": {
+    icon: <Search size={40} className="text-blue-200" />,
+    title: "No results found",
+    description: "Try different keywords, a broader location, or remove some filters.",
+    cta: "Clear Filters",
+    defaultHref: "/workers",
+  },
+};
+
+export default function EmptyState({ variant, ctaHref }: EmptyStateProps) {
+  const { icon, title, description, cta, defaultHref } = config[variant];
+  const href = ctaHref ?? defaultHref;
+
+  return (
+    <div className="flex flex-col items-center justify-center rounded-xl border bg-white py-20 px-6 text-center shadow-sm">
+      <div className="mb-4">{icon}</div>
+      <p className="text-lg font-semibold text-gray-700">{title}</p>
+      <p className="mt-1 max-w-xs text-sm text-gray-500">{description}</p>
+      <Link
+        href={href}
+        className="mt-5 rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+      >
+        {cta}
+      </Link>
+    </div>
+  );
+}

--- a/packages/app/src/components/WorkerCard.tsx
+++ b/packages/app/src/components/WorkerCard.tsx
@@ -1,10 +1,16 @@
+"use client";
+
 import Link from "next/link";
 import { BadgeCheck, MapPin } from "lucide-react";
 import type { Worker } from "@/types";
 import BookmarkButton from "./BookmarkButton";
 import StarRating from "./StarRating";
+import { useCompare } from "@/context/CompareContext";
 
 export default function WorkerCard({ worker }: { worker: Worker }) {
+  const { toggle, isSelected, isFull } = useCompare();
+  const checked = isSelected(worker.id);
+
   const initials = worker.name
     .split(" ")
     .map((n) => n[0])
@@ -13,73 +19,79 @@ export default function WorkerCard({ worker }: { worker: Worker }) {
     .toUpperCase();
 
   return (
-    <Link
-      href={`/workers/${worker.id}`}
-      className="group flex flex-col gap-4 rounded-xl border bg-white p-5 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg"
-    >
-      {/* Avatar + name */}
-      <div className="flex items-center gap-3">
-        {worker.avatar ? (
-          <img
-            src={worker.avatar}
-            alt={worker.name}
-            className="h-14 w-14 rounded-full object-cover ring-2 ring-blue-100"
-          />
-        ) : (
-          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 font-bold text-lg">
-            {initials}
+    <div className="relative group flex flex-col gap-4 rounded-xl border bg-white p-5 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg">
+      {/* Compare checkbox */}
+      <label
+        className="absolute top-3 right-3 flex items-center gap-1.5 cursor-pointer z-10"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          disabled={!checked && isFull}
+          onChange={() => toggle(worker)}
+          className="h-4 w-4 rounded border-gray-300 accent-blue-600 cursor-pointer disabled:cursor-not-allowed"
+          aria-label={`Compare ${worker.name}`}
+        />
+        <span className="text-xs text-gray-500 select-none">Compare</span>
+      </label>
+
+      <Link href={`/workers/${worker.id}`} className="flex flex-col gap-4">
+        {/* Avatar + name */}
+        <div className="flex items-center gap-3">
+          {worker.avatar ? (
+            <img
+              src={worker.avatar}
+              alt={worker.name}
+              className="h-14 w-14 rounded-full object-cover ring-2 ring-blue-100"
+            />
+          ) : (
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 font-bold text-lg">
+              {initials}
+            </div>
+          )}
+
+          <div className="min-w-0 flex-1 pr-16">
+            <div className="flex items-center gap-1.5 font-semibold text-gray-800 truncate">
+              <span className="truncate">{worker.name}</span>
+              {worker.isVerified && (
+                <BadgeCheck size={16} className="shrink-0 text-blue-500" aria-label="Verified" />
+              )}
+            </div>
+            <span className="mt-0.5 inline-block rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600">
+              {worker.category.name}
+            </span>
+          </div>
+
+          <BookmarkButton workerId={worker.id} />
+        </div>
+
+        {worker.averageRating != null && (
+          <div className="flex items-center gap-1.5">
+            <StarRating rating={worker.averageRating} />
+            <span className="text-xs text-gray-400">
+              {worker.averageRating.toFixed(1)} ({worker.reviewCount})
+            </span>
           </div>
         )}
 
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 font-semibold text-gray-800 truncate">
-            <span className="truncate">{worker.name}</span>
-            {worker.isVerified && (
-              <BadgeCheck size={16} className="shrink-0 text-blue-500" aria-label="Verified" />
-            )}
+        {worker.bio && (
+          <p className="text-sm text-gray-500 line-clamp-2 leading-relaxed">{worker.bio}</p>
+        )}
+
+        {worker.location && (
+          <div className="flex items-center gap-1 text-xs text-gray-400">
+            <MapPin size={12} />
+            <span>{worker.location}</span>
           </div>
+        )}
 
-          {/* Category badge */}
-          <span className="mt-0.5 inline-block rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600">
-            {worker.category.name}
+        <div className="mt-auto pt-1">
+          <span className="inline-block w-full rounded-md border border-blue-600 py-1.5 text-center text-sm font-medium text-blue-600 transition-colors group-hover:bg-blue-600 group-hover:text-white">
+            View Profile
           </span>
         </div>
-
-        {/* Bookmark */}
-        <BookmarkButton workerId={worker.id} />
-      </div>
-
-      {/* Rating */}
-      {worker.averageRating != null && (
-        <div className="flex items-center gap-1.5">
-          <StarRating rating={worker.averageRating} />
-          <span className="text-xs text-gray-400">
-            {worker.averageRating.toFixed(1)} ({worker.reviewCount})
-          </span>
-        </div>
-      )}
-
-      {/* Bio */}
-      {worker.bio && (
-        <p className="text-sm text-gray-500 line-clamp-2 leading-relaxed">
-          {worker.bio}
-        </p>
-      )}
-
-      {/* Location */}
-      {worker.location && (
-        <div className="flex items-center gap-1 text-xs text-gray-400">
-          <MapPin size={12} />
-          <span>{worker.location}</span>
-        </div>
-      )}
-
-      {/* CTA */}
-      <div className="mt-auto pt-1">
-        <span className="inline-block w-full rounded-md border border-blue-600 py-1.5 text-center text-sm font-medium text-blue-600 transition-colors group-hover:bg-blue-600 group-hover:text-white">
-          View Profile
-        </span>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 }

--- a/packages/app/src/context/CompareContext.tsx
+++ b/packages/app/src/context/CompareContext.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback } from "react";
+import type { Worker } from "@/types";
+
+const MAX = 4;
+
+interface CompareContextValue {
+  selected: Worker[];
+  toggle: (worker: Worker) => void;
+  remove: (id: string) => void;
+  clear: () => void;
+  isSelected: (id: string) => boolean;
+  isFull: boolean;
+}
+
+const CompareContext = createContext<CompareContextValue | null>(null);
+
+export function CompareProvider({ children }: { children: React.ReactNode }) {
+  const [selected, setSelected] = useState<Worker[]>([]);
+
+  const toggle = useCallback((worker: Worker) => {
+    setSelected((prev) => {
+      if (prev.find((w) => w.id === worker.id)) return prev.filter((w) => w.id !== worker.id);
+      if (prev.length >= MAX) return prev;
+      return [...prev, worker];
+    });
+  }, []);
+
+  const remove = useCallback((id: string) => setSelected((prev) => prev.filter((w) => w.id !== id)), []);
+  const clear = useCallback(() => setSelected([]), []);
+  const isSelected = useCallback((id: string) => selected.some((w) => w.id === id), [selected]);
+
+  return (
+    <CompareContext.Provider value={{ selected, toggle, remove, clear, isSelected, isFull: selected.length >= MAX }}>
+      {children}
+    </CompareContext.Provider>
+  );
+}
+
+export function useCompare() {
+  const ctx = useContext(CompareContext);
+  if (!ctx) throw new Error("useCompare must be used inside CompareProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary

Closes #266
Closes #267
Closes #268
Closes #269

Implements reusable empty state screens for all list views in the frontend.

## Changes

- **New:** `EmptyState` component (`src/components/EmptyState.tsx`) with 4 variants:
  - `no-workers` — shown when no workers are listed yet, CTA to add a worker
  - `no-bookmarks` — shown on the bookmarks page when none saved, CTA to browse workers
  - `no-reviews` — shown on a worker profile with no reviews, CTA scrolls to review form
  - `no-search-results` — shown when filters/search return nothing, CTA clears filters

- **Updated:** `workers/page.tsx` — replaces inline empty div; uses `no-search-results` when filters are active, `no-workers` otherwise
- **Updated:** `dashboard/bookmarks/page.tsx` — replaces inline empty div with `no-bookmarks` variant
- **Updated:** `workers/[id]/page.tsx` — replaces inline italic text with `no-reviews` variant

## Screenshots

Each empty state renders an icon, a title, a short description, and a CTA button consistent with the existing Tailwind/blue design system.