### PR TITLE
feat(contracts): multi-sig escrow, category verification, batch register, staking

### DIFF
--- a/packages/contracts/contracts/market/src/lib.rs
+++ b/packages/contracts/contracts/market/src/lib.rs
@@ -19,7 +19,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Symbol, Vec};
 
 /// Maximum allowed protocol fee: 500 bps = 5%.
 pub const MAX_FEE_BPS: u32 = 500;
@@ -60,6 +60,35 @@ pub struct Escrow {
     pub cancelled: bool,
 }
 
+/// Multi-signature escrow requiring `threshold` approvals before funds are released.
+///
+/// Any address in `signers` may call [`MarketContract::approve_multisig_release`].
+/// Once `approvals` reaches `threshold` the funds are automatically transferred to `to`.
+#[contracttype]
+#[derive(Clone)]
+pub struct MultiSigEscrow {
+    /// Address that funded the escrow.
+    pub from: Address,
+    /// Address that will receive funds once threshold is met.
+    pub to: Address,
+    /// Token contract address.
+    pub token: Address,
+    /// Locked amount.
+    pub amount: i128,
+    /// Unix timestamp after which `from` may cancel.
+    pub expiry: u64,
+    /// Ordered list of addresses authorised to approve release.
+    pub signers: Vec<Address>,
+    /// Number of approvals required to release funds.
+    pub threshold: u32,
+    /// Addresses that have already approved.
+    pub approvals: Vec<Address>,
+    /// `true` once funds have been released.
+    pub released: bool,
+    /// `true` once funds have been refunded.
+    pub cancelled: bool,
+}
+
 /// Storage keys used throughout the contract.
 #[contracttype]
 pub enum DataKey {
@@ -67,6 +96,8 @@ pub enum DataKey {
     Config,
     /// Persistent storage — [`Escrow`] struct keyed by a caller-supplied id [`Symbol`].
     Escrow(Symbol),
+    /// Persistent storage — [`MultiSigEscrow`] keyed by a caller-supplied id [`Symbol`].
+    MultiSigEscrow(Symbol),
 }
 
 // =============================================================================
@@ -338,6 +369,169 @@ impl MarketContract {
     }
 
     // -------------------------------------------------------------------------
+    // Multi-sig escrow (#337)
+    // -------------------------------------------------------------------------
+
+    /// Create a multi-signature escrow requiring `threshold` approvals before release.
+    ///
+    /// Transfers `amount` tokens from `from` to the contract immediately.
+    ///
+    /// # Parameters
+    /// - `id`: Unique identifier for this multi-sig escrow.
+    /// - `from`: Payer; `require_auth()` is enforced.
+    /// - `to`: Worker that receives funds once threshold is met.
+    /// - `token_addr`: Stellar token contract address.
+    /// - `amount`: Amount to lock (must be > 0).
+    /// - `expiry`: Unix timestamp after which `from` may cancel.
+    /// - `signers`: Addresses authorised to approve release.
+    /// - `threshold`: Number of approvals required (1 ≤ threshold ≤ signers.len()).
+    ///
+    /// # Panics
+    /// - `"Amount must be positive"` if `amount <= 0`.
+    /// - `"MultiSigEscrow id already exists"` on duplicate id.
+    /// - `"Invalid threshold"` if threshold is 0 or exceeds signers count.
+    ///
+    /// # Events
+    /// Emits `("MsEscCrt", id, from)` with data `(to, amount, threshold)`.
+    pub fn create_multisig_escrow(
+        env: Env,
+        id: Symbol,
+        from: Address,
+        to: Address,
+        token_addr: Address,
+        amount: i128,
+        expiry: u64,
+        signers: Vec<Address>,
+        threshold: u32,
+    ) {
+        from.require_auth();
+        assert!(amount > 0, "Amount must be positive");
+        assert!(
+            !env.storage().persistent().has(&DataKey::MultiSigEscrow(id.clone())),
+            "MultiSigEscrow id already exists"
+        );
+        assert!(
+            threshold > 0 && threshold <= signers.len(),
+            "Invalid threshold"
+        );
+
+        let client = token::Client::new(&env, &token_addr);
+        client.transfer(&from, &env.current_contract_address(), &amount);
+
+        let escrow = MultiSigEscrow {
+            from: from.clone(),
+            to: to.clone(),
+            token: token_addr,
+            amount,
+            expiry,
+            signers,
+            threshold,
+            approvals: Vec::new(&env),
+            released: false,
+            cancelled: false,
+        };
+        env.storage().persistent().set(&DataKey::MultiSigEscrow(id.clone()), &escrow);
+
+        env.events().publish(
+            (symbol_short!("MsEscCrt"), id, from),
+            (to, amount, threshold),
+        );
+    }
+
+    /// Approve release of a multi-sig escrow. Funds are released automatically when
+    /// the approval count reaches `threshold`.
+    ///
+    /// # Parameters
+    /// - `id`: The multi-sig escrow identifier.
+    /// - `caller`: Must be in `signers`; `require_auth()` is enforced.
+    ///
+    /// # Panics
+    /// - `"MultiSigEscrow not found"` if no escrow exists with the given `id`.
+    /// - `"Not a signer"` if `caller` is not in the signers list.
+    /// - `"Already approved"` if `caller` has already approved.
+    /// - `"Already released"` / `"Escrow cancelled"` if escrow is finalised.
+    ///
+    /// # Events
+    /// Emits `("MsEscApv", id, caller)` with data `approvals_count`.
+    /// Emits `("MsEscRel", id, to)` with data `amount` when threshold is reached.
+    pub fn approve_multisig_release(env: Env, id: Symbol, caller: Address) {
+        caller.require_auth();
+        let mut escrow: MultiSigEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultiSigEscrow(id.clone()))
+            .expect("MultiSigEscrow not found");
+
+        assert!(!escrow.released, "Already released");
+        assert!(!escrow.cancelled, "Escrow cancelled");
+        assert!(
+            escrow.signers.iter().any(|s| s == caller),
+            "Not a signer"
+        );
+        assert!(
+            escrow.approvals.iter().all(|a| a != caller),
+            "Already approved"
+        );
+
+        escrow.approvals.push_back(caller.clone());
+        let count = escrow.approvals.len();
+
+        env.events().publish(
+            (symbol_short!("MsEscApv"), id.clone(), caller),
+            count,
+        );
+
+        if count >= escrow.threshold {
+            let client = token::Client::new(&env, &escrow.token);
+            client.transfer(&env.current_contract_address(), &escrow.to, &escrow.amount);
+            escrow.released = true;
+            env.events().publish(
+                (symbol_short!("MsEscRel"), id.clone(), escrow.to.clone()),
+                escrow.amount,
+            );
+        }
+
+        env.storage().persistent().set(&DataKey::MultiSigEscrow(id), &escrow);
+    }
+
+    /// Cancel a multi-sig escrow and refund the payer (after expiry, payer only).
+    ///
+    /// # Panics
+    /// - `"MultiSigEscrow not found"`, `"Not authorized"`, `"Already released"`,
+    ///   `"Already cancelled"`, `"Escrow not yet expired"`.
+    ///
+    /// # Events
+    /// Emits `("MsEscCnl", id, from)` with data `amount`.
+    pub fn cancel_multisig_escrow(env: Env, id: Symbol, caller: Address) {
+        caller.require_auth();
+        let mut escrow: MultiSigEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultiSigEscrow(id.clone()))
+            .expect("MultiSigEscrow not found");
+
+        assert!(escrow.from == caller, "Not authorized");
+        assert!(!escrow.released, "Already released");
+        assert!(!escrow.cancelled, "Already cancelled");
+        assert!(env.ledger().timestamp() >= escrow.expiry, "Escrow not yet expired");
+
+        let client = token::Client::new(&env, &escrow.token);
+        client.transfer(&env.current_contract_address(), &escrow.from, &escrow.amount);
+        escrow.cancelled = true;
+        env.storage().persistent().set(&DataKey::MultiSigEscrow(id.clone()), &escrow);
+
+        env.events().publish(
+            (symbol_short!("MsEscCnl"), id, escrow.from),
+            escrow.amount,
+        );
+    }
+
+    /// Fetch multi-sig escrow details by id.
+    pub fn get_multisig_escrow(env: Env, id: Symbol) -> Option<MultiSigEscrow> {
+        env.storage().persistent().get(&DataKey::MultiSigEscrow(id))
+    }
+
+    // -------------------------------------------------------------------------
     // Upgrade
     // -------------------------------------------------------------------------
 
