### PR TITLE
feat: implement repository pattern for User, Worker, and Category models

### DIFF
--- a/packages/api/src/repositories/base.repository.ts
+++ b/packages/api/src/repositories/base.repository.ts
@@ -1,0 +1,12 @@
+/**
+ * Generic repository interface.
+ * All model-specific repositories extend this contract.
+ */
+export interface IRepository<T, CreateInput, UpdateInput> {
+  findById(id: string): Promise<T | null>
+  findAll(opts?: { skip?: number; take?: number }): Promise<T[]>
+  create(data: CreateInput): Promise<T>
+  update(id: string, data: UpdateInput): Promise<T>
+  delete(id: string): Promise<T>
+  count(where?: Record<string, unknown>): Promise<number>
+}

--- a/packages/api/src/repositories/category.repository.ts
+++ b/packages/api/src/repositories/category.repository.ts
@@ -1,0 +1,43 @@
+import type { Category, Prisma } from '@prisma/client'
+import type { IRepository } from './base.repository.js'
+import { db } from '../db.js'
+
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface ICategoryRepository extends IRepository<Category, Prisma.CategoryCreateInput, Prisma.CategoryUpdateInput> {
+  findByName(name: string): Promise<Category | null>
+}
+
+// ── Prisma implementation ─────────────────────────────────────────────────────
+
+export class CategoryRepository implements ICategoryRepository {
+  async findById(id: string): Promise<Category | null> {
+    return db.category.findUnique({ where: { id } })
+  }
+
+  async findAll(opts: { skip?: number; take?: number } = {}): Promise<Category[]> {
+    return db.category.findMany({ skip: opts.skip, take: opts.take, orderBy: { name: 'asc' } })
+  }
+
+  async findByName(name: string): Promise<Category | null> {
+    return db.category.findUnique({ where: { name } })
+  }
+
+  async create(data: Prisma.CategoryCreateInput): Promise<Category> {
+    return db.category.create({ data })
+  }
+
+  async update(id: string, data: Prisma.CategoryUpdateInput): Promise<Category> {
+    return db.category.update({ where: { id }, data })
+  }
+
+  async delete(id: string): Promise<Category> {
+    return db.category.delete({ where: { id } })
+  }
+
+  async count(where?: Prisma.CategoryWhereInput): Promise<number> {
+    return db.category.count({ where })
+  }
+}
+
+export const categoryRepository = new CategoryRepository()

--- a/packages/api/src/repositories/index.ts
+++ b/packages/api/src/repositories/index.ts
@@ -1,0 +1,4 @@
+export * from './base.repository.js'
+export * from './user.repository.js'
+export * from './worker.repository.js'
+export * from './category.repository.js'

