### PR TITLE
feat(api): add Redis-backed rate limiting middleware

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,14 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - '6379:6379'
+    volumes:
+      - redis_data:/data
+
   api:
     build:
       context: .
@@ -18,10 +26,13 @@ services:
     restart: unless-stopped
     depends_on:
       - db
+      - redis
     ports:
       - "3000:3000"
     environment:
       DATABASE_URL: postgresql://bluecollar:bluecollar@db:5432/bluecollar
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
       NODE_ENV: production
     env_file:
       - packages/api/.env
@@ -36,3 +47,4 @@ services:
 
 volumes:
   db_data:
+  redis_data:

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -81,3 +81,8 @@ VAPID_PUBLIC_KEY=""
 # VAPID private key for Web Push API — keep this secret!
 # Example: abc...
 VAPID_PRIVATE_KEY=""
+
+# _________Redis private key and other details_________________________
+REDIS_HOST=""
+REDIS_PORT=6379
+REDIS_PASSWORD=""

--- a/packages/api/src/__tests__/rateLimiter.test.ts
+++ b/packages/api/src/__tests__/rateLimiter.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextFunction } from "express";
+process.env.JWT_SECRET = "test-secret";
+const redisMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  incr: vi.fn(),
+  expire: vi.fn(),
+  ttl: vi.fn(),
+}));
+
+vi.mock("../utils/redis.js", () => ({
+  default: redisMock,
+}));
+vi.mock("../utils/config/env.js", () => ({
+  env: { JWT_SECRET: "test-secret" }
+}))
+import { rateLimiter } from "../middleware/rateLimiter.js";
+import jwt from "jsonwebtoken";
+function makeReq(overrides: Record<string, any> = {}): any {
+  return {
+    headers: {},
+    ip: "127.0.0.1",
+    ...overrides,
+  };
+}
+function makeRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.setHeader = vi.fn().mockReturnValue(res);
+  return res;
+}
+function makeNext(): NextFunction {
+  return vi.fn() as unknown as NextFunction;
+}
+function makeAuthHeader(role: string, id = "user-1") {
+  const token = jwt.sign({ id, role }, "test-secret");
+  return { authorization: `Bearer ${token}` };
+}
+function setupRedisDefault() {
+  redisMock.get.mockResolvedValue(null),
+    redisMock.incr.mockResolvedValue(1),
+    redisMock.expire.mockResolvedValue(1),
+    redisMock.ttl.mockResolvedValue(900),
+    redisMock.set.mockResolvedValue("ok")
+}
+describe("admin bypass", () => {
+  beforeEach(() => {
+    vi.clearAllMocks(),
+      setupRedisDefault()
+  });
+  it("calls next() immediately for admin users without touching redis", async () => {
+    const req = makeReq({ headers: makeAuthHeader("admin") });
+    const res = makeRes();
+    const next = makeNext();
+    await rateLimiter(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(redisMock.get).not.toHaveBeenCalled();
+    expect(redisMock.incr).not.toHaveBeenCalled();
+  })
+})
+describe("anonymous rate limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupRedisDefault()
+  })
+  it("calls  next() for anonymous user within the limit", async () => {
+    redisMock.incr.mockResolvedValue(10);
+    const req = makeReq();
+    const res = makeRes()
+    const next = makeNext()
+    await rateLimiter(req, res, next)
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  })
+  it("returns 429 when anonymous user exceeds 30 request", async () => {
+    redisMock.incr.mockResolvedValueOnce(31).mockResolvedValueOnce(1);
+    const req = makeReq();
+    const res = makeRes();
+    const next = makeNext();
+    await rateLimiter(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: "error", message: "Rate limit exceeded." }),)
+    expect(next).not.toHaveBeenCalled()
+  })
+  it("sets X-rateLimit headers on every request", async () => {
+    redisMock.incr.mockResolvedValue(5);
+    const req = makeReq();
+    const res = makeRes();
+    const next = makeNext();
+    await rateLimiter(req, res, next);
+    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Limit", 30)
+    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Remaining", 25)
+    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Reset", expect.any(Number))
+  })
+})
+describe("authenticated-rate-limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupRedisDefault();
+  })
+  it("calls next() for authenticated user within the 100 request limit", async () => {
+    redisMock.incr.mockResolvedValue(50)
+    const req = makeReq({ headers: makeAuthHeader("user") })
+    const res = makeRes()
+    const next = makeNext()
+    await rateLimiter(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  })
+  it("returns 429 when authenticated user exceeds 100 requests", async () => {
+    redisMock.incr.mockResolvedValueOnce(101).mockResolvedValueOnce(1);
+    const req = makeReq({ headers: makeAuthHeader("user") })
+    const res = makeRes();
+    const next = makeNext();
+    await rateLimiter(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(429)
+    expect(next).not.to.toHaveBeenCalledWith();
+  })
+  it("uses auth:<id> as the identifier, not the IP", async () => {
+    redisMock.incr.mockResolvedValue(1);
+    const req = makeReq({ headers: makeAuthHeader("user", "user-29") })
+    const res = makeRes();
+    const next = makeNext()
+    await rateLimiter(req, res, next);
+    expect(redisMock.incr).toHaveBeenCalledWith("ratelimit:auth:user-29");
+  })
+})
+describe("blocked-user", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it("returns 429 with Retry-After header when user is blocked", async () => {
+    const blockedUntil = Date.now() + 60_000;
+    redisMock.get.mockResolvedValue(String(blockedUntil));
+    const req = makeReq()
+    const res = makeRes()
+    const next = makeNext()
+    await rateLimiter(req, res, next)
+    expect(res.status).toHaveBeenCalledWith(429)
+    expect(res.setHeader).toHaveBeenCalledWith("Retry-After", expect.any(Number))
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "error" }),
+    );
+    expect(redisMock.incr).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  })
+  it("calls next() if the block has already expired", async () => {
+    const expiredBlock = Date.now() - 1000
+    redisMock.get.mockResolvedValue(String(expiredBlock))
+    redisMock.incr.mockResolvedValue(1)
+    redisMock.ttl.mockResolvedValue(900)
+    redisMock.expire.mockResolvedValue(1)
+    const req = makeReq();
+    const res = makeRes();
+    const next = makeNext();
+    await rateLimiter(req, res, next)
+    expect(next).toHaveBeenCalledOnce();
+  })
+})
+describe("exponential backoff on violations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupRedisDefault()
+  });
+  it("blocks for 2 minutes on the first violation", async () => {
+    redisMock.incr
+      .mockResolvedValueOnce(31)
+      .mockResolvedValueOnce(1);
+    const req = makeReq();
+    const res = makeRes();
+    const next = makeNext();
+    await rateLimiter(req, res, next);
+    const body = res.json.mock.calls[0][0];
+    expect(body.retryAfter).toBe(Math.pow(2, 1) * 60);
+  })
+  it("blocks for 4 minutes on the second violation", async () => {
+    redisMock.incr
+      .mockResolvedValueOnce(31)
+      .mockResolvedValueOnce(2);
+    const req = makeReq();
+    const res = makeRes();
+    const next = makeNext();
+    await rateLimiter(req, res, next);
+    const body = res.json.mock.calls[0][0];
+    expect(body.retryAfter).toBe(Math.pow(2, 2) * 60);
+  })
+})

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -9,7 +9,7 @@ import categoryRoutes from './routes/categories.js'
 import workerRoutes from './routes/workers.js'
 import adminRoutes from './routes/admin.js'
 import userRoutes from './routes/users.js'