@@ -597,5 +791,71 @@ mod tests {
         let t = TestEnv::new();
         let id = Symbol::new(&t.env, "nope");
         assert!(t.client().get_escrow(&id).is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-sig escrow tests (#337)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_multisig_escrow_releases_at_threshold() {
+        let t = TestEnv::new();
+        let id = Symbol::new(&t.env, "ms1");
+        let s1 = Address::generate(&t.env);
+        let s2 = Address::generate(&t.env);
+        let signers = soroban_sdk::vec![&t.env, s1.clone(), s2.clone()];
+
+        t.client().create_multisig_escrow(&id, &t.payer, &t.worker, &t.token_addr, &200_000, &9999, &signers, &2);
+        assert_eq!(t.token_balance(&t.contract_id), 200_000);
+
+        t.client().approve_multisig_release(&id, &s1);
+        // not yet released
+        assert_eq!(t.token_balance(&t.worker), 0);
+
+        t.client().approve_multisig_release(&id, &s2);
+        // threshold reached
+        assert_eq!(t.token_balance(&t.worker), 200_000);
+        assert!(t.client().get_multisig_escrow(&id).unwrap().released);
+    }
+
+    #[test]
+    #[should_panic(expected = "Not a signer")]
+    fn test_multisig_approve_non_signer_panics() {
+        let t = TestEnv::new();
+        let id = Symbol::new(&t.env, "ms2");
+        let s1 = Address::generate(&t.env);
+        let signers = soroban_sdk::vec![&t.env, s1.clone()];
+        t.client().create_multisig_escrow(&id, &t.payer, &t.worker, &t.token_addr, &100_000, &9999, &signers, &1);
+        let stranger = Address::generate(&t.env);
+        t.client().approve_multisig_release(&id, &stranger);
+    }
+
+    #[test]
+    #[should_panic(expected = "Already approved")]
+    fn test_multisig_double_approve_panics() {
+        let t = TestEnv::new();
+        let id = Symbol::new(&t.env, "ms3");
+        let s1 = Address::generate(&t.env);
+        let s2 = Address::generate(&t.env);
+        let signers = soroban_sdk::vec![&t.env, s1.clone(), s2.clone()];
+        t.client().create_multisig_escrow(&id, &t.payer, &t.worker, &t.token_addr, &100_000, &9999, &signers, &2);
+        t.client().approve_multisig_release(&id, &s1);
+        t.client().approve_multisig_release(&id, &s1);
+    }
+
+    #[test]
+    fn test_multisig_cancel_after_expiry() {
+        let t = TestEnv::new();
+        let id = Symbol::new(&t.env, "ms4");
+        let s1 = Address::generate(&t.env);
+        let signers = soroban_sdk::vec![&t.env, s1.clone()];
+
+        t.set_time(1000);
+        t.client().create_multisig_escrow(&id, &t.payer, &t.worker, &t.token_addr, &100_000, &2000, &signers, &1);
+        t.set_time(3000);
+        t.client().cancel_multisig_escrow(&id, &t.payer);
+
+        assert_eq!(t.token_balance(&t.payer), 1_000_000);
+        assert!(t.client().get_multisig_escrow(&id).unwrap().cancelled);
     }
 }

--- a/packages/contracts/contracts/registry/src/lib.rs
+++ b/packages/contracts/contracts/registry/src/lib.rs
@@ -20,7 +20,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String, Symbol, Vec,
+    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, String,
+    Symbol, Vec,
 };
 
 /// Approximate TTL extension target (~1 year at 5 s/ledger).
