### PR TITLE
feat(devops): implement infrastructure as code with Terraform

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,113 @@
+name: Terraform CI/CD
+
+on:
+  push:
+    branches: [main]
+    paths: ['deploy/terraform/**']
+  pull_request:
+    paths: ['deploy/terraform/**']
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+env:
+  TF_DIR: deploy/terraform
+  TF_VERSION: "1.7.0"
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+        working-directory: ${{ env.TF_DIR }}
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+        working-directory: ${{ env.TF_DIR }}
+
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: ${{ env.TF_DIR }}
+
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_TERRAFORM_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: ${{ env.TF_DIR }}
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -out=tfplan
+        working-directory: ${{ env.TF_DIR }}
+        env:
+          TF_VAR_db_username: ${{ secrets.DB_USERNAME }}
+          TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
+
+      - name: Comment Plan on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `#### Terraform Plan
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\``;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+  apply:
+    name: Apply
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_TERRAFORM_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: ${{ env.TF_DIR }}
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        working-directory: ${{ env.TF_DIR }}
+        env:
+          TF_VAR_db_username: ${{ secrets.DB_USERNAME }}
+          TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,60 @@
+# BlueCollar Infrastructure (Terraform)
+
+All infrastructure is managed as code using Terraform.
+
+## Structure
+
+```
+deploy/terraform/
+├── main.tf           # Root module — wires all child modules
+├── variables.tf      # Input variables
+├── outputs.tf        # Root outputs
+├── bootstrap/        # One-time state backend setup
+│   └── state.tf
+├── modules/
+│   ├── networking/   # VPC, subnets, IGW
+│   ├── database/     # RDS PostgreSQL
+│   ├── registry/     # ECR repository + lifecycle policies
+│   └── cdn/          # S3 + CloudFront
+└── tests/
+    └── infra_test.go # Terratest integration tests
+```
+
+## First-time setup
+
+1. Bootstrap remote state (run once):
+   ```bash
+   terraform -chdir=deploy/terraform/bootstrap init
+   terraform -chdir=deploy/terraform/bootstrap apply
+   ```
+
+2. Initialise the root module:
+   ```bash
+   cd deploy/terraform
+   terraform init
+   ```
+
+3. Plan and apply:
+   ```bash
+   terraform plan -var="db_username=..." -var="db_password=..."
+   terraform apply
+   ```
+
+## State management
+
+- State is stored in S3 (`bluecollar-terraform-state`) with versioning and AES-256 encryption.
+- State locking uses DynamoDB (`bluecollar-terraform-locks`).
+
+## CI/CD
+
+The `terraform.yml` workflow runs on every PR and push to `main`:
+- PRs: `fmt` → `validate` → `plan` (plan posted as PR comment)
+- Merge to main: `apply` (requires `production` environment approval)
+
+## Infrastructure tests
+
+Uses [Terratest](https://terratest.gruntwork.io/):
+```bash
+cd deploy/terraform/tests
+go test -v -timeout 30m ./...
+```

--- a/deploy/terraform/bootstrap/state.tf
+++ b/deploy/terraform/bootstrap/state.tf
@@ -1,0 +1,49 @@
+# Run once to create the S3 bucket and DynamoDB table for remote state.
+# terraform -chdir=deploy/terraform/bootstrap apply
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}
+
+provider "aws" { region = "us-east-1" }
+
+resource "aws_s3_bucket" "state" {
+  bucket = "bluecollar-terraform-state"
+  tags   = { Name = "Terraform State", ManagedBy = "Terraform" }
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+  rule {
+    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket                  = aws_s3_bucket.state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "locks" {
+  name         = "bluecollar-terraform-locks"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = { Name = "Terraform State Locks", ManagedBy = "Terraform" }
+}

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,65 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Remote state — configure bucket/key before first apply
+  backend "s3" {
+    bucket         = "bluecollar-terraform-state"
+    key            = "bluecollar/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "bluecollar-terraform-locks"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "BlueCollar"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Modules
+# ---------------------------------------------------------------------------
+
+module "networking" {
+  source      = "./modules/networking"
+  environment = var.environment
+  vpc_cidr    = var.vpc_cidr
+}
+
+module "database" {
+  source            = "./modules/database"
+  environment       = var.environment
+  vpc_id            = module.networking.vpc_id
+  private_subnet_ids = module.networking.private_subnet_ids
+  db_instance_class = var.db_instance_class
+  db_name           = var.db_name
+  db_username       = var.db_username
+  db_password       = var.db_password
+}
+
+module "registry" {
+  source      = "./modules/registry"
+  environment = var.environment
+}
+
+module "cdn" {
+  source                  = "./modules/cdn"
+  environment             = var.environment
+  assets_bucket_name      = var.assets_bucket_name
+  use_default_certificate = var.use_default_certificate
+  acm_certificate_arn     = var.acm_certificate_arn
+}

--- a/deploy/terraform/modules/cdn/main.tf
+++ b/deploy/terraform/modules/cdn/main.tf
@@ -1,0 +1,93 @@
+variable "environment"             { type = string }
+variable "assets_bucket_name"      { type = string }
+variable "use_default_certificate" { type = bool }
+variable "acm_certificate_arn"     { type = string; default = "" }
+
+# Move existing CDN resources into this module
+# (cdn.tf at root is kept for backward compat — this module is the canonical source)
+
+resource "aws_s3_bucket" "assets" {
+  bucket = var.assets_bucket_name
+  tags   = { Name = "BlueCollar Assets", Environment = var.environment }
+}
+
+resource "aws_s3_bucket_versioning" "assets" {
+  bucket = aws_s3_bucket.assets.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_public_access_block" "assets" {
+  bucket                  = aws_s3_bucket.assets.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "assets" {
+  bucket = aws_s3_bucket.assets.id
+  rule {
+    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+  }
+}
+
+resource "aws_cloudfront_origin_access_identity" "oai" {
+  comment = "OAI for BlueCollar assets"
+}
+
+resource "aws_s3_bucket_policy" "assets" {
+  bucket = aws_s3_bucket.assets.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "CloudFrontAccess"
+      Effect    = "Allow"
+      Principal = { AWS = aws_cloudfront_origin_access_identity.oai.iam_arn }
+      Action    = "s3:GetObject"
+      Resource  = "${aws_s3_bucket.assets.arn}/*"
+    }]
+  })
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  origin {
+    domain_name            = aws_s3_bucket.assets.bucket_regional_domain_name
+    origin_id              = "S3-assets"
+    origin_access_identity = aws_cloudfront_origin_access_identity.oai.cloudfront_access_identity_path
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  http_version        = "http2and3"
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-assets"
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+  }
+
+  restrictions {
+    geo_restriction { restriction_type = "none" }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = var.use_default_certificate
+    acm_certificate_arn            = var.use_default_certificate ? null : var.acm_certificate_arn
+    ssl_support_method             = var.use_default_certificate ? null : "sni-only"
+    minimum_protocol_version       = var.use_default_certificate ? null : "TLSv1.2_2021"
+  }
+
+  tags = { Name = "BlueCollar CDN", Environment = var.environment }
+}
+
+output "cloudfront_domain_name"    { value = aws_cloudfront_distribution.cdn.domain_name }
+output "cloudfront_distribution_id" { value = aws_cloudfront_distribution.cdn.id }
+output "s3_bucket_name"            { value = aws_s3_bucket.assets.id }

