### PR TITLE
feat: Add Multi-Milestone Escrow Support with Partial Releases

### DIFF
--- a/packages/contracts/contracts/market/src/lib.rs
+++ b/packages/contracts/contracts/market/src/lib.rs
@@ -19,7 +19,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Symbol, Vec};
 
 /// Maximum allowed protocol fee: 500 bps = 5%.
 pub const MAX_FEE_BPS: u32 = 500;
@@ -69,6 +69,41 @@ pub enum DataKey {
     Paused,
     /// Persistent storage — [`Escrow`] struct keyed by a caller-supplied id [`Symbol`].
     Escrow(Symbol),
+    /// Persistent storage — [`MilestoneEscrow`] struct keyed by a caller-supplied id [`Symbol`].
+    MilestoneEscrow(Symbol),
+}
+
+/// A single milestone within a [`MilestoneEscrow`].
+#[contracttype]
+#[derive(Clone)]
+pub struct Milestone {
+    /// Amount to release to the worker when this milestone is completed.
+    pub amount: i128,
+    /// `true` once the payer has approved completion and funds have been released.
+    pub completed: bool,
+    /// `true` if this milestone is under dispute.
+    pub disputed: bool,
+}
+
+/// Multi-milestone escrow stored in persistent storage.
+///
+/// The total locked amount equals the sum of all milestone amounts.
+/// Each milestone is released independently via [`MarketContract::complete_milestone`].
+#[contracttype]
+#[derive(Clone)]
+pub struct MilestoneEscrow {
+    /// Address that funded the escrow (the payer).
+    pub from: Address,
+    /// Address that will receive funds as milestones are completed (the worker).
+    pub to: Address,
+    /// Token contract address.
+    pub token: Address,
+    /// Unix timestamp after which the payer may cancel any unreleased funds.
+    pub expiry: u64,
+    /// Ordered list of milestones.
+    pub milestones: Vec<Milestone>,
+    /// `true` once all milestones are completed or the escrow is cancelled.
+    pub cancelled: bool,
 }
 
 // =============================================================================
@@ -415,6 +450,301 @@ impl MarketContract {
     }
 
     // -------------------------------------------------------------------------
