### PR TITLE
Issue 313 314 315 316  Worker analytics, email verification reminders, CSV import, and API versioning

### DIFF
--- a/packages/api/API_VERSIONING.md
+++ b/packages/api/API_VERSIONING.md
@@ -1,0 +1,57 @@
+# API Versioning Strategy
+
+## Overview
+
+BlueCollar uses **URL-based versioning** (`/api/v1/*`) to maintain backward compatibility while allowing the API to evolve.
+
+## Current Versions
+
+| Version | Base Path   | Status     | Sunset Date |
+|---------|-------------|------------|-------------|
+| v1      | `/api/v1/*` | ✅ Current  | —           |
+| —       | `/api/*`    | ⚠️ Deprecated | 2027-01-01 |
+
+## Using the API
+
+All new integrations should use the versioned base path:
+
+```
+https://api.bluecollar.app/api/v1/workers
+https://api.bluecollar.app/api/v1/auth/login
+```
+
+## Deprecation Warnings
+
+Requests to unversioned paths (`/api/*`) receive the following response headers:
+
+```
+Deprecation: true
+Warning: 299 - "Unversioned API path is deprecated. Use /api/v1/* instead."
+Sunset: Sat, 01 Jan 2027 00:00:00 GMT
+X-API-Version: v1
+```
+
+## Version Discovery
+
+```
+GET /api/versions
+```
+
+Returns the current version, supported versions, and deprecation info.
+
+## Introducing a New Version (v2)
+
+1. Create new route files in `src/routes/v2/` (or modify existing routes with version-specific logic).
+2. Mount them in `app.ts`:
+   ```ts
+   app.use('/api/v2/workers', v2WorkerRoutes)
+   ```
+3. Update `/api/versions` to include `v2` in `supported` and move `v1` to `deprecated`.
+4. Set a `Sunset` date for v1 and add `deprecationWarning` middleware to v1 routes.
+
+## Version Middleware
+
+- `versionMiddleware` — attaches `req.apiVersion` and sets `X-API-Version` response header.
+- `deprecationWarning` — adds `Deprecation`, `Warning`, and `Sunset` headers to deprecated paths.
+
+Both are in `src/middleware/version.ts`.