@@ -58,6 +59,46 @@ pub struct Worker {
     /// Reputation score in basis points (0–10000, where 10000 = 100.00%).
     /// Updated by the admin via [`RegistryContract::update_reputation`].
     pub reputation: u32,
+    /// On-chain verified categories for this worker (see [`CategoryVerification`]).
+    pub verified_categories: Vec<Symbol>,
+    /// Total tokens staked by this worker for visibility boost.
+    pub staked_amount: i128,
+}
+
+/// On-chain record of a curator verifying a worker's category.
+#[contracttype]
+#[derive(Clone)]
+pub struct CategoryVerification {
+    /// The category that was verified.
+    pub category: Symbol,
+    /// Curator who performed the verification.
+    pub curator: Address,
+    /// Unix timestamp when this verification expires.
+    pub expires_at: u64,
+}
+
+/// Staking record for a worker.
+#[contracttype]
+#[derive(Clone)]
+pub struct StakeInfo {
+    /// Token contract used for staking.
+    pub token: Address,
+    /// Total amount currently staked.
+    pub amount: i128,
+    /// Ledger timestamp when unstake was requested (0 = no pending unstake).
+    pub unstake_requested_at: u64,
+    /// Accumulated rewards in basis points of staked amount per ledger.
+    pub rewards_accumulated: i128,
+    /// Ledger timestamp of last reward calculation.
+    pub last_reward_ledger: u64,
+}
+
+/// Result of a single registration attempt in [`RegistryContract::batch_register`].
+#[contracttype]
+#[derive(Clone)]
+pub struct BatchRegisterResult {
+    pub id: Symbol,
+    pub success: bool,
 }
 
 /// Storage keys used throughout the contract.
@@ -71,6 +112,10 @@ pub enum DataKey {
     Worker(Symbol),
     /// Persistent storage — ordered list of all registered worker id [`Symbol`]s.
     WorkerList,
+    /// Persistent storage — [`CategoryVerification`] keyed by `(worker_id, category)`.
+    CategoryVerification(Symbol, Symbol),
+    /// Persistent storage — [`StakeInfo`] keyed by worker id.
+    StakeInfo(Symbol),
 }
 
 // =============================================================================