--- a/deploy/terraform/modules/database/main.tf
+++ b/deploy/terraform/modules/database/main.tf
@@ -1,0 +1,57 @@
+variable "environment"        { type = string }
+variable "vpc_id"             { type = string }
+variable "private_subnet_ids" { type = list(string) }
+variable "db_instance_class"  { type = string }
+variable "db_name"            { type = string }
+variable "db_username"        { type = string; sensitive = true }
+variable "db_password"        { type = string; sensitive = true }
+
+resource "aws_db_subnet_group" "main" {
+  name       = "bluecollar-${var.environment}"
+  subnet_ids = var.private_subnet_ids
+}
+
+resource "aws_security_group" "db" {
+  name   = "bluecollar-db-${var.environment}"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier             = "bluecollar-${var.environment}"
+  engine                 = "postgres"
+  engine_version         = "15"
+  instance_class         = var.db_instance_class
+  allocated_storage      = 20
+  max_allocated_storage  = 100
+  storage_encrypted      = true
+  db_name                = var.db_name
+  username               = var.db_username
+  password               = var.db_password
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+  multi_az               = var.environment == "production"
+  skip_final_snapshot    = var.environment != "production"
+  deletion_protection    = var.environment == "production"
+  backup_retention_period = 7
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "Mon:04:00-Mon:05:00"
+
+  tags = { Name = "bluecollar-db-${var.environment}" }
+}
+
+output "endpoint" { value = aws_db_instance.main.endpoint; sensitive = true }
+output "db_name"  { value = aws_db_instance.main.db_name }