-
+import { rateLimiter } from './middleware/rateLimiter.js'
 const app = express()
 
 app.use(cors())
@@ -18,7 +18,7 @@ app.use(express.urlencoded({ extended: true }))
 app.use(pinoHttp({ logger }))
 app.use(methodOverride('X-HTTP-Method'))
 app.use(passport.initialize())
-
+app.use(rateLimiter)
 app.use('/api/auth', authRoutes)
 app.use('/api/categories', categoryRoutes)
 app.use('/api/workers', workerRoutes)

--- a/packages/api/src/middleware/rateLimiter.ts
+++ b/packages/api/src/middleware/rateLimiter.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from "express";
+import { NextFunction } from "express";
+import redis from "../utils/redis";
+import jwt from 'jsonwebtoken'
+import { logger } from "../config/logger";
+const ANON_LIMIT = 30
+const AUTH_LIMIT = 100;
+const WINDOW_SECONDS = 900
+const getUserFromToken = (req: Request): { id: string; role: string } | null => {
+    try {
+        const token = req.headers.authorization?.split(' ')[1];
+        if (!token) return null;
+        return jwt.verify(token, process.env.JWT_SECRET!) as { id: string; role: string };
+    } catch {
+        logger.info("no token received from getUserFromToken");
+        return null;
+    }
+}
+export const rateLimiter = async (req: Request, res: Response, next: NextFunction) => {
+    const user = getUserFromToken(req);
+    logger.info(user);
+    if (user?.role == "admin") {
+        return next();
+    }
+    const isAuthenticated = !!user;
+    const limit = isAuthenticated ? AUTH_LIMIT : ANON_LIMIT;
+    const identifier = isAuthenticated ? `auth:${user.id}` : `anon:${req.ip}`;
+    const key = `ratelimit:${identifier}`;
+    const violationKey = `violations:${identifier}`;
+    const blockedUntil = await redis.get(`blocked:${identifier}`);
+    if (blockedUntil && Date.now() < parseInt(blockedUntil)) {
+        const retryAfter = Math.ceil((parseInt(blockedUntil) - Date.now()) / 1000);
+        res.setHeader('Retry-After', retryAfter);
+        return res.status(429).json({
+            status: 'error',
+            message: `Too many violations. Try again in ${retryAfter} seconds.`
+        });
+    }
+    const current = await redis.incr(key);
+    if (current === 1) {
+        await redis.expire(key, WINDOW_SECONDS);
+    }
+    const ttl = await redis.ttl(key);
+    const reset = Math.floor(Date.now() / 1000) + ttl;
+    res.setHeader('X-RateLimit-Limit', limit);
+    res.setHeader('X-RateLimit-Remaining', Math.max(0, limit - current));
+    res.setHeader('X-RateLimit-Reset', reset);
+    if (current > limit) {
+        const violations = await redis.incr(violationKey);
+        await redis.expire(violationKey, 60 * 60);
+        const backoffSeconds = Math.pow(2, violations) * 60;
+        const blockedUntilTime = Date.now() + backoffSeconds * 1000;
+        await redis.set(`blocked:${identifier}`, blockedUntilTime, 'EX', backoffSeconds);
+        return res.status(429).json({
+            status: 'error',
+            message: 'Rate limit exceeded.',
+            retryAfter: backoffSeconds
+        });
+    }
+    next();
+}