--- a/packages/api/prisma/migrations/20260425_issue_313_worker_analytics/migration.sql
+++ b/packages/api/prisma/migrations/20260425_issue_313_worker_analytics/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable: WorkerAnalytics (aggregated stats per worker)
+CREATE TABLE "WorkerAnalytics" (
+    "id"            TEXT NOT NULL,
+    "workerId"      TEXT NOT NULL,
+    "totalViews"    INTEGER NOT NULL DEFAULT 0,
+    "uniqueViews"   INTEGER NOT NULL DEFAULT 0,
+    "totalTips"     DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "tipCount"      INTEGER NOT NULL DEFAULT 0,
+    "bookmarkCount" INTEGER NOT NULL DEFAULT 0,
+    "updatedAt"     TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "WorkerAnalytics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: ProfileView (deduplicated by IP per worker per day)
+CREATE TABLE "ProfileView" (
+    "id"        TEXT NOT NULL,
+    "workerId"  TEXT NOT NULL,
+    "ip"        TEXT NOT NULL,
+    "viewedAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ProfileView_pkey" PRIMARY KEY ("id")
+);
+
+-- Unique analytics record per worker
+CREATE UNIQUE INDEX "WorkerAnalytics_workerId_key" ON "WorkerAnalytics"("workerId");
+
+-- Deduplicate views: one IP per worker per calendar day
+CREATE UNIQUE INDEX "ProfileView_workerId_ip_day_key"
+    ON "ProfileView"("workerId", "ip", DATE("viewedAt"));
+
+CREATE INDEX "ProfileView_workerId_idx" ON "ProfileView"("workerId");
+
+-- FK constraints
+ALTER TABLE "WorkerAnalytics" ADD CONSTRAINT "WorkerAnalytics_workerId_fkey"
+    FOREIGN KEY ("workerId") REFERENCES "Worker"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ProfileView" ADD CONSTRAINT "ProfileView_workerId_fkey"
+    FOREIGN KEY ("workerId") REFERENCES "Worker"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/api/prisma/migrations/20260425_issue_314_email_reminders/migration.sql
+++ b/packages/api/prisma/migrations/20260425_issue_314_email_reminders/migration.sql
@@ -1,0 +1,5 @@
+-- Add email verification reminder tracking fields to User
+ALTER TABLE "User"
+    ADD COLUMN IF NOT EXISTS "reminderSentAt"        TIMESTAMP(3),
+    ADD COLUMN IF NOT EXISTS "reminderCount"          INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS "unsubscribedReminders"  BOOLEAN NOT NULL DEFAULT false;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -57,6 +57,7 @@ model User {
   verificationRequests VerificationRequest[] @relation("VerificationRequests")
   verificationReviews  VerificationRequest[] @relation("VerificationReviews")
   auditLogs            AuditLog[]
+  jobsPosted           Job[]     @relation("JobsPosted")
 }
 
 model Category {
@@ -98,6 +99,11 @@ model Worker {
   disputes            Dispute[]
   interactions        UserInteraction[]
   verificationRequests VerificationRequest[]
+  analytics            WorkerAnalytics?
+  profileViews         ProfileView[]
+  portfolio            PortfolioItem[]
+  subscription         Subscription?
+  jobApplications      JobApplication[]
 }
 
 model PortfolioItem {
@@ -249,6 +255,77 @@ model AuditLog {
   @@index([userId])
   @@index([action])
   @@index([createdAt])
+}
+
+model Bookmark {
+  id        String   @id @default(cuid())
+  userId    String
+  workerId  String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  worker    Worker   @relation(fields: [workerId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, workerId])
+}
+
+model Availability {
+  id          String   @id @default(cuid())
+  workerId    String
+  worker      Worker   @relation(fields: [workerId], references: [id], onDelete: Cascade)
+  dayOfWeek   Int
+  startTime   String
+  endTime     String
+  timezone    String   @default("UTC")
+  isRecurring Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([workerId, dayOfWeek, startTime, endTime])
+}
+
+model ContactRequest {
+  id         String   @id @default(cuid())
+  workerId   String
+  worker     Worker   @relation(fields: [workerId], references: [id], onDelete: Cascade)
+  fromUserId String
+  fromUser   User     @relation(fields: [fromUserId], references: [id], onDelete: Cascade)
+  message    String
+  status     String   @default("pending")
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+}
+
+model PushSubscription {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  endpoint  String   @unique
+  p256dh    String
+  auth      String
+  createdAt DateTime @default(now())
+}
+
+model WorkerAnalytics {
+  id            String   @id @default(cuid())
+  workerId      String   @unique
+  worker        Worker   @relation(fields: [workerId], references: [id], onDelete: Cascade)
+  totalViews    Int      @default(0)
+  uniqueViews   Int      @default(0)
+  totalTips     Float    @default(0)
+  tipCount      Int      @default(0)
+  bookmarkCount Int      @default(0)
+  updatedAt     DateTime @updatedAt
+}
+
+model ProfileView {
+  id        String   @id @default(cuid())
+  workerId  String
+  worker    Worker   @relation(fields: [workerId], references: [id], onDelete: Cascade)
+  ip        String
+  viewedAt  DateTime @default(now())
+
+  @@unique([workerId, ip, viewedAt])
+  @@index([workerId])
 }
 
 enum DisputeStatus {

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -41,6 +41,9 @@ model User {
   twoFactorSecret         String?
   twoFactorEnabled        Boolean   @default(false)
   twoFactorBackupCodes    String[]  @default([])
+  reminderSentAt          DateTime?
+  reminderCount           Int       @default(0)
+  unsubscribedReminders   Boolean   @default(false)
   locationId    String?
   location      Location? @relation(fields: [locationId], references: [id])
   createdAt     DateTime  @default(now())

--- a/packages/api/src/__tests__/versioning.test.ts
+++ b/packages/api/src/__tests__/versioning.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { versionMiddleware, deprecationWarning } from '../middleware/version.js'
+import type { Request, Response, NextFunction } from 'express'
+
+function mockReq(path: string): Partial<Request> {
+  return { path } as any
+}
+
+function mockRes(): { headers: Record<string, string>; setHeader: ReturnType<typeof vi.fn> } {
+  const headers: Record<string, string> = {}
+  return {
+    headers,
+    setHeader: vi.fn((key: string, value: string) => { headers[key] = value }),
+  }
+}
+
+describe('versionMiddleware', () => {
+  it('sets X-API-Version to v1 for /api/v1/ paths', () => {
+    const req = mockReq('/api/v1/workers') as any
+    const res = mockRes() as any
+    const next = vi.fn()
+    versionMiddleware(req, res, next)
+    expect(res.setHeader).toHaveBeenCalledWith('X-API-Version', 'v1')
+    expect(req.apiVersion).toBe('v1')
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('defaults to v1 for unversioned /api/ paths', () => {
+    const req = mockReq('/api/workers') as any
+    const res = mockRes() as any
+    const next = vi.fn()
+    versionMiddleware(req, res, next)
+    expect(res.setHeader).toHaveBeenCalledWith('X-API-Version', 'v1')
+    expect(req.apiVersion).toBe('v1')
+  })
+
+  it('sets X-API-Version to v2 for /api/v2/ paths', () => {
+    const req = mockReq('/api/v2/workers') as any
+    const res = mockRes() as any
+    const next = vi.fn()
+    versionMiddleware(req, res, next)
+    expect(res.setHeader).toHaveBeenCalledWith('X-API-Version', 'v2')
+    expect(req.apiVersion).toBe('v2')
+  })
+})
+
+describe('deprecationWarning', () => {
+  it('sets Deprecation, Warning, and Sunset headers', () => {
+    const req = mockReq('/api/workers') as any
+    const res = mockRes() as any
+    const next = vi.fn()
+    deprecationWarning(req, res, next)
+    expect(res.headers['Deprecation']).toBe('true')
+    expect(res.headers['Warning']).toContain('deprecated')
+    expect(res.headers['Sunset']).toBeDefined()
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -17,6 +17,7 @@ import webhookRoutes from './routes/webhooks.js'
 import verificationRoutes from './routes/verifications.js'
 import auditRoutes from './routes/audit.js'
 import { auditMiddleware } from './middleware/audit.js'
+import { versionMiddleware, deprecationWarning } from './middleware/version.js'
 
 const app = express()
 
@@ -29,19 +30,44 @@ app.use(express.urlencoded({ extended: true }))
 app.use(pinoHttp({ logger }))
 app.use(methodOverride('X-HTTP-Method'))
 app.use(passport.initialize())
+app.use(versionMiddleware)
 
 app.use(auditMiddleware)
 
-app.use('/api/auth', authRoutes)
-app.use('/api/categories', categoryRoutes)
-app.use('/api/workers', workerRoutes)
-app.use('/api/admin', adminRoutes)
-app.use('/api/users', userRoutes)
-app.use('/api/disputes', disputeRoutes)
-app.use('/api/recommendations', recommendationRoutes)
-app.use('/api/webhooks', webhookRoutes)
-app.use('/api/verifications', verificationRoutes)
-app.use('/api/audit', auditRoutes)
+// ── v1 versioned routes (canonical) ──────────────────────────────────────────
+app.use('/api/v1/auth', authRoutes)
+app.use('/api/v1/categories', categoryRoutes)
+app.use('/api/v1/workers', workerRoutes)
+app.use('/api/v1/admin', adminRoutes)
+app.use('/api/v1/users', userRoutes)
+app.use('/api/v1/disputes', disputeRoutes)
+app.use('/api/v1/recommendations', recommendationRoutes)
+app.use('/api/v1/webhooks', webhookRoutes)
+app.use('/api/v1/verifications', verificationRoutes)
+app.use('/api/v1/audit', auditRoutes)
+
+// ── Unversioned routes (deprecated — kept for backward compatibility) ─────────
+app.use('/api/auth', deprecationWarning, authRoutes)
+app.use('/api/categories', deprecationWarning, categoryRoutes)
+app.use('/api/workers', deprecationWarning, workerRoutes)
+app.use('/api/admin', deprecationWarning, adminRoutes)
+app.use('/api/users', deprecationWarning, userRoutes)
+app.use('/api/disputes', deprecationWarning, disputeRoutes)
+app.use('/api/recommendations', deprecationWarning, recommendationRoutes)
+app.use('/api/webhooks', deprecationWarning, webhookRoutes)
+app.use('/api/verifications', deprecationWarning, verificationRoutes)
+app.use('/api/audit', deprecationWarning, auditRoutes)
+
+// API versioning info
+app.get('/api/versions', (_req, res) => {
+  res.json({
+    current: 'v1',
+    supported: ['v1'],
+    deprecated: ['unversioned (/api/*)'],
+    sunset: '2027-01-01',
+    message: 'Use /api/v1/* for all requests. Unversioned /api/* paths are deprecated.',
+  })
+})
 
 app.get('/health', async (_req, res) => {
   const checks: Record<string, { status: 'ok' | 'error'; latencyMs?: number; error?: string }> = {}

--- a/packages/api/src/controllers/analytics.ts
+++ b/packages/api/src/controllers/analytics.ts
@@ -1,0 +1,24 @@
+import type { Request, Response } from 'express'
+import * as analyticsService from '../services/analytics.service.js'
+import { handleError } from '../utils/handleError.js'
+
+/** GET /api/workers/:id/analytics — curator or admin only */
+export async function getAnalytics(req: Request, res: Response) {
+  try {
+    const data = await analyticsService.getWorkerAnalytics(req.params.id)
+    return res.json({ data, status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}
+
+/** POST /api/workers/:id/analytics/view — public, records a profile view */
+export async function trackView(req: Request, res: Response) {
+  try {
+    const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.socket.remoteAddress ?? 'unknown'
+    await analyticsService.recordProfileView(req.params.id, ip)
+    return res.json({ status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -8,6 +8,7 @@ import { sanitizeUser } from "../models/user.model.js";
 import { UserResource } from "../resources/index.js";
 import { AppError } from "../services/AppError.js";
 import { catchAsync } from "../utils/catchAsync.js";
+import type { Request, Response } from "express";
 import type {
   LoginBody,
   RegisterBody,
@@ -194,5 +195,26 @@ export async function resetPassword(
       });
   } catch (err) {
     return handleError(res, err);
+  }
+}
+
+/**
+ * GET /api/auth/unsubscribe-reminders?token=<jwt>
+ * Opt a user out of verification reminder emails.
+ */
+export async function unsubscribeReminders(req: Request, res: Response) {
+  const { token } = req.query
+  if (!token || typeof token !== 'string') {
+    return res.status(400).json({ status: 'error', message: 'Token is required', code: 400 })
+  }
+  try {
+    const payload = jwt.verify(token, env.JWT_SECRET) as { id?: string; purpose?: string }
+    if (payload.purpose !== 'unsubscribe-reminders' || !payload.id) {
+      return res.status(400).json({ status: 'error', message: 'Invalid token', code: 400 })
+    }
+    await db.user.update({ where: { id: payload.id }, data: { unsubscribedReminders: true } })
+    return res.json({ status: 'success', message: 'You have been unsubscribed from reminder emails', code: 200 })
+  } catch {
+    return res.status(400).json({ status: 'error', message: 'Invalid or expired token', code: 400 })
   }
 }

--- a/packages/api/src/controllers/csv-import.ts
+++ b/packages/api/src/controllers/csv-import.ts
@@ -1,0 +1,33 @@
+import type { Request, Response } from 'express'
+import { importWorkersFromCsv } from '../services/csv-import.service.js'
+import { handleError } from '../utils/handleError.js'
+
+/**
+ * POST /api/admin/workers/import
+ * Upload a CSV file to bulk-import workers. Admin only.
+ *
+ * Expects multipart/form-data with a `file` field (text/csv).
+ * Returns an import summary with counts and per-row errors.
+ */
+export async function importWorkersFromCsvController(req: Request, res: Response) {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ status: 'error', message: 'CSV file is required', code: 400 })
+    }
+
+    const csvText = req.file.buffer.toString('utf-8')
+    const result = await importWorkersFromCsv(csvText, req.user!.id)
+
+    return res.status(result.imported > 0 ? 201 : 400).json({
+      data: result,
+      status: result.imported > 0 ? 'success' : 'error',
+      message: `Imported ${result.imported} worker(s). ${result.failed} row(s) failed.`,
+      code: result.imported > 0 ? 201 : 400,
+    })
+  } catch (err: any) {
+    if (err?.message?.startsWith('Missing required CSV column')) {
+      return res.status(400).json({ status: 'error', message: err.message, code: 400 })
+    }
+    return handleError(res, err)
+  }
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,6 +13,7 @@ import workerRoutes from './routes/workers.js'
 import portfolioRoutes from './routes/portfolio.js'
 import reviewRoutes from './routes/reviews.js'
 import subscriptionRoutes from './routes/subscriptions.js'
+import { startReminderScheduler } from './services/reminder.service.js'
 
 const app = express()
 const PORT = env.PORT || 3000
@@ -42,4 +43,5 @@ app.use(errorHandler)
 
 app.listen(PORT, () => {
   logger.info(`BlueCollar API running on port ${PORT}`)
+  startReminderScheduler()
 })

--- a/packages/api/src/mailer/index.ts
+++ b/packages/api/src/mailer/index.ts
@@ -64,6 +64,15 @@ export async function sendModerationEmail(
   }
 }
 
+export async function sendVerificationReminderEmail(to: string, name: string, token: string, unsubscribeToken: string) {
+  const html = loadTemplate('verification-reminder.html')
+    .replace(/{{name}}/g, name)
+    .replace(/{{verificationLink}}/g, `${APP_URL}/api/auth/verify-account?token=${token}`)
+    .replace(/{{unsubscribeLink}}/g, `${APP_URL}/api/auth/unsubscribe-reminders?token=${unsubscribeToken}`)
+
+  await transporter.sendMail({ from: FROM, to, subject: 'Reminder: Verify your BlueCollar email', html })
+}
+
 export async function sendVerificationStatusEmail(
   to: string,
   firstName: string,

--- a/packages/api/src/mailer/templates/verification-reminder.html
+++ b/packages/api/src/mailer/templates/verification-reminder.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Verify your BlueCollar email</title></head>
+<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:20px">
+  <h2>Hi {{name}},</h2>
+  <p>You registered on BlueCollar but haven't verified your email yet.</p>
+  <p>Please click the button below to verify your account:</p>
+  <p>
+    <a href="{{verificationLink}}"
+       style="background:#2563eb;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;display:inline-block">
+      Verify Email
+    </a>
+  </p>
+  <p style="color:#6b7280;font-size:14px">
+    If you no longer want reminders,
+    <a href="{{unsubscribeLink}}">unsubscribe here</a>.
+  </p>
+  <p style="color:#6b7280;font-size:14px">— The BlueCollar Team</p>
+</body>
+</html>

--- a/packages/api/src/middleware/version.ts
+++ b/packages/api/src/middleware/version.ts
@@ -1,0 +1,30 @@
+import type { Request, Response, NextFunction } from 'express'
+
+/**
+ * Middleware: attach the resolved API version to `req` and response headers.
+ * Reads from the URL prefix (/api/v1, /api/v2) or defaults to 'v1'.
+ */
+export function versionMiddleware(req: Request, res: Response, next: NextFunction) {
+  const match = req.path.match(/^\/api\/(v\d+)\//)
+  const version = match ? match[1] : 'v1'
+  ;(req as any).apiVersion = version
+  res.setHeader('X-API-Version', version)
+  next()
+}
+
+/**
+ * Middleware: add a deprecation warning header for unversioned /api/* routes.
+ * Encourages clients to migrate to /api/v1/*.
+ */
+export function deprecationWarning(req: Request, res: Response, next: NextFunction) {
+  res.setHeader(
+    'Deprecation',
+    'true',
+  )
+  res.setHeader(
+    'Warning',
+    '299 - "Unversioned API path is deprecated. Use /api/v1/* instead."',
+  )
+  res.setHeader('Sunset', 'Sat, 01 Jan 2027 00:00:00 GMT')
+  next()
+}

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1,13 +1,17 @@
 import { Router } from 'express'
 import { listWorkers, listUsers, getStats } from '../controllers/admin.js'
+import { importWorkersFromCsvController } from '../controllers/csv-import.js'
 import { authenticate, authorize } from '../middleware/auth.js'
+import multer from 'multer'
 
 const router = Router()
+const csvUpload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 5 * 1024 * 1024 } })
 
 router.use(authenticate, authorize('admin'))
 
 router.get('/stats', getStats)
 router.get('/workers', listWorkers)
 router.get('/users', listUsers)
+router.post('/workers/import', csvUpload.single('file'), importWorkersFromCsvController)
 
 export default router

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -8,6 +8,7 @@ import {
   resetPassword,
   verifyAccount,
   googleAuthCallback,
+  unsubscribeReminders,
 } from '../controllers/auth.js'
 import {
   setup2FA,
@@ -58,6 +59,9 @@ router.get('/me', authenticate, me)
 // Verifies the SHA-256 hash of the token against the stored hash, then marks
 // the account as verified and clears the token fields.
 router.put('/verify-account', validate(verifyAccountRules), verifyAccount)
+
+// Unsubscribe from verification reminder emails via token in email link
+router.get('/unsubscribe-reminders', unsubscribeReminders)
 
 // ── Password reset ────────────────────────────────────────────────────────────
 // Sends a reset link to the given email (always 200 to prevent enumeration).

--- a/packages/api/src/routes/workers.ts
+++ b/packages/api/src/routes/workers.ts
@@ -14,6 +14,7 @@ import { getAvailability, upsertAvailability, addAvailabilitySlot, deleteAvailab
 import { registerOnChain } from '../controllers/stellar.js'
 import { createContactRequest, getContactRequests, updateContactRequestStatus } from '../controllers/contact-request.js'
 import { getWorkerVerifications } from '../controllers/verifications.js'
+import { getAnalytics, trackView } from '../controllers/analytics.js'
 import { authenticate, authorize } from '../middleware/auth.js'
 import { validate } from '../middleware/validate.js'
 import { upload, handleMulterError } from '../middleware/upload.js'
@@ -54,5 +55,9 @@ router.post('/:id/reviews', authenticate, createReview)
 
 // Verifications
 router.get('/:id/verifications', authenticate, authorize('curator', 'admin'), getWorkerVerifications)
+
+// Analytics
+router.post('/:id/analytics/view', trackView)
+router.get('/:id/analytics', authenticate, authorize('curator', 'admin'), getAnalytics)
 
 export default router

--- a/packages/api/src/services/analytics.service.ts
+++ b/packages/api/src/services/analytics.service.ts
@@ -1,0 +1,76 @@
+import { db } from '../db.js'
+import { AppError } from './AppError.js'
+
+/**
+ * Record a profile view with IP deduplication (one unique view per IP per day).
+ * Upserts the WorkerAnalytics aggregate row.
+ */
+export async function recordProfileView(workerId: string, ip: string) {
+  const worker = await db.worker.findUnique({ where: { id: workerId } })
+  if (!worker) throw new AppError('Worker not found', 404)
+
+  // Normalise to start-of-day for deduplication
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+
+  const existing = await db.profileView.findFirst({
+    where: { workerId, ip, viewedAt: { gte: today } },
+  })
+
+  // Always increment total views
+  await db.workerAnalytics.upsert({
+    where: { workerId },
+    create: { workerId, totalViews: 1, uniqueViews: existing ? 0 : 1 },
+    update: {
+      totalViews: { increment: 1 },
+      ...(existing ? {} : { uniqueViews: { increment: 1 } }),
+    },
+  })
+
+  if (!existing) {
+    await db.profileView.create({ data: { workerId, ip } })
+  }
+}
+
+/**
+ * Update tip analytics for a worker.
+ */
+export async function recordTip(workerId: string, amount: number) {
+  await db.workerAnalytics.upsert({
+    where: { workerId },
+    create: { workerId, totalTips: amount, tipCount: 1 },
+    update: { totalTips: { increment: amount }, tipCount: { increment: 1 } },
+  })
+}
+
+/**
+ * Update bookmark count for a worker (+1 or -1).
+ */
+export async function updateBookmarkCount(workerId: string, delta: 1 | -1) {
+  await db.workerAnalytics.upsert({
+    where: { workerId },
+    create: { workerId, bookmarkCount: delta === 1 ? 1 : 0 },
+    update: { bookmarkCount: { increment: delta } },
+  })
+}
+
+/**
+ * Get analytics dashboard for a worker.
+ */
+export async function getWorkerAnalytics(workerId: string) {
+  const worker = await db.worker.findUnique({ where: { id: workerId } })
+  if (!worker) throw new AppError('Worker not found', 404)
+
+  const analytics = await db.workerAnalytics.findUnique({ where: { workerId } })
+
+  return {
+    workerId,
+    workerName: worker.name,
+    totalViews: analytics?.totalViews ?? 0,
+    uniqueViews: analytics?.uniqueViews ?? 0,
+    totalTips: analytics?.totalTips ?? 0,
+    tipCount: analytics?.tipCount ?? 0,
+    bookmarkCount: analytics?.bookmarkCount ?? 0,
+    updatedAt: analytics?.updatedAt ?? null,
+  }
+}

--- a/packages/api/src/services/bookmark.service.ts
+++ b/packages/api/src/services/bookmark.service.ts
@@ -1,5 +1,6 @@
 import { db } from '../db.js'
 import { AppError } from './AppError.js'
+import { updateBookmarkCount } from './analytics.service.js'
 
 /**
  * Toggle a bookmark for a user/worker pair.
@@ -16,10 +17,12 @@ export async function toggleBookmark(userId: string, workerId: string) {
 
   if (existing) {
     await db.bookmark.delete({ where: { id: existing.id } })
+    updateBookmarkCount(workerId, -1).catch(() => {})
     return { bookmarked: false }
   }
 
   await db.bookmark.create({ data: { userId, workerId } })
+  updateBookmarkCount(workerId, 1).catch(() => {})
   return { bookmarked: true }
 }
 

--- a/packages/api/src/services/csv-import.service.ts
+++ b/packages/api/src/services/csv-import.service.ts
@@ -1,0 +1,134 @@
+import { db } from '../db.js'
+
+export interface CsvWorkerRow {
+  name: string
+  bio?: string
+  phone?: string
+  email?: string
+  categoryId: string
+  walletAddress?: string
+}
+
+export interface ImportResult {
+  imported: number
+  failed: number
+  errors: Array<{ row: number; reason: string }>
+}
+
+const REQUIRED_HEADERS = ['name', 'categoryId'] as const
+
+/**
+ * Parse a CSV string into rows. Handles quoted fields.
+ */
+function parseCsv(text: string): { headers: string[]; rows: string[][] } {
+  const lines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n').filter(Boolean)
+  if (lines.length === 0) return { headers: [], rows: [] }
+
+  const parseRow = (line: string): string[] => {
+    const fields: string[] = []
+    let current = ''
+    let inQuotes = false
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i]
+      if (ch === '"') {
+        if (inQuotes && line[i + 1] === '"') { current += '"'; i++ }
+        else inQuotes = !inQuotes
+      } else if (ch === ',' && !inQuotes) {
+        fields.push(current.trim()); current = ''
+      } else {
+        current += ch
+      }
+    }
+    fields.push(current.trim())
+    return fields
+  }
+
+  const headers = parseRow(lines[0]).map(h => h.toLowerCase())
+  const rows = lines.slice(1).map(parseRow)
+  return { headers, rows }
+}
+
+/**
+ * Validate and import workers from CSV content.
+ * Uses a transaction for batch insert; invalid rows are skipped and reported.
+ */
+export async function importWorkersFromCsv(csvText: string, curatorId: string): Promise<ImportResult> {
+  const { headers, rows } = parseCsv(csvText)
+
+  // Validate headers
+  for (const required of REQUIRED_HEADERS) {
+    if (!headers.includes(required)) {
+      throw new Error(`Missing required CSV column: "${required}"`)
+    }
+  }
+
+  const idx = (col: string) => headers.indexOf(col)
+
+  const errors: ImportResult['errors'] = []
+  const validRows: CsvWorkerRow[] = []
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]
+    const rowNum = i + 2 // 1-indexed, +1 for header
+
+    const name = row[idx('name')]?.trim()
+    const categoryId = row[idx('categoryid')]?.trim()
+
+    if (!name) { errors.push({ row: rowNum, reason: 'name is required' }); continue }
+    if (!categoryId) { errors.push({ row: rowNum, reason: 'categoryId is required' }); continue }
+
+    validRows.push({
+      name,
+      categoryId,
+      bio: idx('bio') >= 0 ? row[idx('bio')]?.trim() || undefined : undefined,
+      phone: idx('phone') >= 0 ? row[idx('phone')]?.trim() || undefined : undefined,
+      email: idx('email') >= 0 ? row[idx('email')]?.trim() || undefined : undefined,
+      walletAddress: idx('walletaddress') >= 0 ? row[idx('walletaddress')]?.trim() || undefined : undefined,
+    })
+  }
+
+  if (validRows.length === 0) {
+    return { imported: 0, failed: errors.length, errors }
+  }
+
+  // Validate categoryIds exist
+  const categoryIds = [...new Set(validRows.map(r => r.categoryId))]
+  const existingCategories = await db.category.findMany({
+    where: { id: { in: categoryIds } },
+    select: { id: true },
+  })
+  const validCategoryIds = new Set(existingCategories.map(c => c.id))
+
+  const toInsert: CsvWorkerRow[] = []
+  for (const row of validRows) {
+    if (!validCategoryIds.has(row.categoryId)) {
+      const rowNum = validRows.indexOf(row) + 2
+      errors.push({ row: rowNum, reason: `categoryId "${row.categoryId}" does not exist` })
+    } else {
+      toInsert.push(row)
+    }
+  }
+
+  if (toInsert.length === 0) {
+    return { imported: 0, failed: errors.length, errors }
+  }
+
+  // Batch insert in a transaction
+  await db.$transaction(
+    toInsert.map(row =>
+      db.worker.create({
+        data: {
+          name: row.name,
+          bio: row.bio,
+          phone: row.phone,
+          email: row.email,
+          walletAddress: row.walletAddress,
+          categoryId: row.categoryId,
+          curatorId,
+        },
+      })
+    )
+  )
+
+  return { imported: toInsert.length, failed: errors.length, errors }
+}

--- a/packages/api/src/services/reminder.service.ts
+++ b/packages/api/src/services/reminder.service.ts
@@ -1,0 +1,103 @@
+import crypto from 'node:crypto'
+import jwt from 'jsonwebtoken'
+import { db } from '../db.js'
+import { logger } from '../config/logger.js'
+import { sendVerificationReminderEmail } from '../mailer/index.js'
+
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+function generateVerificationToken(userId: string) {
+  const raw = jwt.sign({ id: userId, purpose: 'email-verify' }, process.env.JWT_SECRET!, { expiresIn: '7d' })
+  const hash = crypto.createHash('sha256').update(raw).digest('hex')
+  const expiry = new Date(Date.now() + 7 * DAY)
+  return { raw, hash, expiry }
+}
+
+function generateUnsubscribeToken(userId: string) {
+  return jwt.sign({ id: userId, purpose: 'unsubscribe-reminders' }, process.env.JWT_SECRET!, { expiresIn: '30d' })
+}
+
+/**
+ * Run the verification reminder job:
+ * - Send first reminder 24h after registration (reminderCount === 0)
+ * - Send second reminder 7 days after registration (reminderCount === 1)
+ * - Delete unverified accounts older than 30 days
+ */
+export async function runVerificationReminderJob() {
+  const now = new Date()
+
+  // --- First reminder: 24h after creation, not yet reminded ---
+  const firstReminderCutoff = new Date(now.getTime() - DAY)
+  const firstBatch = await db.user.findMany({
+    where: {
+      verified: false,
+      unsubscribedReminders: false,
+      reminderCount: 0,
+      createdAt: { lte: firstReminderCutoff },
+    },
+    select: { id: true, email: true, firstName: true },
+  })
+
+  for (const user of firstBatch) {
+    try {
+      const { raw, hash, expiry } = generateVerificationToken(user.id)
+      await db.user.update({
+        where: { id: user.id },
+        data: { verificationToken: hash, verificationTokenExpiry: expiry, reminderCount: 1, reminderSentAt: now },
+      })
+      const unsubToken = generateUnsubscribeToken(user.id)
+      await sendVerificationReminderEmail(user.email, user.firstName, raw, unsubToken)
+      logger.info({ userId: user.id }, 'Sent first verification reminder')
+    } catch (err) {
+      logger.error({ err, userId: user.id }, 'Failed to send first reminder')
+    }
+  }
+
+  // --- Second reminder: 7 days after creation, already sent first reminder ---
+  const secondReminderCutoff = new Date(now.getTime() - 7 * DAY)
+  const secondBatch = await db.user.findMany({
+    where: {
+      verified: false,
+      unsubscribedReminders: false,
+      reminderCount: 1,
+      createdAt: { lte: secondReminderCutoff },
+    },
+    select: { id: true, email: true, firstName: true },
+  })
+
+  for (const user of secondBatch) {
+    try {
+      const { raw, hash, expiry } = generateVerificationToken(user.id)
+      await db.user.update({
+        where: { id: user.id },
+        data: { verificationToken: hash, verificationTokenExpiry: expiry, reminderCount: 2, reminderSentAt: now },
+      })
+      const unsubToken = generateUnsubscribeToken(user.id)
+      await sendVerificationReminderEmail(user.email, user.firstName, raw, unsubToken)
+      logger.info({ userId: user.id }, 'Sent second verification reminder')
+    } catch (err) {
+      logger.error({ err, userId: user.id }, 'Failed to send second reminder')
+    }
+  }
+
+  // --- Delete unverified accounts older than 30 days ---
+  const deleteCutoff = new Date(now.getTime() - 30 * DAY)
+  const deleted = await db.user.deleteMany({
+    where: { verified: false, createdAt: { lte: deleteCutoff } },
+  })
+  if (deleted.count > 0) {
+    logger.info({ count: deleted.count }, 'Deleted unverified accounts older than 30 days')
+  }
+}
+
+/**
+ * Start the scheduled job — runs every hour.
+ */
+export function startReminderScheduler() {
+  // Run immediately on startup, then every hour
+  runVerificationReminderJob().catch((err) => logger.error({ err }, 'Reminder job failed'))
+  return setInterval(() => {
+    runVerificationReminderJob().catch((err) => logger.error({ err }, 'Reminder job failed'))
+  }, HOUR)
+}


### PR DESCRIPTION

  
  Closes #313
  Closes #314
  Closes #315
  Closes #316
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #313 — Add worker analytics endpoint
  
  What changed:
  
  - Added WorkerAnalytics and ProfileView Prisma models with a DB migration
  - WorkerAnalytics aggregates totalViews, uniqueViews, totalTips, tipCount, and bookmarkCount per worker
  - ProfileView records per-IP views with a unique constraint on (workerId, ip, DATE(viewedAt)) for daily deduplication
  - analytics.service.ts: recordProfileView (IP dedup), recordTip, updateBookmarkCount, getWorkerAnalytics
  - analytics.controller.ts: two handlers — trackView (public) and getAnalytics (curator/admin)
  - New routes on the workers router:
    - POST /api/v1/workers/:id/analytics/view — public, records a profile view
    - GET /api/v1/workers/:id/analytics — curator/admin, returns aggregated dashboard data
  
  - Bookmark toggle (bookmark.service.ts) now fires updateBookmarkCount to keep analytics in sync
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #314 — Implement email verification reminders
  
  What changed:
  
  - DB migration adds three columns to User: reminderCount (Int, default 0), reminderSentAt (DateTime?), unsubscribedReminders (Boolean, default false)
  - reminder.service.ts implements a scheduled job (startReminderScheduler) that runs every hour:
    - First reminder — sent 24 hours after registration if reminderCount === 0 and account is unverified
    - Second reminder — sent 7 days after registration if reminderCount === 1 and account is unverified
    - Account deletion — unverified accounts older than 30 days are hard-deleted
    - Each reminder generates a fresh 7-day verification token (SHA-256 hashed in DB) and a 30-day unsubscribe JWT
  
  - verification-reminder.html email template with a "Verify Email" CTA and an unsubscribe link
  - sendVerificationReminderEmail added to mailer/index.ts
  - New auth route: GET /api/v1/auth/unsubscribe-reminders?token=<jwt> — verifies the unsubscribe JWT and sets unsubscribedReminders: true
  - unsubscribeReminders controller added to controllers/auth.ts
  - Scheduler is started on server boot in index.ts
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #315 — Add worker import from CSV
  
  What changed:
  
  - csv-import.service.ts:
    - Custom CSV parser with quoted-field and escaped-quote support
    - Validates required headers (name, categoryId); throws a descriptive error if missing
    - Per-row validation: skips rows missing name or categoryId and records them with row number and reason
    - Validates all categoryId values exist in the database before inserting
    - Batch inserts all valid rows in a single Prisma $transaction
    - Returns ImportResult: { imported, failed, errors: [{ row, reason }] }
  
  - csv-import.controller.ts: reads the uploaded file buffer, delegates to the service, returns a structured summary response
  - New admin route: POST /api/v1/admin/workers/import
    - Admin-only (requires authenticate + authorize('admin'))
    - Accepts multipart/form-data with a file field (CSV, max 5 MB via multer memory storage)
    - Response includes imported count, failed count, and per-row error details
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #316 — Implement API versioning
  
  What changed:
  
  - middleware/version.ts:
    - versionMiddleware — parses the URL prefix (/api/v1/, /api/v2/, etc.), attaches req.apiVersion, and sets the X-API-Version response header; defaults
  to v1 for unversioned paths
    - deprecationWarning — adds Deprecation: true, Warning: 299 - "...", and Sunset: Sat, 01 Jan 2027 00:00:00 GMT headers to all unversioned /api/*
   responses
  
  - app.ts updated:
    - All routes mounted at canonical /api/v1/* paths
    - All routes also mounted at legacy /api/* paths with deprecationWarning middleware applied
    - GET /api/versions endpoint returns current version, supported versions, deprecated paths, and sunset date
  
  - API_VERSIONING.md documents the versioning strategy, migration guide for clients, and v2 rollout process
  - src/__tests__/versioning.test.ts: unit tests covering versionMiddleware (v1, v2, unversioned) and deprecationWarning (header assertions)
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  - Versioning middleware covered by unit tests in versioning.test.ts
  - All existing tests continue to pass (routes unchanged in behaviour, only path aliases added)