--- a/deploy/terraform/modules/networking/main.tf
+++ b/deploy/terraform/modules/networking/main.tf
@@ -1,0 +1,40 @@
+variable "environment" { type = string }
+variable "vpc_cidr"    { type = string }
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = { Name = "bluecollar-${var.environment}" }
+}
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = { Name = "bluecollar-private-${count.index}-${var.environment}" }
+}
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index + 10)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = { Name = "bluecollar-public-${count.index}-${var.environment}" }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "bluecollar-igw-${var.environment}" }
+}
+
+data "aws_availability_zones" "available" { state = "available" }
+
+output "vpc_id"             { value = aws_vpc.main.id }
+output "private_subnet_ids" { value = aws_subnet.private[*].id }
+output "public_subnet_ids"  { value = aws_subnet.public[*].id }

--- a/deploy/terraform/modules/registry/main.tf
+++ b/deploy/terraform/modules/registry/main.tf
@@ -1,0 +1,51 @@
+variable "environment" { type = string }
+
+resource "aws_ecr_repository" "api" {
+  name                 = "bluecollar-api"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = { Name = "bluecollar-api-${var.environment}" }
+}
+
+# Retain last 10 production images; clean up untagged after 1 day
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Remove untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+output "repository_url" { value = aws_ecr_repository.api.repository_url }
+output "repository_arn" { value = aws_ecr_repository.api.arn }

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,20 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.networking.vpc_id
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL"
+  value       = module.registry.repository_url
+}
+
+output "db_endpoint" {
+  description = "RDS endpoint"
+  value       = module.database.endpoint
+  sensitive   = true
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = module.cdn.cloudfront_domain_name
+}

--- a/deploy/terraform/tests/infra_test.go
+++ b/deploy/terraform/tests/infra_test.go
@@ -1,0 +1,49 @@
+// Infrastructure tests using Terratest.
+// Run: go test -v -timeout 30m ./deploy/terraform/tests/
+
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkingModule(t *testing.T) {
+	t.Parallel()
+
+	opts := &terraform.Options{
+		TerraformDir: "../modules/networking",
+		Vars: map[string]interface{}{
+			"environment": "test",
+			"vpc_cidr":    "10.99.0.0/16",
+		},
+	}
+
+	defer terraform.Destroy(t, opts)
+	terraform.InitAndApply(t, opts)
+
+	vpcID := terraform.Output(t, opts, "vpc_id")
+	assert.NotEmpty(t, vpcID)
+
+	privateSubnets := terraform.OutputList(t, opts, "private_subnet_ids")
+	assert.Equal(t, 2, len(privateSubnets))
+}
+
+func TestRegistryModule(t *testing.T) {
+	t.Parallel()
+
+	opts := &terraform.Options{
+		TerraformDir: "../modules/registry",
+		Vars: map[string]interface{}{
+			"environment": "test",
+		},
+	}
+
+	defer terraform.Destroy(t, opts)
+	terraform.InitAndApply(t, opts)
+
+	repoURL := terraform.Output(t, opts, "repository_url")
+	assert.Contains(t, repoURL, "bluecollar-api")
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Terraform variables for CDN setup
+# Terraform variables
 
 variable "aws_region" {
   description = "AWS region"
@@ -7,9 +7,20 @@ variable "aws_region" {
 }
 
 variable "environment" {
-  description = "Environment name"
+  description = "Environment name (production | staging)"
   type        = string
   default     = "production"
+
+  validation {
+    condition     = contains(["production", "staging"], var.environment)
+    error_message = "environment must be 'production' or 'staging'."
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
 }
 
 variable "assets_bucket_name" {
@@ -29,3 +40,28 @@ variable "acm_certificate_arn" {
   type        = string
   default     = ""
 }
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.medium"
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "bluecollar"
+}
+
+variable "db_username" {
+  description = "Database master username"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_password" {
+  description = "Database master password"
+  type        = string
+  sensitive   = true
+}
+


### PR DESCRIPTION
closes #394 

- Root module wiring networking, database, registry, cdn modules
- Remote state: S3 bucket + DynamoDB lock table (bootstrap/)
- modules/networking: VPC, public/private subnets, IGW
- modules/database: RDS PostgreSQL with multi-AZ in prod
- modules/registry: ECR with image scanning + lifecycle policies
- modules/cdn: S3 + CloudFront (extracted from cdn.tf)
- Terratest integration tests for networking and registry modules
- GitHub Actions CI/CD: fmt/validate/plan on PRs, apply on main
- README documenting structure, state management, and usage

Closes #394

## Description

<!-- A clear and concise description of what this PR does. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Testing Done

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Docs updated (if applicable)
- [ ] No unrelated changes included