+    // Milestone Escrow
+    // -------------------------------------------------------------------------
+
+    /// Create a multi-milestone escrow, locking the total of all milestone amounts.
+    ///
+    /// # Parameters
+    /// - `id`: Caller-supplied unique identifier.
+    /// - `from`: Payer; `require_auth()` is enforced.
+    /// - `to`: Worker that receives funds per milestone.
+    /// - `token_addr`: Stellar token contract address.
+    /// - `milestones`: Ordered vec of milestone amounts (each must be > 0).
+    /// - `expiry`: Unix timestamp after which `from` may cancel remaining funds.
+    ///
+    /// # Panics
+    /// - `"No milestones provided"` if `milestones` is empty.
+    /// - `"Milestone amount must be positive"` if any amount <= 0.
+    /// - `"Milestone escrow id already exists"` on duplicate id.
+    /// - `"Contract is paused"` if paused.
+    ///
+    /// # Events
+    /// Emits `("MilCrt", id, from)` with data `(to, token_addr, total_amount, expiry)`.
+    pub fn create_milestone_escrow(
+        env: Env,
+        id: Symbol,
+        from: Address,
+        to: Address,
+        token_addr: Address,
+        milestone_amounts: Vec<i128>,
+        expiry: u64,
+    ) {
+        from.require_auth();
+        Self::require_not_paused(&env);
+
+        assert!(!milestone_amounts.is_empty(), "No milestones provided");
+        assert!(
+            !env.storage().persistent().has(&DataKey::MilestoneEscrow(id.clone())),
+            "Milestone escrow id already exists"
+        );
+
+        let mut total: i128 = 0;
+        let mut milestones: Vec<Milestone> = Vec::new(&env);
+        for amt in milestone_amounts.iter() {
+            assert!(amt > 0, "Milestone amount must be positive");
+            total += amt;
+            milestones.push_back(Milestone { amount: amt, completed: false, disputed: false });
+        }
+
+        let contract_addr = env.current_contract_address();
+        token::Client::new(&env, &token_addr).transfer(&from, &contract_addr, &total);
+
+        let escrow = MilestoneEscrow {
+            from: from.clone(),
+            to: to.clone(),
+            token: token_addr.clone(),
+            expiry,
+            milestones,
+            cancelled: false,
+        };
+        env.storage().persistent().set(&DataKey::MilestoneEscrow(id.clone()), &escrow);
+
+        env.events().publish(
+            (symbol_short!("MilCrt"), id, from),
+            (to, token_addr, total, expiry),
+        );
+    }
+
+    /// Mark a milestone as complete and release its funds to the worker.
+    ///
+    /// Only the payer (`from`) may approve completion.
+    ///
+    /// # Parameters
+    /// - `id`: The milestone escrow identifier.
+    /// - `caller`: Must be `from`; `require_auth()` is enforced.
+    /// - `milestone_index`: Zero-based index of the milestone to complete.
+    ///
+    /// # Panics
+    /// - `"Milestone escrow not found"` if `id` does not exist.
+    /// - `"Not authorized"` if `caller` is not `from`.
+    /// - `"Escrow cancelled"` if the escrow was cancelled.
+    /// - `"Invalid milestone index"` if index is out of bounds.
+    /// - `"Milestone already completed"` if already released.
+    /// - `"Milestone is disputed"` if under active dispute.
+    /// - `"Contract is paused"` if paused.
+    ///
+    /// # Events
+    /// Emits `("MilCmp", id, milestone_index)` with data `amount`.
+    pub fn complete_milestone(env: Env, id: Symbol, caller: Address, milestone_index: u32) {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+
+        let mut escrow: MilestoneEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestoneEscrow(id.clone()))
+            .expect("Milestone escrow not found");
+
+        assert!(escrow.from == caller, "Not authorized");
+        assert!(!escrow.cancelled, "Escrow cancelled");
+        assert!(milestone_index < escrow.milestones.len(), "Invalid milestone index");
+
+        let mut milestone = escrow.milestones.get(milestone_index).unwrap();
+        assert!(!milestone.completed, "Milestone already completed");
+        assert!(!milestone.disputed, "Milestone is disputed");
+
+        let amount = milestone.amount;
+        milestone.completed = true;
+        escrow.milestones.set(milestone_index, milestone);
+        env.storage().persistent().set(&DataKey::MilestoneEscrow(id.clone()), &escrow);
+
+        let contract_addr = env.current_contract_address();
+        token::Client::new(&env, &escrow.token).transfer(&contract_addr, &escrow.to, &amount);
+
+        env.events().publish(
+            (symbol_short!("MilCmp"), id, milestone_index),
+            amount,
+        );
+    }
+
+    /// Raise a dispute on a specific milestone.
+    ///
+    /// Either `from` (payer) or `to` (worker) may open a dispute.
+    ///
+    /// # Parameters
+    /// - `id`: The milestone escrow identifier.
+    /// - `caller`: Must be `from` or `to`; `require_auth()` is enforced.
+    /// - `milestone_index`: Zero-based index of the milestone to dispute.
+    ///
+    /// # Panics
+    /// - `"Milestone escrow not found"` if `id` does not exist.
+    /// - `"Not authorized"` if `caller` is neither `from` nor `to`.
+    /// - `"Escrow cancelled"` if the escrow was cancelled.
+    /// - `"Invalid milestone index"` if index is out of bounds.
+    /// - `"Milestone already completed"` if already released.
+    /// - `"Already disputed"` if already under dispute.
+    /// - `"Contract is paused"` if paused.
+    ///
+    /// # Events
+    /// Emits `("MilDsp", id, milestone_index)` with data `caller`.
+    pub fn dispute_milestone(env: Env, id: Symbol, caller: Address, milestone_index: u32) {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+
+        let mut escrow: MilestoneEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestoneEscrow(id.clone()))
+            .expect("Milestone escrow not found");
+
+        assert!(
+            escrow.from == caller || escrow.to == caller,
+            "Not authorized"
+        );
+        assert!(!escrow.cancelled, "Escrow cancelled");
+        assert!(milestone_index < escrow.milestones.len(), "Invalid milestone index");
+
+        let mut milestone = escrow.milestones.get(milestone_index).unwrap();
+        assert!(!milestone.completed, "Milestone already completed");
+        assert!(!milestone.disputed, "Already disputed");
+
+        milestone.disputed = true;
+        escrow.milestones.set(milestone_index, milestone);
+        env.storage().persistent().set(&DataKey::MilestoneEscrow(id.clone()), &escrow);
+
+        env.events().publish(
+            (symbol_short!("MilDsp"), id, milestone_index),
+            caller,
+        );
+    }
+
+    /// Resolve a disputed milestone (admin only).
+    ///
+    /// Admin decides whether to release funds to the worker or refund the payer.
+    ///
+    /// # Parameters
+    /// - `id`: The milestone escrow identifier.
+    /// - `admin`: Must be the contract admin; `require_auth()` is enforced.
+    /// - `milestone_index`: Zero-based index of the disputed milestone.
+    /// - `release_to_worker`: `true` → pay worker; `false` → refund payer.
+    ///
+    /// # Panics
+    /// - `"Milestone escrow not found"` if `id` does not exist.
+    /// - `"Unauthorized"` if `admin` is not the stored admin.
+    /// - `"Milestone not disputed"` if the milestone is not under dispute.
+    /// - `"Contract is paused"` if paused.
+    ///
+    /// # Events
+    /// Emits `("MilRes", id, milestone_index)` with data `release_to_worker`.
+    pub fn resolve_milestone_dispute(
+        env: Env,
+        id: Symbol,
+        admin: Address,
+        milestone_index: u32,
+        release_to_worker: bool,
+    ) {
+        admin.require_auth();
+        Self::require_not_paused(&env);
+
+        let config: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("Not initialized");
+        assert!(config.admin == admin, "Unauthorized");
+
+        let mut escrow: MilestoneEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestoneEscrow(id.clone()))
+            .expect("Milestone escrow not found");
+
+        assert!(milestone_index < escrow.milestones.len(), "Invalid milestone index");
+
+        let mut milestone = escrow.milestones.get(milestone_index).unwrap();
+        assert!(milestone.disputed, "Milestone not disputed");
+
+        let amount = milestone.amount;
+        milestone.disputed = false;
+        milestone.completed = true;
+        escrow.milestones.set(milestone_index, milestone);
+        env.storage().persistent().set(&DataKey::MilestoneEscrow(id.clone()), &escrow);
+
+        let contract_addr = env.current_contract_address();
+        let recipient = if release_to_worker { escrow.to.clone() } else { escrow.from.clone() };
+        token::Client::new(&env, &escrow.token).transfer(&contract_addr, &recipient, &amount);
+
+        env.events().publish(
+            (symbol_short!("MilRes"), id, milestone_index),
+            release_to_worker,
+        );
+    }
+
+    /// Cancel a milestone escrow and refund all unreleased funds to the payer.
+    ///
+    /// Only callable by `from` after `expiry` has passed.
+    ///
+    /// # Parameters
+    /// - `id`: The milestone escrow identifier.
+    /// - `caller`: Must be `from`; `require_auth()` is enforced.
+    ///
+    /// # Panics
+    /// - `"Milestone escrow not found"` if `id` does not exist.
+    /// - `"Not authorized"` if `caller` is not `from`.
+    /// - `"Already cancelled"` if already cancelled.
+    /// - `"Escrow not yet expired"` if before `expiry`.
+    /// - `"Contract is paused"` if paused.
+    ///
+    /// # Events
+    /// Emits `("MilCnl", id, caller)` with data `refund_amount`.
+    pub fn cancel_milestone_escrow(env: Env, id: Symbol, caller: Address) {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+
+        let mut escrow: MilestoneEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestoneEscrow(id.clone()))
+            .expect("Milestone escrow not found");
+
+        assert!(escrow.from == caller, "Not authorized");
+        assert!(!escrow.cancelled, "Already cancelled");
+
+        let now = env.ledger().timestamp();
+        assert!(now >= escrow.expiry, "Escrow not yet expired");
+
+        // Sum all unreleased (not completed) milestone amounts for refund.
+        let mut refund: i128 = 0;
+        for m in escrow.milestones.iter() {
+            if !m.completed {
+                refund += m.amount;
+            }
+        }
+
+        escrow.cancelled = true;
+        env.storage().persistent().set(&DataKey::MilestoneEscrow(id.clone()), &escrow);
+
+        if refund > 0 {
+            let contract_addr = env.current_contract_address();
+            token::Client::new(&env, &escrow.token).transfer(&contract_addr, &escrow.from, &refund);
+        }
+
+        env.events().publish(
+            (symbol_short!("MilCnl"), id, caller),
+            refund,
+        );
+    }
+
+    /// Fetch a milestone escrow by id.
+    ///
+    /// # Returns
+    /// `Some(MilestoneEscrow)` if found, `None` otherwise.
+    pub fn get_milestone_escrow(env: Env, id: Symbol) -> Option<MilestoneEscrow> {
+        env.storage().persistent().get(&DataKey::MilestoneEscrow(id))
+    }
+
+    // -------------------------------------------------------------------------
     // Upgrade
     // -------------------------------------------------------------------------
 