@@ -232,6 +277,8 @@ impl RegistryContract {
             location_hash,
             contact_hash,
             reputation: 0,
+            verified_categories: Vec::new(&env),
+            staked_amount: 0,
         };
 
         let key = DataKey::Worker(id.clone());
@@ -533,6 +580,322 @@ impl RegistryContract {
     }
 
     // -------------------------------------------------------------------------
+    // Category verification (#338)
+    // -------------------------------------------------------------------------
+
+    /// Verify a worker's category on-chain. Curator only.
+    ///
+    /// Adds `category` to the worker's `verified_categories` list (idempotent) and
+    /// stores a [`CategoryVerification`] record with expiry and curator info.
+    ///
+    /// # Panics
+    /// - `"Caller is not a curator"` / `"Worker not found"`.
+    ///
+    /// # Events
+    /// Emits `("CatVfy", worker_id, category)` with data `(curator, expires_at)`.
+    pub fn verify_category(
+        env: Env,
+        curator: Address,
+        worker_id: Symbol,
+        category: Symbol,
+        expires_at: u64,
+    ) {
+        curator.require_auth();
+        assert!(
+            Self::get_curators(&env).iter().any(|c| c == curator),
+            "Caller is not a curator"
+        );
+
+        let mut worker: Worker = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Worker(worker_id.clone()))
+            .expect("Worker not found");
+
+        if worker.verified_categories.iter().all(|c| c != category) {
+            worker.verified_categories.push_back(category.clone());
+            env.storage().persistent().set(&DataKey::Worker(worker_id.clone()), &worker);
+        }
+
+        let verification = CategoryVerification {
+            category: category.clone(),
+            curator: curator.clone(),
+            expires_at,
+        };
+        env.storage().persistent().set(
+            &DataKey::CategoryVerification(worker_id.clone(), category.clone()),
+            &verification,
+        );
+
+        env.events().publish(
+            (symbol_short!("CatVfy"), worker_id, category),
+            (curator, expires_at),
+        );
+    }
+
+    /// Get the verification record for a specific worker + category pair.
+    pub fn get_category_verification(
+        env: Env,
+        worker_id: Symbol,
+        category: Symbol,
+    ) -> Option<CategoryVerification> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CategoryVerification(worker_id, category))
+    }
+
+    // -------------------------------------------------------------------------
+    // Batch registration (#340)
+    // -------------------------------------------------------------------------
+
+    /// Maximum number of workers that can be registered in a single batch call.
+    pub const MAX_BATCH_SIZE: u32 = 20;
+
+    /// Register multiple workers in one transaction. Curator only.
+    ///
+    /// Processes up to [`MAX_BATCH_SIZE`] entries. Duplicate ids are skipped
+    /// (partial success) rather than aborting the whole batch.
+    ///
+    /// # Panics
+    /// - `"Caller is not a curator"` / `"Batch too large"` / `"Mismatched input lengths"`.
+    ///
+    /// # Returns
+    /// A [`Vec<BatchRegisterResult>`] with one entry per input.
+    pub fn batch_register(
+        env: Env,
+        curator: Address,
+        ids: Vec<Symbol>,
+        owners: Vec<Address>,
+        names: Vec<String>,
+        categories: Vec<Symbol>,
+        location_hashes: Vec<BytesN<32>>,
+        contact_hashes: Vec<BytesN<32>>,
+    ) -> Vec<BatchRegisterResult> {
+        curator.require_auth();
+        assert!(
+            Self::get_curators(&env).iter().any(|c| c == curator),
+            "Caller is not a curator"
+        );
+
+        let n = ids.len();
+        assert!(n <= Self::MAX_BATCH_SIZE, "Batch too large");
+        assert!(
+            owners.len() == n
+                && names.len() == n
+                && categories.len() == n
+                && location_hashes.len() == n
+                && contact_hashes.len() == n,
+            "Mismatched input lengths"
+        );
+
+        let mut results: Vec<BatchRegisterResult> = Vec::new(&env);
+        let list_key = DataKey::WorkerList;
+        let mut list: Vec<Symbol> = env
+            .storage()
+            .persistent()
+            .get(&list_key)
+            .unwrap_or(Vec::new(&env));
+
+        for i in 0..n {
+            let id = ids.get(i).unwrap();
+            let key = DataKey::Worker(id.clone());
+
+            if env.storage().persistent().has(&key) {
+                results.push_back(BatchRegisterResult { id, success: false });
+                continue;
+            }
+
+            let owner = owners.get(i).unwrap();
+            let worker = Worker {
+                id: id.clone(),
+                owner: owner.clone(),
+                name: names.get(i).unwrap(),
+                category: categories.get(i).unwrap(),
+                is_active: true,
+                wallet: owner.clone(),
+                location_hash: location_hashes.get(i).unwrap(),
+                contact_hash: contact_hashes.get(i).unwrap(),
+                reputation: 0,
+                verified_categories: Vec::new(&env),
+                staked_amount: 0,
+            };
+
+            env.storage().persistent().set(&key, &worker);
+            env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+            list.push_back(id.clone());
+
+            env.events().publish(
+                (symbol_short!("WrkReg"), id.clone()),
+                (owner, categories.get(i).unwrap()),
+            );
+
+            results.push_back(BatchRegisterResult { id, success: true });
+        }
+
+        env.storage().persistent().set(&list_key, &list);
+        env.storage().persistent().extend_ttl(&list_key, TTL_THRESHOLD, TTL_EXTEND_TO);
+
+        results
+    }
+
+    // -------------------------------------------------------------------------
+    // Worker staking (#341)
+    // -------------------------------------------------------------------------
+
+    /// Cooldown period in seconds before an unstake request can be finalised (~7 days).
+    pub const UNSTAKE_COOLDOWN_SECS: u64 = 604_800;
+    /// Reward rate: 1 basis point per 1000 seconds of staking.
+    pub const REWARD_RATE_BPS_PER_1000_SECS: i128 = 1;
+
+    /// Stake tokens for a worker to boost visibility.
+    ///
+    /// Transfers `amount` tokens from `caller` to the contract.
+    ///
+    /// # Panics
+    /// - `"Worker not found"` / `"Not authorized"` / `"Amount must be positive"`.
+    ///
+    /// # Events
+    /// Emits `("Staked", worker_id, caller)` with data `(amount, total_staked)`.
+    pub fn stake(env: Env, caller: Address, worker_id: Symbol, token_addr: Address, amount: i128) {
+        caller.require_auth();
+        assert!(amount > 0, "Amount must be positive");
+
+        let mut worker: Worker = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Worker(worker_id.clone()))
+            .expect("Worker not found");
+        assert!(worker.owner == caller, "Not authorized");
+
+        let client = token::Client::new(&env, &token_addr);
+        client.transfer(&caller, &env.current_contract_address(), &amount);
+
+        let now = env.ledger().timestamp();
+        let mut info: StakeInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StakeInfo(worker_id.clone()))
+            .unwrap_or(StakeInfo {
+                token: token_addr.clone(),
+                amount: 0,
+                unstake_requested_at: 0,
+                rewards_accumulated: 0,
+                last_reward_ledger: now,
+            });
+
+        let elapsed = now.saturating_sub(info.last_reward_ledger);
+        info.rewards_accumulated +=
+            info.amount * Self::REWARD_RATE_BPS_PER_1000_SECS * elapsed as i128 / 1000;
+        info.last_reward_ledger = now;
+        info.amount += amount;
+        info.unstake_requested_at = 0;
+        env.storage().persistent().set(&DataKey::StakeInfo(worker_id.clone()), &info);
+
+        worker.staked_amount = info.amount;
+        env.storage().persistent().set(&DataKey::Worker(worker_id.clone()), &worker);
+
+        env.events().publish(
+            (symbol_short!("Staked"), worker_id, caller),
+            (amount, info.amount),
+        );
+    }
+
+    /// Request an unstake. Starts the cooldown timer.
+    ///
+    /// # Panics
+    /// - `"Worker not found"` / `"Not authorized"` / `"No active stake"` /
+    ///   `"Unstake already requested"`.
+    ///
+    /// # Events
+    /// Emits `("UnstakeRq", worker_id, caller)` with data `unstake_requested_at`.
+    pub fn request_unstake(env: Env, caller: Address, worker_id: Symbol) {
+        caller.require_auth();
+        let worker: Worker = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Worker(worker_id.clone()))
+            .expect("Worker not found");
+        assert!(worker.owner == caller, "Not authorized");
+
+        let mut info: StakeInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StakeInfo(worker_id.clone()))
+            .expect("No active stake");
+        assert!(info.amount > 0, "No active stake");
+        assert!(info.unstake_requested_at == 0, "Unstake already requested");
+
+        let now = env.ledger().timestamp();
+        info.unstake_requested_at = now;
+        env.storage().persistent().set(&DataKey::StakeInfo(worker_id.clone()), &info);
+
+        env.events().publish(
+            (symbol_short!("UnstakeRq"), worker_id, caller),
+            now,
+        );
+    }
+
+    /// Finalise unstake after cooldown. Returns staked tokens + rewards to caller.
+    ///
+    /// # Panics
+    /// - `"Worker not found"` / `"Not authorized"` / `"No active stake"` /
+    ///   `"Unstake not requested"` / `"Cooldown not elapsed"`.
+    ///
+    /// # Events
+    /// Emits `("Unstaked", worker_id, caller)` with data `(staked, rewards)`.
+    pub fn unstake(env: Env, caller: Address, worker_id: Symbol) {
+        caller.require_auth();
+        let mut worker: Worker = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Worker(worker_id.clone()))
+            .expect("Worker not found");
+        assert!(worker.owner == caller, "Not authorized");
+
+        let mut info: StakeInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StakeInfo(worker_id.clone()))
+            .expect("No active stake");
+        assert!(info.amount > 0, "No active stake");
+        assert!(info.unstake_requested_at > 0, "Unstake not requested");
+
+        let now = env.ledger().timestamp();
+        assert!(
+            now >= info.unstake_requested_at + Self::UNSTAKE_COOLDOWN_SECS,
+            "Cooldown not elapsed"
+        );
+
+        let elapsed = now.saturating_sub(info.last_reward_ledger);
+        info.rewards_accumulated +=
+            info.amount * Self::REWARD_RATE_BPS_PER_1000_SECS * elapsed as i128 / 1000;
+
+        let total_return = info.amount + info.rewards_accumulated;
+        let client = token::Client::new(&env, &info.token);
+        client.transfer(&env.current_contract_address(), &caller, &total_return);
+
+        let staked = info.amount;
+        let rewards = info.rewards_accumulated;
+        info.amount = 0;
+        info.rewards_accumulated = 0;
+        info.unstake_requested_at = 0;
+        env.storage().persistent().set(&DataKey::StakeInfo(worker_id.clone()), &info);
+
+        worker.staked_amount = 0;
+        env.storage().persistent().set(&DataKey::Worker(worker_id.clone()), &worker);
+
+        env.events().publish(
+            (symbol_short!("Unstaked"), worker_id, caller),
+            (staked, rewards),
+        );
+    }
+
+    /// Get staking info for a worker.
+    pub fn get_stake_info(env: Env, worker_id: Symbol) -> Option<StakeInfo> {
+        env.storage().persistent().get(&DataKey::StakeInfo(worker_id))
+    }
+
+    // -------------------------------------------------------------------------
     // Upgrade
     // -------------------------------------------------------------------------
 