--- a/packages/api/src/repositories/repositories.test.ts
+++ b/packages/api/src/repositories/repositories.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { UserRepository } from '../repositories/user.repository.js'
+import { WorkerRepository } from '../repositories/worker.repository.js'
+import { CategoryRepository } from '../repositories/category.repository.js'
+
+// ── Mock Prisma ───────────────────────────────────────────────────────────────
+
+vi.mock('../db.js', () => ({
+  db: {
+    user: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    worker: {
+      findUnique: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    category: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}))
+
+import { db } from '../db.js'
+
+// ── UserRepository ────────────────────────────────────────────────────────────
+
+describe('UserRepository', () => {
+  let repo: UserRepository
+
+  beforeEach(() => {
+    repo = new UserRepository()
+    vi.clearAllMocks()
+  })
+
+  it('findById calls db.user.findUnique with id', async () => {
+    vi.mocked(db.user.findUnique).mockResolvedValue({ id: '1' } as any)
+    const result = await repo.findById('1')
+    expect(db.user.findUnique).toHaveBeenCalledWith({ where: { id: '1' } })
+    expect(result).toEqual({ id: '1' })
+  })
+
+  it('findByEmail calls db.user.findUnique with email', async () => {
+    vi.mocked(db.user.findUnique).mockResolvedValue({ email: 'a@b.com' } as any)
+    await repo.findByEmail('a@b.com')
+    expect(db.user.findUnique).toHaveBeenCalledWith({ where: { email: 'a@b.com' } })
+  })
+
+  it('findByGoogleId calls db.user.findUnique with googleId', async () => {
+    vi.mocked(db.user.findUnique).mockResolvedValue(null)
+    await repo.findByGoogleId('gid123')
+    expect(db.user.findUnique).toHaveBeenCalledWith({ where: { googleId: 'gid123' } })
+  })
+
+  it('findByReferralCode calls db.user.findUnique with referralCode', async () => {
+    vi.mocked(db.user.findUnique).mockResolvedValue(null)
+    await repo.findByReferralCode('REF123')
+    expect(db.user.findUnique).toHaveBeenCalledWith({ where: { referralCode: 'REF123' } })
+  })
+
+  it('findByResetToken calls db.user.findFirst with token and expiry check', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(null)
+    await repo.findByResetToken('tok')
+    expect(db.user.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ resetToken: 'tok' }) })
+    )
+  })
+
+  it('findByVerificationToken calls db.user.findFirst', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(null)
+    await repo.findByVerificationToken('vtok')
+    expect(db.user.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ verificationToken: 'vtok' }) })
+    )
+  })
+
+  it('create calls db.user.create', async () => {
+    const data = { email: 'x@y.com', firstName: 'X', lastName: 'Y', password: 'hash' } as any
+    vi.mocked(db.user.create).mockResolvedValue({ id: '2', ...data } as any)
+    await repo.create(data)
+    expect(db.user.create).toHaveBeenCalledWith({ data })
+  })
+
+  it('update calls db.user.update', async () => {
+    vi.mocked(db.user.update).mockResolvedValue({ id: '1' } as any)
+    await repo.update('1', { firstName: 'New' })
+    expect(db.user.update).toHaveBeenCalledWith({ where: { id: '1' }, data: { firstName: 'New' } })
+  })
+
+  it('delete calls db.user.delete', async () => {
+    vi.mocked(db.user.delete).mockResolvedValue({ id: '1' } as any)
+    await repo.delete('1')
+    expect(db.user.delete).toHaveBeenCalledWith({ where: { id: '1' } })
+  })
+
+  it('count calls db.user.count', async () => {
+    vi.mocked(db.user.count).mockResolvedValue(5)
+    const n = await repo.count()
+    expect(n).toBe(5)
+  })
+})
+
+// ── WorkerRepository ──────────────────────────────────────────────────────────
+
+describe('WorkerRepository', () => {
+  let repo: WorkerRepository
+
+  beforeEach(() => {
+    repo = new WorkerRepository()
+    vi.clearAllMocks()
+  })
+
+  it('findById calls db.worker.findUnique', async () => {
+    vi.mocked(db.worker.findUnique).mockResolvedValue({ id: 'w1' } as any)
+    await repo.findById('w1')
+    expect(db.worker.findUnique).toHaveBeenCalledWith({ where: { id: 'w1' } })
+  })
+
+  it('findByCurator calls db.worker.findMany with curatorId', async () => {
+    vi.mocked(db.worker.findMany).mockResolvedValue([])
+    await repo.findByCurator('c1')
+    expect(db.worker.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { curatorId: 'c1' } })
+    )
+  })
+
+  it('findActive filters by isActive: true', async () => {
+    vi.mocked(db.worker.findMany).mockResolvedValue([])
+    await repo.findActive()
+    expect(db.worker.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { isActive: true } })
+    )
+  })
+
+  it('findByCategory filters by categoryId and isActive', async () => {
+    vi.mocked(db.worker.findMany).mockResolvedValue([])
+    await repo.findByCategory('cat1')
+    expect(db.worker.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { categoryId: 'cat1', isActive: true } })
+    )
+  })
+
+  it('toggleActive flips isActive', async () => {
+    vi.mocked(db.worker.findUniqueOrThrow).mockResolvedValue({ id: 'w1', isActive: true } as any)
+    vi.mocked(db.worker.update).mockResolvedValue({ id: 'w1', isActive: false } as any)
+    const result = await repo.toggleActive('w1')
+    expect(db.worker.update).toHaveBeenCalledWith({ where: { id: 'w1' }, data: { isActive: false } })
+    expect(result).toEqual({ id: 'w1', isActive: false })
+  })
+
+  it('delete calls db.worker.delete', async () => {
+    vi.mocked(db.worker.delete).mockResolvedValue({ id: 'w1' } as any)
+    await repo.delete('w1')
+    expect(db.worker.delete).toHaveBeenCalledWith({ where: { id: 'w1' } })
+  })
+})
+
+// ── CategoryRepository ────────────────────────────────────────────────────────
+
+describe('CategoryRepository', () => {
+  let repo: CategoryRepository
+
+  beforeEach(() => {
+    repo = new CategoryRepository()
+    vi.clearAllMocks()
+  })
+
+  it('findAll returns categories ordered by name', async () => {
+    vi.mocked(db.category.findMany).mockResolvedValue([])
+    await repo.findAll()
+    expect(db.category.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { name: 'asc' } })
+    )
+  })
+
+  it('findByName calls db.category.findUnique', async () => {
+    vi.mocked(db.category.findUnique).mockResolvedValue({ id: 'c1', name: 'Plumber' } as any)
+    await repo.findByName('Plumber')
+    expect(db.category.findUnique).toHaveBeenCalledWith({ where: { name: 'Plumber' } })
+  })
+
+  it('create calls db.category.create', async () => {
+    const data = { name: 'Electrician' } as any
+    vi.mocked(db.category.create).mockResolvedValue({ id: 'c2', ...data } as any)
+    await repo.create(data)
+    expect(db.category.create).toHaveBeenCalledWith({ data })
+  })
+
+  it('count calls db.category.count', async () => {
+    vi.mocked(db.category.count).mockResolvedValue(10)
+    const n = await repo.count()
+    expect(n).toBe(10)
+  })
+})