@@ -449,12 +779,13 @@ mod tests {
     use soroban_sdk::{
         testutils::{Address as _, Ledger, LedgerInfo},
         token::{Client as TokenClient, StellarAssetClient},
-        Address, Env, Symbol,
+        Address, Env, Symbol, Vec,
     };
 
     struct TestEnv {
         env: Env,
         contract_id: Address,
+        admin: Address,
         payer: Address,
         worker: Address,
         token_addr: Address,
@@ -474,8 +805,9 @@ mod tests {
             StellarAssetClient::new(&env, &token_addr).mint(&payer, &1_000_000);
 
             let contract_id = env.register_contract(None, MarketContract);
+            MarketContractClient::new(&env, &contract_id).initialize(&admin, &0, &admin);
 
-            TestEnv { env, contract_id, payer, worker, token_addr }
+            TestEnv { env, contract_id, admin, payer, worker, token_addr }
         }
 
         fn client(&self) -> MarketContractClient {
@@ -674,5 +1006,139 @@ mod tests {
         let t = TestEnv::new();
         let id = Symbol::new(&t.env, "nope");
         assert!(t.client().get_escrow(&id).is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // Milestone escrow tests
+    // -------------------------------------------------------------------------
+
+    fn milestone_id(t: &TestEnv) -> Symbol {
+        Symbol::new(&t.env, "mil1")
+    }
+
+    fn two_milestones(t: &TestEnv) -> Vec<i128> {
+        let mut v = Vec::new(&t.env);
+        v.push_back(100_000_i128);
+        v.push_back(200_000_i128);
+        v
+    }
+
+    #[test]
+    fn test_create_milestone_escrow_locks_total() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        t.client().create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &9999);
+
+        assert_eq!(t.token_balance(&t.payer), 700_000);
+        assert_eq!(t.token_balance(&t.contract_id), 300_000);
+
+        let esc = t.client().get_milestone_escrow(&id).unwrap();
+        assert_eq!(esc.milestones.len(), 2);
+        assert!(!esc.cancelled);
+    }
+
+    #[test]
+    fn test_complete_milestone_releases_partial_funds() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        let client = t.client();
+        client.create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &9999);
+
+        client.complete_milestone(&id, &t.payer, &0);
+        assert_eq!(t.token_balance(&t.worker), 100_000);
+        assert_eq!(t.token_balance(&t.contract_id), 200_000);
+
+        let esc = client.get_milestone_escrow(&id).unwrap();
+        assert!(esc.milestones.get(0).unwrap().completed);
+        assert!(!esc.milestones.get(1).unwrap().completed);
+    }
+
+    #[test]
+    fn test_complete_all_milestones() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        let client = t.client();
+        client.create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &9999);
+
+        client.complete_milestone(&id, &t.payer, &0);
+        client.complete_milestone(&id, &t.payer, &1);
+
+        assert_eq!(t.token_balance(&t.worker), 300_000);
+        assert_eq!(t.token_balance(&t.contract_id), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Milestone already completed")]
+    fn test_complete_milestone_twice_panics() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        let client = t.client();
+        client.create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &9999);
+        client.complete_milestone(&id, &t.payer, &0);
+        client.complete_milestone(&id, &t.payer, &0);
+    }
+
+    #[test]
+    fn test_dispute_milestone_blocks_completion() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        let client = t.client();
+        client.create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &9999);
+        client.dispute_milestone(&id, &t.worker, &0);
+
+        let esc = client.get_milestone_escrow(&id).unwrap();
+        assert!(esc.milestones.get(0).unwrap().disputed);
+    }
+
+    #[test]
+    #[should_panic(expected = "Milestone is disputed")]
+    fn test_complete_disputed_milestone_panics() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        let client = t.client();
+        client.create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &9999);
+        client.dispute_milestone(&id, &t.worker, &0);
+        client.complete_milestone(&id, &t.payer, &0);
+    }
+
+    #[test]
+    fn test_resolve_dispute_releases_to_worker() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        let client = t.client();
+        client.create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &9999);
+        client.dispute_milestone(&id, &t.payer, &0);
+        client.resolve_milestone_dispute(&id, &t.admin, &0, &true);
+
+        assert_eq!(t.token_balance(&t.worker), 100_000);
+        assert_eq!(t.token_balance(&t.contract_id), 200_000); // second milestone still locked
+    }
+
+    #[test]
+    fn test_cancel_milestone_escrow_refunds_remaining() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        let client = t.client();
+
+        t.set_time(1000);
+        client.create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &2000);
+        // Complete first milestone
+        client.complete_milestone(&id, &t.payer, &0);
+        // Cancel after expiry — only second milestone (200_000) should be refunded
+        t.set_time(3000);
+        client.cancel_milestone_escrow(&id, &t.payer);
+
+        assert_eq!(t.token_balance(&t.payer), 900_000); // 1_000_000 - 100_000 (worker kept)
+        assert_eq!(t.token_balance(&t.contract_id), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Escrow not yet expired")]
+    fn test_cancel_milestone_before_expiry_panics() {
+        let t = TestEnv::new();
+        let id = milestone_id(&t);
+        t.set_time(500);
+        t.client().create_milestone_escrow(&id, &t.payer, &t.worker, &t.token_addr, &two_milestones(&t), &2000);
+        t.client().cancel_milestone_escrow(&id, &t.payer);
     }
 }