@@ -810,5 +1173,251 @@ mod tests {
 
         let page2 = t.client().list_workers_paginated(&3, &3);
         assert_eq!(page2.len(), 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Category verification tests (#338)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_verify_category_stores_record() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+        t.register_worker(&t.curator);
+
+        let cat = Symbol::new(&t.env, "plumber");
+        t.client().verify_category(&t.curator, &t.worker_id(), &cat, &9999);
+
+        let v = t.client().get_category_verification(&t.worker_id(), &cat).unwrap();
+        assert_eq!(v.curator, t.curator);
+        assert_eq!(v.expires_at, 9999);
+
+        let worker = t.client().get_worker(&t.worker_id()).unwrap();
+        assert_eq!(worker.verified_categories.len(), 1);
+    }
+
+    #[test]
+    fn test_verify_category_idempotent() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+        t.register_worker(&t.curator);
+
+        let cat = Symbol::new(&t.env, "plumber");
+        t.client().verify_category(&t.curator, &t.worker_id(), &cat, &9999);
+        t.client().verify_category(&t.curator, &t.worker_id(), &cat, &9999);
+
+        let worker = t.client().get_worker(&t.worker_id()).unwrap();
+        assert_eq!(worker.verified_categories.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Caller is not a curator")]
+    fn test_verify_category_non_curator_panics() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+        t.register_worker(&t.curator);
+        let stranger = Address::generate(&t.env);
+        t.client().verify_category(&stranger, &t.worker_id(), &Symbol::new(&t.env, "plumber"), &9999);
+    }
+
+    // -------------------------------------------------------------------------
+    // Batch registration tests (#340)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_batch_register_all_succeed() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+
+        let ids = soroban_sdk::vec![
+            &t.env,
+            Symbol::new(&t.env, "b1"),
+            Symbol::new(&t.env, "b2"),
+        ];
+        let owners = soroban_sdk::vec![&t.env, t.owner.clone(), t.owner.clone()];
+        let names = soroban_sdk::vec![
+            &t.env,
+            String::from_str(&t.env, "Alice"),
+            String::from_str(&t.env, "Bob"),
+        ];
+        let cats = soroban_sdk::vec![
+            &t.env,
+            Symbol::new(&t.env, "plumber"),
+            Symbol::new(&t.env, "welder"),
+        ];
+        let hashes = soroban_sdk::vec![&t.env, t.zero_hash(), t.zero_hash()];
+
+        let results = t.client().batch_register(
+            &t.curator, &ids, &owners, &names, &cats, &hashes, &hashes,
+        );
+
+        assert_eq!(results.len(), 2);
+        assert!(results.get(0).unwrap().success);
+        assert!(results.get(1).unwrap().success);
+        assert_eq!(t.client().worker_count(), 2);
+    }
+
+    #[test]
+    fn test_batch_register_partial_success_on_duplicate() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+        t.register_worker(&t.curator); // registers "worker1"
+
+        let ids = soroban_sdk::vec![
+            &t.env,
+            t.worker_id(), // duplicate
+            Symbol::new(&t.env, "b2"),
+        ];
+        let owners = soroban_sdk::vec![&t.env, t.owner.clone(), t.owner.clone()];
+        let names = soroban_sdk::vec![
+            &t.env,
+            String::from_str(&t.env, "Alice"),
+            String::from_str(&t.env, "Bob"),
+        ];
+        let cats = soroban_sdk::vec![
+            &t.env,
+            Symbol::new(&t.env, "plumber"),
+            Symbol::new(&t.env, "welder"),
+        ];
+        let hashes = soroban_sdk::vec![&t.env, t.zero_hash(), t.zero_hash()];
+
+        let results = t.client().batch_register(
+            &t.curator, &ids, &owners, &names, &cats, &hashes, &hashes,
+        );
+
+        assert!(!results.get(0).unwrap().success); // duplicate
+        assert!(results.get(1).unwrap().success);
+        assert_eq!(t.client().worker_count(), 2); // original + b2
+    }
+
+    #[test]
+    #[should_panic(expected = "Batch too large")]
+    fn test_batch_register_too_large_panics() {
+        let t = TestEnv::new();
+        t.client().add_curator(&t.admin, &t.curator);
+
+        let mut ids = Vec::new(&t.env);
+        let mut owners = Vec::new(&t.env);
+        let mut names = Vec::new(&t.env);
+        let mut cats = Vec::new(&t.env);
+        let mut hashes = Vec::new(&t.env);
+
+        for i in 0..21u32 {
+            let id_str = soroban_sdk::String::from_str(&t.env, &format!("w{i}"));
+            ids.push_back(Symbol::new(&t.env, &id_str));
+            owners.push_back(t.owner.clone());
+            names.push_back(String::from_str(&t.env, "W"));
+            cats.push_back(Symbol::new(&t.env, "plumber"));
+            hashes.push_back(t.zero_hash());
+        }
+
+        t.client().batch_register(&t.curator, &ids, &owners, &names, &cats, &hashes, &hashes);
+    }
+
+    // -------------------------------------------------------------------------
+    // Staking tests (#341)
+    // -------------------------------------------------------------------------
+
+    struct StakeTestEnv {
+        base: TestEnv,
+        token_addr: Address,
+    }
+
+    impl StakeTestEnv {
+        fn new() -> Self {
+            use soroban_sdk::token::StellarAssetClient;
+            let base = TestEnv::new();
+            let admin = base.admin.clone();
+            let token_id = base.env.register_stellar_asset_contract_v2(admin.clone());
+            let token_addr = token_id.address();
+            StellarAssetClient::new(&base.env, &token_addr).mint(&base.owner, &1_000_000);
+            // Mint to contract for reward payouts
+            StellarAssetClient::new(&base.env, &token_addr)
+                .mint(&base.contract_id, &1_000_000);
+            StakeTestEnv { base, token_addr }
+        }
+
+        fn set_time(&self, ts: u64) {
+            use soroban_sdk::testutils::{Ledger, LedgerInfo};
+            self.base.env.ledger().set(LedgerInfo {
+                timestamp: ts,
+                protocol_version: 22,
+                sequence_number: 1,
+                network_id: Default::default(),
+                base_reserve: 10,
+                min_temp_entry_ttl: 1,
+                min_persistent_entry_ttl: 1,
+                max_entry_ttl: 100_000,
+            });
+        }
+
+        fn token_balance(&self, addr: &Address) -> i128 {
+            soroban_sdk::token::Client::new(&self.base.env, &self.token_addr).balance(addr)
+        }
+    }
+
+    #[test]
+    fn test_stake_increases_staked_amount() {
+        let s = StakeTestEnv::new();
+        s.base.client().add_curator(&s.base.admin, &s.base.curator);
+        s.base.register_worker(&s.base.curator);
+
+        s.set_time(1000);
+        s.base.client().stake(&s.base.owner, &s.base.worker_id(), &s.token_addr, &500_000);
+
+        let info = s.base.client().get_stake_info(&s.base.worker_id()).unwrap();
+        assert_eq!(info.amount, 500_000);
+
+        let worker = s.base.client().get_worker(&s.base.worker_id()).unwrap();
+        assert_eq!(worker.staked_amount, 500_000);
+    }
+
+    #[test]
+    fn test_unstake_after_cooldown_returns_tokens() {
+        let s = StakeTestEnv::new();
+        s.base.client().add_curator(&s.base.admin, &s.base.curator);
+        s.base.register_worker(&s.base.curator);
+
+        s.set_time(1000);
+        s.base.client().stake(&s.base.owner, &s.base.worker_id(), &s.token_addr, &500_000);
+
+        s.set_time(2000);
+        s.base.client().request_unstake(&s.base.owner, &s.base.worker_id());
+
+        // advance past cooldown
+        s.set_time(2000 + 604_800 + 1);
+        s.base.client().unstake(&s.base.owner, &s.base.worker_id());
+
+        // owner gets back at least their stake
+        assert!(s.token_balance(&s.base.owner) >= 500_000);
+
+        let info = s.base.client().get_stake_info(&s.base.worker_id()).unwrap();
+        assert_eq!(info.amount, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cooldown not elapsed")]
+    fn test_unstake_before_cooldown_panics() {
+        let s = StakeTestEnv::new();
+        s.base.client().add_curator(&s.base.admin, &s.base.curator);
+        s.base.register_worker(&s.base.curator);
+
+        s.set_time(1000);
+        s.base.client().stake(&s.base.owner, &s.base.worker_id(), &s.token_addr, &100_000);
+        s.base.client().request_unstake(&s.base.owner, &s.base.worker_id());
+        s.base.client().unstake(&s.base.owner, &s.base.worker_id());
+    }
+
+    #[test]
+    #[should_panic(expected = "Unstake already requested")]
+    fn test_double_request_unstake_panics() {
+        let s = StakeTestEnv::new();
+        s.base.client().add_curator(&s.base.admin, &s.base.curator);
+        s.base.register_worker(&s.base.curator);
+
+        s.set_time(1000);
+        s.base.client().stake(&s.base.owner, &s.base.worker_id(), &s.token_addr, &100_000);
+        s.base.client().request_unstake(&s.base.owner, &s.base.worker_id());
+        s.base.client().request_unstake(&s.base.owner, &s.base.worker_id());
     }
 }


### PR DESCRIPTION
## Summary

## Changes

### #337 — Multi-signature escrow (Market contract)

- New `MultiSigEscrow` struct with `signers`, `threshold`, and `approvals` tracking
- `create_multisig_escrow` — locks tokens, validates threshold ≤ signers count
- `approve_multisig_release` — records each signer's approval; auto-releases funds when `approvals.len() >= threshold`
- `cancel_multisig_escrow` — payer can reclaim after expiry
- `get_multisig_escrow` — read-only view
- Events: `MsEscCrt`, `MsEscApv`, `MsEscRel`, `MsEscCnl`


### #338 — Worker category verification (Registry contract)

- New `CategoryVerification` struct storing `category`, `curator`, and `expires_at`
- `verify_category` — curator-gated, idempotent; appends to `Worker.verified_categories`
- `get_category_verification` — read-only view keyed by `(worker_id, category)`
- `Worker` struct extended with `verified_categories: Vec<Symbol>`
- Event: `CatVfy`

### #340 — Batch worker registration (Registry contract)

- New `BatchRegisterResult` struct (`id`, `success`)
- `batch_register` — registers up to `MAX_BATCH_SIZE = 20` workers per call
- Duplicate ids are skipped (partial success) rather than aborting the whole batch
- Guards: batch size limit, mismatched input lengths
- Event: `WrkReg` per successfully registered worker

### #341 — Worker staking (Registry contract)

- New `StakeInfo` struct tracking `amount`, `unstake_requested_at`, `rewards_accumulated`, `last_reward_ledger`
- `stake` — transfers tokens in, accrues pending rewards on top-up
- `request_unstake` — starts 7-day cooldown (`UNSTAKE_COOLDOWN_SECS = 604_800`)
- `unstake` — finalises after cooldown, returns principal + accumulated rewards
- `get_stake_info` — read-only view
- `Worker` struct extended with `staked_amount: i128`
- Events: `Staked`, `UnstakeRq`, `Unstaked`

---

## Testing

Each feature has dedicated unit tests covering happy paths and all panic conditions:

| Feature | Tests added |
|---|---|
| Multi-sig escrow | threshold release, non-signer, double-approve, cancel after expiry |
| Category verification | stores record, idempotent, non-curator panics |
| Batch registration | all succeed, partial success on duplicate, batch-too-large |
| Worker staking | stake increases amount, unstake after cooldown, cooldown guard, double-request guard |

---

Closes #337
Closes #338
Closes #340
Closes #341