--- a/packages/api/src/repositories/user.repository.ts
+++ b/packages/api/src/repositories/user.repository.ts
@@ -1,0 +1,67 @@
+import type { User, Prisma } from '@prisma/client'
+import type { IRepository } from './base.repository.js'
+import { db } from '../db.js'
+
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface IUserRepository extends IRepository<User, Prisma.UserCreateInput, Prisma.UserUpdateInput> {
+  findByEmail(email: string): Promise<User | null>
+  findByGoogleId(googleId: string): Promise<User | null>
+  findByResetToken(token: string): Promise<User | null>
+  findByVerificationToken(token: string): Promise<User | null>
+  findByReferralCode(code: string): Promise<User | null>
+}
+
+// ── Prisma implementation ─────────────────────────────────────────────────────
+
+export class UserRepository implements IUserRepository {
+  async findById(id: string): Promise<User | null> {
+    return db.user.findUnique({ where: { id } })
+  }
+
+  async findAll(opts: { skip?: number; take?: number } = {}): Promise<User[]> {
+    return db.user.findMany({ skip: opts.skip, take: opts.take, orderBy: { createdAt: 'desc' } })
+  }
+
+  async create(data: Prisma.UserCreateInput): Promise<User> {
+    return db.user.create({ data })
+  }
+
+  async update(id: string, data: Prisma.UserUpdateInput): Promise<User> {
+    return db.user.update({ where: { id }, data })
+  }
+
+  async delete(id: string): Promise<User> {
+    return db.user.delete({ where: { id } })
+  }
+
+  async count(where?: Prisma.UserWhereInput): Promise<number> {
+    return db.user.count({ where })
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    return db.user.findUnique({ where: { email } })
+  }
+
+  async findByGoogleId(googleId: string): Promise<User | null> {
+    return db.user.findUnique({ where: { googleId } })
+  }
+
+  async findByResetToken(token: string): Promise<User | null> {
+    return db.user.findFirst({
+      where: { resetToken: token, resetTokenExpiry: { gt: new Date() } },
+    })
+  }
+
+  async findByVerificationToken(token: string): Promise<User | null> {
+    return db.user.findFirst({
+      where: { verificationToken: token, verificationTokenExpiry: { gt: new Date() } },
+    })
+  }
+
+  async findByReferralCode(code: string): Promise<User | null> {
+    return db.user.findUnique({ where: { referralCode: code } })
+  }
+}
+
+export const userRepository = new UserRepository()