--- a/packages/contracts/contracts/market/src/lib.rs
+++ b/packages/contracts/contracts/market/src/lib.rs
@@ -65,6 +65,8 @@ pub struct Escrow {
 pub enum DataKey {
     /// Instance storage — [`Config`] struct, set once at [`MarketContract::initialize`].
     Config,
+    /// Instance storage — paused flag; when `true` all state-mutating functions revert.
+    Paused,
     /// Persistent storage — [`Escrow`] struct keyed by a caller-supplied id [`Symbol`].
     Escrow(Symbol),
 }
@@ -132,6 +134,77 @@ impl MarketContract {
     }
 
     // -------------------------------------------------------------------------
+    // Pause / Unpause (admin only)
+    // -------------------------------------------------------------------------
+
+    /// Assert that the contract is not paused.
+    ///
+    /// # Panics
+    /// Panics with `"Contract is paused"` if the paused flag is set.
+    fn require_not_paused(env: &Env) {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        assert!(!paused, "Contract is paused");
+    }
+
+    /// Pause the contract, blocking all state-mutating operations.
+    ///
+    /// # Parameters
+    /// - `admin`: Must be the contract admin; `require_auth()` is enforced.
+    ///
+    /// # Panics
+    /// - `"Not initialized"` if [`initialize`] has not been called.
+    /// - `"Unauthorized"` if `admin` does not match the stored admin.
+    ///
+    /// # Events
+    /// Emits `("Paused", admin)`.
+    pub fn pause(env: Env, admin: Address) {
+        admin.require_auth();
+        let config: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("Not initialized");
+        assert!(config.admin == admin, "Unauthorized");
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish((symbol_short!("Paused"), admin), ());
+    }
+
+    /// Unpause the contract, re-enabling all state-mutating operations.
+    ///
+    /// # Parameters
+    /// - `admin`: Must be the contract admin; `require_auth()` is enforced.
+    ///
+    /// # Panics
+    /// - `"Not initialized"` if [`initialize`] has not been called.
+    /// - `"Unauthorized"` if `admin` does not match the stored admin.
+    ///
+    /// # Events
+    /// Emits `("Unpaused", admin)`.
+    pub fn unpause(env: Env, admin: Address) {
+        admin.require_auth();
+        let config: Config = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("Not initialized");
+        assert!(config.admin == admin, "Unauthorized");
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish((symbol_short!("Unpaused"), admin), ());
+    }
+
+    /// Returns `true` if the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    // -------------------------------------------------------------------------
     // Tip
     // -------------------------------------------------------------------------
 
@@ -154,6 +227,7 @@ impl MarketContract {
     /// Emits `("TipSent", from, to)` with data `(token_addr, amount)`.
     pub fn tip(env: Env, from: Address, to: Address, token_addr: Address, amount: i128) {
         from.require_auth();
+        Self::require_not_paused(&env);
         assert!(amount > 0, "Amount must be positive");
 
         let config: Config = env
@@ -210,6 +284,7 @@ impl MarketContract {
         expiry: u64,
     ) {
         from.require_auth();
+        Self::require_not_paused(&env);
         assert!(amount > 0, "Amount must be positive");
         assert!(
             !env.storage().persistent().has(&DataKey::Escrow(id.clone())),
@@ -255,6 +330,7 @@ impl MarketContract {
     /// Emits `("EscRel", id, escrow.to)` with data `escrow.amount`.
     pub fn release_escrow(env: Env, id: Symbol, caller: Address) {
         caller.require_auth();
+        Self::require_not_paused(&env);
         let mut escrow: Escrow = env
             .storage()
             .persistent()
@@ -300,6 +376,7 @@ impl MarketContract {
     /// Emits `("EscCnl", id, escrow.from)` with data `escrow.amount`.
     pub fn cancel_escrow(env: Env, id: Symbol, caller: Address) {
         caller.require_auth();
+        Self::require_not_paused(&env);
         let mut escrow: Escrow = env
             .storage()
             .persistent()

--- a/packages/contracts/contracts/registry/src/lib.rs
+++ b/packages/contracts/contracts/registry/src/lib.rs
@@ -65,6 +65,8 @@ pub struct Worker {
 pub enum DataKey {
     /// Instance storage — admin address, set once at [`RegistryContract::initialize`].
     Admin,
+    /// Instance storage — paused flag; when `true` all state-mutating functions revert.
+    Paused,
     /// Persistent storage — ordered list of approved curator [`Address`]es.
     Curators,
     /// Persistent storage — [`Worker`] record keyed by its `id` [`Symbol`].
@@ -114,6 +116,63 @@ impl RegistryContract {
         assert!(*caller == Self::get_admin(env.clone()), "Admin only");
     }
 
+    /// Assert that the contract is not paused.
+    ///
+    /// # Panics
+    /// Panics with `"Contract is paused"` if the paused flag is set.
+    fn require_not_paused(env: &Env) {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        assert!(!paused, "Contract is paused");
+    }
+
+    // -------------------------------------------------------------------------
+    // Pause / Unpause (admin only)
+    // -------------------------------------------------------------------------
+
+    /// Pause the contract, blocking all state-mutating operations.
+    ///
+    /// # Parameters
+    /// - `admin`: Must be the contract admin; `require_auth()` is enforced.
+    ///
+    /// # Panics
+    /// Panics with `"Admin only"` if `admin` is not the stored admin.
+    ///
+    /// # Events
+    /// Emits `("Paused", admin)`.
+    pub fn pause(env: Env, admin: Address) {
+        Self::require_admin(&env, &admin);
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish((symbol_short!("Paused"), admin), ());
+    }
+
+    /// Unpause the contract, re-enabling all state-mutating operations.
+    ///
+    /// # Parameters
+    /// - `admin`: Must be the contract admin; `require_auth()` is enforced.
+    ///
+    /// # Panics
+    /// Panics with `"Admin only"` if `admin` is not the stored admin.
+    ///
+    /// # Events
+    /// Emits `("Unpaused", admin)`.
+    pub fn unpause(env: Env, admin: Address) {
+        Self::require_admin(&env, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish((symbol_short!("Unpaused"), admin), ());
+    }
+
+    /// Returns `true` if the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
     /// Return the current curator list, or an empty vec if none have been added yet.
     fn get_curators(env: &Env) -> Vec<Address> {
         env.storage()
@@ -139,6 +198,7 @@ impl RegistryContract {
     /// Emits `("CurAdd", admin, curator)`.
     pub fn add_curator(env: Env, admin: Address, curator: Address) {
         Self::require_admin(&env, &admin);
+        Self::require_not_paused(&env);
 
         let mut curators = Self::get_curators(&env);
         if curators.iter().all(|c| c != curator) {
@@ -162,6 +222,7 @@ impl RegistryContract {
     /// Emits `("CurRem", admin, curator)`.
     pub fn remove_curator(env: Env, admin: Address, curator: Address) {
         Self::require_admin(&env, &admin);
+        Self::require_not_paused(&env);
 
         let curators = Self::get_curators(&env);
         let mut updated: Vec<Address> = Vec::new(&env);
@@ -217,6 +278,7 @@ impl RegistryContract {
         curator: Address,
     ) {
         curator.require_auth();
+        Self::require_not_paused(&env);
         assert!(
             Self::get_curators(&env).iter().any(|c| c == curator),
             "Caller is not a curator"
@@ -272,6 +334,7 @@ impl RegistryContract {
     /// Emits `("WrkTgl", id)` with data `new_is_active: bool`.
     pub fn toggle(env: Env, id: Symbol, caller: Address) {
         caller.require_auth();
+        Self::require_not_paused(&env);
         let mut worker: Worker = env
             .storage()
             .persistent()
@@ -313,6 +376,7 @@ impl RegistryContract {
         contact_hash: BytesN<32>,
     ) {
         caller.require_auth();
+        Self::require_not_paused(&env);
         let mut worker: Worker = env
             .storage()
             .persistent()
@@ -357,6 +421,7 @@ impl RegistryContract {
         wallet: Address,
     ) {
         caller.require_auth();
+        Self::require_not_paused(&env);
 
         let mut worker: Worker = env
             .storage()
@@ -393,6 +458,7 @@ impl RegistryContract {
     /// Emits `("WrkDrg", id, caller)`.
     pub fn deregister(env: Env, id: Symbol, caller: Address) {
         caller.require_auth();
+        Self::require_not_paused(&env);
         let worker: Worker = env
             .storage()
             .persistent()
@@ -518,6 +584,7 @@ impl RegistryContract {
     /// Emits `("RepUpd", id)` with data `score`.
     pub fn update_reputation(env: Env, admin: Address, id: Symbol, score: u32) {
         Self::require_admin(&env, &admin);
+        Self::require_not_paused(&env);
         assert!(score <= 10_000, "Score out of range");
 
         let mut worker: Worker = env


### PR DESCRIPTION
Summary

Introduces support for escrows with multiple milestones, allowing funds to be released in stages instead of a single final payout. This improves flexibility for staged payments and better dispute handling across long-running transactions.

Changes
- Added Milestone struct with milestone-specific amounts and status tracking
- Implemented milestone completion tracking for escrow progress
- Added partial fund release functionality based on completed milestones
- Added handling for milestone-level disputes before release
- Emitted MilestoneCompleted events for transparency and monitoring

Impact
- Enables staged escrow payments for multi-phase transactions
- Reduces risk by allowing controlled partial releases instead of full upfront settlement
- Improves dispute resolution by isolating issues to specific milestones
- Provides better visibility into escrow progress through milestone events

Acceptance Criteria
- [ ]  Milestone struct with amounts created
- [ ]  Milestone completion tracking implemented
- [ ]  Partial release functionality added
- [ ]  Milestone dispute handling supported
- [ ]  MilestoneCompleted events emitted

Closes #343