### PR TITLE
feat: dispute resolution, health check, and on-chain reputation

### DIFF
--- a/packages/api/prisma/migrations/20260425_add_dispute_model/migration.sql
+++ b/packages/api/prisma/migrations/20260425_add_dispute_model/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "DisputeStatus" AS ENUM ('open', 'under_review', 'resolved', 'dismissed');
+
+-- CreateTable
+CREATE TABLE "Dispute" (
+    "id" TEXT NOT NULL,
+    "workerId" TEXT NOT NULL,
+    "filedById" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "evidence" TEXT,
+    "status" "DisputeStatus" NOT NULL DEFAULT 'open',
+    "resolution" TEXT,
+    "resolvedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Dispute_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Dispute" ADD CONSTRAINT "Dispute_workerId_fkey" FOREIGN KEY ("workerId") REFERENCES "Worker"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Dispute" ADD CONSTRAINT "Dispute_filedById_fkey" FOREIGN KEY ("filedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Dispute" ADD CONSTRAINT "Dispute_resolvedById_fkey" FOREIGN KEY ("resolvedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -46,6 +46,8 @@ model User {
   reviews       Review[]
   contactRequests ContactRequest[]
   pushSubscriptions PushSubscription[]
+  disputesFiled   Dispute[] @relation("DisputesFiled")
+  disputesResolved Dispute[] @relation("DisputesResolved")
 }
 
 model Category {
@@ -83,6 +85,7 @@ model Worker {
   reviews             Review[]
   availability        Availability[]
   contactRequests     ContactRequest[]
+  disputes            Dispute[]
 }
 
 model Bookmark {
@@ -146,8 +149,31 @@ model PushSubscription {
   @@unique([userId, endpoint])
 }
 
+model Dispute {
+  id          String        @id @default(cuid())
+  workerId    String
+  filedById   String
+  reason      String
+  evidence    String?       // URL or description of evidence
+  status      DisputeStatus @default(open)
+  resolution  String?
+  resolvedById String?
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  worker      Worker        @relation(fields: [workerId], references: [id], onDelete: Cascade)
+  filedBy     User          @relation("DisputesFiled", fields: [filedById], references: [id], onDelete: Cascade)
+  resolvedBy  User?         @relation("DisputesResolved", fields: [resolvedById], references: [id])
+}
+
 enum Role {
   user
   curator
   admin
+}
+
+enum DisputeStatus {
+  open
+  under_review
+  resolved
+  dismissed
 }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -5,11 +5,13 @@ import methodOverride from 'method-override'
 import passport from './config/passport.js'
 import { logger } from './config/logger.js'
 import { redis, cacheMetrics } from './config/redis.js'
+import { db } from './db.js'
 import authRoutes from './routes/auth.js'
 import categoryRoutes from './routes/categories.js'
 import workerRoutes from './routes/workers.js'
 import adminRoutes from './routes/admin.js'
 import userRoutes from './routes/users.js'
+import disputeRoutes from './routes/disputes.js'
 
 const app = express()
 
@@ -28,9 +30,36 @@ app.use('/api/categories', categoryRoutes)
 app.use('/api/workers', workerRoutes)
 app.use('/api/admin', adminRoutes)
 app.use('/api/users', userRoutes)
+app.use('/api/disputes', disputeRoutes)
 
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok', service: 'bluecollar-api' })
+app.get('/health', async (_req, res) => {
+  const checks: Record<string, { status: 'ok' | 'error'; latencyMs?: number; error?: string }> = {}
+
+  // Database check
+  const dbStart = Date.now()
+  try {
+    await db.$queryRaw`SELECT 1`
+    checks.database = { status: 'ok', latencyMs: Date.now() - dbStart }
+  } catch (err: any) {
+    checks.database = { status: 'error', latencyMs: Date.now() - dbStart, error: err?.message }
+  }
+
+  // Redis check
+  const redisStart = Date.now()
+  try {
+    await redis.ping()
+    checks.redis = { status: 'ok', latencyMs: Date.now() - redisStart }
+  } catch (err: any) {
+    checks.redis = { status: 'error', latencyMs: Date.now() - redisStart, error: err?.message }
+  }
+
+  const allOk = Object.values(checks).every((c) => c.status === 'ok')
+  res.status(allOk ? 200 : 503).json({
+    status: allOk ? 'ok' : 'degraded',
+    service: 'bluecollar-api',
+    checks,
+    timestamp: new Date().toISOString(),
+  })
 })
 
 app.get('/metrics/cache', (_req, res) => {

--- a/packages/api/src/controllers/disputes.ts
+++ b/packages/api/src/controllers/disputes.ts
@@ -1,0 +1,47 @@
+import type { Request, Response } from 'express'
+import * as disputeService from '../services/dispute.service.js'
+import { handleError } from '../utils/handleError.js'
+
+/** POST /api/disputes — file a dispute against a worker */
+export async function createDispute(req: Request, res: Response) {
+  try {
+    const { workerId, reason, evidence } = req.body
+    const dispute = await disputeService.fileDispute(workerId, req.user!.id, reason, evidence)
+    return res.status(201).json({ data: dispute, status: 'success', code: 201 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}
+
+/** GET /api/disputes — list disputes (admin: all; user: own) */
+export async function listDisputes(req: Request, res: Response) {
+  try {
+    const page = Number(req.query.page ?? 1)
+    const limit = Number(req.query.limit ?? 20)
+    const result = await disputeService.listDisputes(req.user!.id, req.user!.role, page, limit)
+    return res.json({ ...result, status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}
+
+/** GET /api/disputes/:id — get a single dispute */
+export async function getDispute(req: Request, res: Response) {
+  try {
+    const dispute = await disputeService.getDispute(req.params.id, req.user!.id, req.user!.role)
+    return res.json({ data: dispute, status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}
+
+/** PATCH /api/disputes/:id/resolve — resolve/dismiss a dispute (admin only) */
+export async function resolveDispute(req: Request, res: Response) {
+  try {
+    const { status, resolution } = req.body
+    const dispute = await disputeService.resolveDispute(req.params.id, req.user!.id, status, resolution)
+    return res.json({ data: dispute, status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}

--- a/packages/api/src/routes/disputes.ts
+++ b/packages/api/src/routes/disputes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express'
+import { createDispute, listDisputes, getDispute, resolveDispute } from '../controllers/disputes.js'
+import { authenticate, authorize } from '../middleware/auth.js'
+
+const router = Router()
+
+router.post('/', authenticate, createDispute)
+router.get('/', authenticate, listDisputes)
+router.get('/:id', authenticate, getDispute)
+router.patch('/:id/resolve', authenticate, authorize('admin'), resolveDispute)
+
+export default router

--- a/packages/api/src/services/dispute.service.ts
+++ b/packages/api/src/services/dispute.service.ts
@@ -1,0 +1,60 @@
+import { db } from '../db.js'
+import { AppError } from './AppError.js'
+
+/**
+ * File a new dispute against a worker.
+ */
+export async function fileDispute(workerId: string, filedById: string, reason: string, evidence?: string) {
+  const worker = await db.worker.findUnique({ where: { id: workerId } })
+  if (!worker) throw new AppError('Worker not found', 404)
+
+  return db.dispute.create({
+    data: { workerId, filedById, reason, evidence },
+    include: { worker: { select: { id: true, name: true } }, filedBy: { select: { id: true, firstName: true, lastName: true } } },
+  })
+}
+
+/**
+ * List disputes. Admins see all; users see only their own.
+ */
+export async function listDisputes(userId: string, role: string, page: number, limit: number) {
+  const where = role === 'admin' ? {} : { filedById: userId }
+  const [data, total] = await Promise.all([
+    db.dispute.findMany({
+      where,
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+      include: { worker: { select: { id: true, name: true } }, filedBy: { select: { id: true, firstName: true, lastName: true } } },
+    }),
+    db.dispute.count({ where }),
+  ])
+  return { data, meta: { total, page, limit, pages: Math.ceil(total / limit) } }
+}
+
+/**
+ * Get a single dispute by id.
+ */
+export async function getDispute(id: string, userId: string, role: string) {
+  const dispute = await db.dispute.findUnique({
+    where: { id },
+    include: { worker: { select: { id: true, name: true } }, filedBy: { select: { id: true, firstName: true, lastName: true } } },
+  })
+  if (!dispute) throw new AppError('Dispute not found', 404)
+  if (role !== 'admin' && dispute.filedById !== userId) throw new AppError('Forbidden', 403)
+  return dispute
+}
+
+/**
+ * Resolve or dismiss a dispute (admin only).
+ */
+export async function resolveDispute(id: string, adminId: string, status: 'resolved' | 'dismissed' | 'under_review', resolution?: string) {
+  const dispute = await db.dispute.findUnique({ where: { id } })
+  if (!dispute) throw new AppError('Dispute not found', 404)
+
+  return db.dispute.update({
+    where: { id },
+    data: { status, resolution, resolvedById: adminId },
+    include: { worker: { select: { id: true, name: true } } },
+  })
+}

--- a/packages/contracts/contracts/registry/src/lib.rs
+++ b/packages/contracts/contracts/registry/src/lib.rs
@@ -22,7 +22,6 @@
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String, Symbol, Vec,
 };
-use bluecollar_types::Worker;
 
 /// Approximate TTL extension target (~1 year at 5 s/ledger).
 const TTL_EXTEND_TO: u32 = 535_000;
@@ -56,6 +55,9 @@ pub struct Worker {
     pub location_hash: BytesN<32>,
     /// SHA-256( lowercase(email_or_e164_phone) )
     pub contact_hash: BytesN<32>,
+    /// Reputation score in basis points (0–10000, where 10000 = 100.00%).
+    /// Updated by the admin via [`RegistryContract::update_reputation`].
+    pub reputation: u32,
 }
 
 /// Storage keys used throughout the contract.
@@ -229,6 +231,7 @@ impl RegistryContract {
             wallet: owner.clone(),
             location_hash,
             contact_hash,
+            reputation: 0,
         };
 
         let key = DataKey::Worker(id.clone());
@@ -496,6 +499,40 @@ impl RegistryContract {
     }
 
     // -------------------------------------------------------------------------
+    // Reputation
+    // -------------------------------------------------------------------------
+
+    /// Update a worker's on-chain reputation score (admin only).
+    ///
+    /// # Parameters
+    /// - `admin`: Must be the contract admin; `require_auth()` is enforced.
+    /// - `id`: The worker's unique identifier.
+    /// - `score`: New reputation score in basis points (0–10000).
+    ///
+    /// # Panics
+    /// - `"Admin only"` if `admin` is not the stored admin.
+    /// - `"Worker not found"` if no worker exists with the given `id`.
+    /// - `"Score out of range"` if `score > 10000`.
+    ///
+    /// # Events
+    /// Emits `("RepUpd", id)` with data `score`.
+    pub fn update_reputation(env: Env, admin: Address, id: Symbol, score: u32) {
+        Self::require_admin(&env, &admin);
+        assert!(score <= 10_000, "Score out of range");
+
+        let mut worker: Worker = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Worker(id.clone()))
+            .expect("Worker not found");
+
+        worker.reputation = score;
+        env.storage().persistent().set(&DataKey::Worker(id.clone()), &worker);
+
+        env.events().publish((symbol_short!("RepUpd"), id), score);
+    }
+
+    // -------------------------------------------------------------------------
     // Upgrade
     // -------------------------------------------------------------------------
 
@@ -715,6 +752,42 @@ mod tests {
     }
 
     #[test]
+    fn test_reputation_defaults_to_zero() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+        t.register_worker(&t.curator);
+        let worker = t.client().get_worker(&t.worker_id()).unwrap();
+        assert_eq!(worker.reputation, 0);
+    }
+
+    #[test]
+    fn test_update_reputation() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+        t.register_worker(&t.curator);
+        t.client().update_reputation(&t.admin, &t.worker_id(), &8500);
+        let worker = t.client().get_worker(&t.worker_id()).unwrap();
+        assert_eq!(worker.reputation, 8500);
+    }
+
+    #[test]
+    #[should_panic(expected = "Score out of range")]
+    fn test_update_reputation_out_of_range() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+        t.register_worker(&t.curator);
+        t.client().update_reputation(&t.admin, &t.worker_id(), &10_001);
+    }
+
+    #[test]
+    #[should_panic(expected = "Admin only")]
+    fn test_update_reputation_non_admin_panics() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+        t.register_worker(&t.curator);
+        let stranger = Address::generate(&t.env);
+        t.client().update_reputation(&stranger, &t.worker_id(), &5000);
+    }    #[test]
     fn test_list_workers_paginated() {
         let t = TestEnv::new();
         t.client().add_curator(&t.admin, &t.curator);


### PR DESCRIPTION
## Summary

## Changes

### #334 — Health check endpoint
- Enhanced `GET /health` to probe PostgreSQL and Redis connectivity
- Returns `200 ok` when all services are healthy, `503 degraded` otherwise
- Response includes per-service `status` and `latencyMs`

closes #334 

### #333 — Worker dispute resolution
- Added `Dispute` model and `DisputeStatus` enum (`open`, `under_review`, `resolved`, `dismissed`) to Prisma schema
- Migration: `prisma/migrations/20260425_add_dispute_model/migration.sql`
- New endpoints under `/api/disputes`:
  - `POST /api/disputes` — file a dispute (authenticated)
  - `GET /api/disputes` — list disputes (admin sees all; users see their own)
  - `GET /api/disputes/:id` — get a single dispute
  - `PATCH /api/disputes/:id/resolve` — resolve or dismiss (admin only)

closes #333 

### #335 — Smart contracts housekeeping
- Removed stale `use bluecollar_types::Worker` import from the registry contract (crate was never in `Cargo.toml`)

closes #335 

### #336 — On-chain reputation score
- Added `reputation: u32` field (basis points, 0–10000) to the `Worker` struct in the registry contract
- `register` initialises `reputation` to `0`
- New `update_reputation(admin, id, score)` function — admin-only, emits `RepUpd` event
- 4 new contract tests: default value, update, out-of-range panic, non-admin panic

closes #336 

## Testing
- TypeScript: `pnpm test` (no new type errors introduced)
- Contract: `cargo test -p bluecollar-registry` (4 new tests added)