--- a/packages/api/src/repositories/worker.repository.ts
+++ b/packages/api/src/repositories/worker.repository.ts
@@ -1,0 +1,82 @@
+import type { Worker, Prisma } from '@prisma/client'
+import type { IRepository } from './base.repository.js'
+import { db } from '../db.js'
+
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface IWorkerRepository extends IRepository<Worker, Prisma.WorkerCreateInput, Prisma.WorkerUpdateInput> {
+  findWithRelations(id: string): Promise<(Worker & { category: unknown; curator: unknown }) | null>
+  findByCurator(curatorId: string): Promise<Worker[]>
+  findByCategory(categoryId: string, opts?: { skip?: number; take?: number }): Promise<Worker[]>
+  findActive(opts?: { skip?: number; take?: number }): Promise<Worker[]>
+  toggleActive(id: string): Promise<Worker>
+}
+
+// ── Prisma implementation ─────────────────────────────────────────────────────
+
+const workerInclude = { category: true, curator: true } as const
+
+export class WorkerRepository implements IWorkerRepository {
+  async findById(id: string): Promise<Worker | null> {
+    return db.worker.findUnique({ where: { id } })
+  }
+
+  async findWithRelations(id: string) {
+    return db.worker.findUnique({ where: { id }, include: workerInclude })
+  }
+
+  async findAll(opts: { skip?: number; take?: number } = {}): Promise<Worker[]> {
+    return db.worker.findMany({ skip: opts.skip, take: opts.take, orderBy: { createdAt: 'desc' } })
+  }
+
+  async findActive(opts: { skip?: number; take?: number } = {}): Promise<Worker[]> {
+    return db.worker.findMany({
+      where: { isActive: true },
+      skip: opts.skip,
+      take: opts.take,
+      include: workerInclude,
+      orderBy: { createdAt: 'desc' },
+    })
+  }
+
+  async findByCurator(curatorId: string): Promise<Worker[]> {
+    return db.worker.findMany({
+      where: { curatorId },
+      include: workerInclude,
+      orderBy: { createdAt: 'desc' },
+    })
+  }
+
+  async findByCategory(categoryId: string, opts: { skip?: number; take?: number } = {}): Promise<Worker[]> {
+    return db.worker.findMany({
+      where: { categoryId, isActive: true },
+      skip: opts.skip,
+      take: opts.take,
+      include: workerInclude,
+      orderBy: { createdAt: 'desc' },
+    })
+  }
+
+  async create(data: Prisma.WorkerCreateInput): Promise<Worker> {
+    return db.worker.create({ data, include: workerInclude })
+  }
+
+  async update(id: string, data: Prisma.WorkerUpdateInput): Promise<Worker> {
+    return db.worker.update({ where: { id }, data, include: workerInclude })
+  }
+
+  async delete(id: string): Promise<Worker> {
+    return db.worker.delete({ where: { id } })
+  }
+
+  async count(where?: Prisma.WorkerWhereInput): Promise<number> {
+    return db.worker.count({ where })
+  }
+
+  async toggleActive(id: string): Promise<Worker> {
+    const worker = await db.worker.findUniqueOrThrow({ where: { id } })
+    return db.worker.update({ where: { id }, data: { isActive: !worker.isActive } })
+  }
+}
+
+export const workerRepository = new WorkerRepository()

--- a/packages/api/src/services/category.service.ts
+++ b/packages/api/src/services/category.service.ts
@@ -1,24 +1,19 @@
-import { db } from '../db.js'
+import { categoryRepository } from '../repositories/category.repository.js'
 import { AppError } from './AppError.js'
 
 /**
  * Return all categories ordered by name.
- *
- * @returns Array of all `Category` records.
  */
 export async function listCategories() {
-  return db.category.findMany()
+  return categoryRepository.findAll()
 }
 
 /**
  * Get a single category by id.
- *
- * @param id - The category's database id.
- * @returns The `Category` record.
- * @throws AppError 404 if no category exists with the given id.
+ * @throws AppError 404 if not found.
  */
 export async function getCategory(id: string) {
-  const category = await db.category.findUnique({ where: { id } })
+  const category = await categoryRepository.findById(id)
   if (!category) throw new AppError('Not found', 404)
   return category
 }


### PR DESCRIPTION
- Add IRepository<T, CreateInput, UpdateInput> base interface
- Add IUserRepository with findByEmail, findByGoogleId, findByResetToken, findByVerificationToken, findByReferralCode
- Add IWorkerRepository with findWithRelations, findByCurator, findByCategory, findActive, toggleActive
- Add ICategoryRepository with findByName
- Implement UserRepository, WorkerRepository, CategoryRepository backed by Prisma (singleton exports: userRepository, workerRepository, categoryRepository)
- Update category.service.ts to use categoryRepository
- Add repositories.test.ts with mocked Prisma covering all methods
- Export all repositories from src/repositories/index.ts

Closes #409

## Description

<!-- A clear and concise description of what this PR does. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Testing Done

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Docs updated (if applicable)
- [ ] No unrelated changes included