--- a/packages/api/src/utils/redis.ts
+++ b/packages/api/src/utils/redis.ts
@@ -1,0 +1,6 @@
+import  { Redis } from 'ioredis'
+const redis=new Redis({
+    host:process.env.REDIS_HOST,
+    port:parseInt(process.env.REDIS_PORT || '6379')
+})
+export default redis;


### PR DESCRIPTION
## Description
Implements a Redis-backed rate limiting middleware that applies globally to all API endpoints. Differentiates between anonymous and authenticated users, bypasses limits for admins, and applies exponential backoff for repeat violators.

## Type of Change
- [x] New feature

## Testing Done
- All 11 unit tests pass with mocked Redis (no real Redis connection needed for tests)
- Manually verified with Thunder Client:
  - `x-ratelimit-limit`, `x-ratelimit-remaining`, `x-ratelimit-reset` headers present on every response
  - Anonymous users get blocked with 429 after 30 requests
  - Authenticated users get blocked after 100 requests
  - Admin token bypasses rate limiting entirely
  - `Retry-After` header returned on 429 responses
<img width="1008" height="848" alt="Screenshot 2026-04-24 160304" src="https://github.com/user-attachments/assets/1a82ebde-f303-4be0-a78a-d03aafbf9106" />


## Checklist
- [x] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [x] No unrelated changes included