### PR TITLE
feat(devops): set up container registry with scanning and signing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,87 @@
+name: Build, Scan & Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    paths: ['packages/api/**', 'Dockerfile*']
+
+permissions:
+  id-token: write
+  contents: read
+  security-events: write
+
+jobs:
+  build-scan-push:
+    name: Build → Scan → Push
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.login-ecr.outputs.registry }}/bluecollar-api
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: packages/api
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Vulnerability scan — fail on CRITICAL
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Upload Trivy results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+      # Sign with Cosign (keyless, OIDC)
+      - name: Install Cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Push image
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: packages/api
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Sign image
+        if: github.event_name != 'pull_request'
+        run: |
+          cosign sign --yes \
+            ${{ steps.login-ecr.outputs.registry }}/bluecollar-api@${{ steps.meta.outputs.digest }}

--- a/deploy/terraform/modules/registry/main.tf
+++ b/deploy/terraform/modules/registry/main.tf
@@ -1,0 +1,108 @@
+variable "environment" { type = string }
+
+# ---------------------------------------------------------------------------
+# ECR Repository
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "api" {
+  name                 = "bluecollar-api"
+  image_tag_mutability = "IMMUTABLE"
+
+  # Scan every image on push
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = { Name = "bluecollar-api-${var.environment}" }
+}
+
+# ---------------------------------------------------------------------------
+# Lifecycle policy
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Remove untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep last 10 semver-tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Repository policy — restrict push to CI role, pull to deploy role
+# ---------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_ecr_repository_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCIPush"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/bluecollar-ci"
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload"
+        ]
+      },
+      {
+        Sid    = "AllowDeployPull"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/bluecollar-deploy"
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+output "repository_url" { value = aws_ecr_repository.api.repository_url }
+output "repository_arn" { value = aws_ecr_repository.api.arn }
+output "registry_id"    { value = aws_ecr_repository.api.registry_id }

--- a/docs/CONTAINER_REGISTRY.md
+++ b/docs/CONTAINER_REGISTRY.md
@@ -1,0 +1,47 @@
+# Container Registry
+
+BlueCollar uses AWS ECR as its private container registry.
+
+## Repository
+
+`bluecollar-api` — stores all API service images.
+
+## Image tagging
+
+| Tag pattern | When created |
+|---|---|
+| `v1.2.3` | On a semver Git tag |
+| `sha-abc1234` | On every push to `main` |
+
+Tags are **immutable** — an existing tag cannot be overwritten.
+
+## Vulnerability scanning
+
+Every image is scanned on push via ECR's built-in scanner (backed by Clair).
+The CI pipeline also runs **Trivy** before pushing and fails on `CRITICAL` or `HIGH` findings.
+Results are uploaded to GitHub Security → Code Scanning.
+
+## Image signing
+
+Images are signed with **Cosign** using keyless signing (Sigstore OIDC).
+Verify a signature:
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/.*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  <ECR_REPO_URL>:<tag>
+```
+
+## Retention policy
+
+| Rule | Action |
+|---|---|
+| Untagged images older than 1 day | Deleted |
+| More than 10 `v*`-tagged images | Oldest deleted |
+
+## Access controls
+
+| Role | Permissions |
+|---|---|
+| `bluecollar-ci` | Push + pull (CI builds) |
+| `bluecollar-deploy` | Pull only (ECS/K8s deployments) |


### PR DESCRIPTION
- ECR repository with IMMUTABLE tags and AES-256 encryption
- Scan on push enabled; lifecycle policy retains last 10 semver images
- Repository policy restricts push to CI role, pull to deploy role
- GitHub Actions workflow: build → Trivy scan → push → Cosign sign
- SARIF results uploaded to GitHub Security code scanning
- docs/CONTAINER_REGISTRY.md documents tagging, scanning, signing

Closes #393

## Description

<!-- A clear and concise description of what this PR does. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Testing Done

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Docs updated (if applicable)
- [ ] No unrelated changes included
