### PR TITLE
feat: add Pact consumer/provider contract tests and CI workflow

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -1,0 +1,104 @@
+name: Contract Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  PNPM_VERSION: 9
+
+jobs:
+  contract-consumer:
+    name: Pact Consumer Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/api
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Run consumer contract tests
+        run: pnpm vitest run src/__tests__/contract/consumer.workers.pact.test.ts
+        env:
+          JWT_SECRET: test-secret
+
+      - name: Upload pact files
+        uses: actions/upload-artifact@v4
+        with:
+          name: pacts
+          path: packages/api/pacts/
+          retention-days: 7
+
+  contract-provider:
+    name: Pact Provider Verification
+    runs-on: ubuntu-latest
+    needs: contract-consumer
+    defaults:
+      run:
+        working-directory: packages/api
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: bluecollar
+          POSTGRES_PASSWORD: bluecollar
+          POSTGRES_DB: bluecollar_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Download pact files
+        uses: actions/download-artifact@v4
+        with:
+          name: pacts
+          path: packages/api/pacts/
+
+      - name: Run migrations
+        run: pnpm prisma migrate deploy
+        env:
+          DATABASE_URL: postgresql://bluecollar:bluecollar@localhost:5432/bluecollar_test
+
+      - name: Run provider verification
+        run: pnpm vitest run src/__tests__/contract/provider.verification.pact.test.ts
+        env:
+          DATABASE_URL: postgresql://bluecollar:bluecollar@localhost:5432/bluecollar_test
+          JWT_SECRET: test-secret

--- a/docs/CONTRACT_TESTING.md
+++ b/docs/CONTRACT_TESTING.md
@@ -1,0 +1,40 @@
+# Contract Testing Guide
+
+> Closes #430
+
+BlueCollar uses [Pact](https://pact.io/) for consumer-driven contract testing to ensure the API and frontend remain compatible.
+
+## Overview
+
+| Role | File | Purpose |
+|------|------|---------|
+| Consumer | `src/__tests__/contract/consumer.workers.pact.test.ts` | App defines expected API shape |
+| Provider | `src/__tests__/contract/provider.verification.pact.test.ts` | API verifies it satisfies consumer pacts |
+
+## Running Locally
+
+```bash
+# Consumer tests (generates pact files in packages/api/pacts/)
+cd packages/api
+pnpm vitest run src/__tests__/contract/consumer.workers.pact.test.ts
+
+# Provider verification (requires running DB)
+DATABASE_URL=postgresql://... pnpm vitest run src/__tests__/contract/provider.verification.pact.test.ts
+```
+
+## CI
+
+The `contract-tests.yml` workflow runs on every push/PR:
+
+1. **consumer** job – runs consumer tests and uploads pact files as artifacts
+2. **provider** job – downloads pacts and verifies the API satisfies them
+
+## Adding New Contracts
+
+1. Add an `addInteraction` block in `consumer.workers.pact.test.ts`
+2. Add a matching `stateHandler` in `provider.verification.pact.test.ts`
+3. Re-run consumer tests to regenerate the pact file
+
+## Pact File Location
+
+Generated pact JSON files are written to `packages/api/pacts/` (git-ignored).

--- a/packages/api/src/__tests__/contract/consumer.workers.pact.test.ts
+++ b/packages/api/src/__tests__/contract/consumer.workers.pact.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Pact Consumer Contract Tests – Workers API
+ * Closes #430
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PactV3, MatchersV3 } from '@pact-foundation/pact';
+import path from 'path';
+
+const { like, eachLike, string, integer } = MatchersV3;
+
+const provider = new PactV3({
+  consumer: 'BlueCollarApp',
+  provider: 'BlueCollarAPI',
+  dir: path.resolve(__dirname, '../../../pacts'),
+  logLevel: 'warn',
+});
+
+describe('Workers API – Consumer Contract', () => {
+  describe('GET /api/workers', () => {
+    beforeAll(async () => {
+      await provider.addInteraction({
+        states: [{ description: 'workers exist' }],
+        uponReceiving: 'a request for all workers',
+        withRequest: {
+          method: 'GET',
+          path: '/api/workers',
+        },
+        willRespondWith: {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            status: string('success'),
+            data: eachLike({
+              id: string('worker-id-1'),
+              name: string('John Doe'),
+              category: like({ id: string('cat-1'), name: string('Plumber') }),
+              isActive: like(true),
+            }),
+          },
+        },
+      });
+    });
+
+    it('returns a list of workers', async () => {
+      await provider.executeTest(async (mockServer) => {
+        const res = await fetch(`${mockServer.url}/api/workers`);
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body.status).toBe('success');
+        expect(Array.isArray(body.data)).toBe(true);
+      });
+    });
+  });
+
+  describe('GET /api/workers/:id', () => {
+    beforeAll(async () => {
+      await provider.addInteraction({
+        states: [{ description: 'worker with id worker-id-1 exists' }],
+        uponReceiving: 'a request for a single worker',
+        withRequest: {
+          method: 'GET',
+          path: '/api/workers/worker-id-1',
+        },
+        willRespondWith: {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            status: string('success'),
+            data: {
+              id: string('worker-id-1'),
+              name: string('John Doe'),
+              category: like({ id: string('cat-1'), name: string('Plumber') }),
+              isActive: like(true),
+            },
+          },
+        },
+      });
+    });
+
+    it('returns a single worker', async () => {
+      await provider.executeTest(async (mockServer) => {
+        const res = await fetch(`${mockServer.url}/api/workers/worker-id-1`);
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body.data.id).toBe('worker-id-1');
+      });
+    });
+  });
+
+  describe('GET /api/categories', () => {
+    beforeAll(async () => {
+      await provider.addInteraction({
+        states: [{ description: 'categories exist' }],
+        uponReceiving: 'a request for all categories',
+        withRequest: {
+          method: 'GET',
+          path: '/api/categories',
+        },
+        willRespondWith: {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            status: string('success'),
+            data: eachLike({
+              id: string('cat-1'),
+              name: string('Plumber'),
+            }),
+          },
+        },
+      });
+    });
+
+    it('returns a list of categories', async () => {
+      await provider.executeTest(async (mockServer) => {
+        const res = await fetch(`${mockServer.url}/api/categories`);
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body.status).toBe('success');
+        expect(Array.isArray(body.data)).toBe(true);
+      });
+    });
+  });
+
+  describe('POST /api/auth/login', () => {
+    beforeAll(async () => {
+      await provider.addInteraction({
+        states: [{ description: 'user with email test@example.com exists' }],
+        uponReceiving: 'a valid login request',
+        withRequest: {
+          method: 'POST',
+          path: '/api/auth/login',
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            email: 'test@example.com',
+            password: 'Password123!',
+          },
+        },
+        willRespondWith: {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            status: string('success'),
+            token: string('jwt-token'),
+            data: like({
+              id: string('user-id-1'),
+              email: string('test@example.com'),
+              role: string('user'),
+            }),
+          },
+        },
+      });
+    });
+
+    it('returns a token on valid login', async () => {
+      await provider.executeTest(async (mockServer) => {
+        const res = await fetch(`${mockServer.url}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'test@example.com', password: 'Password123!' }),
+        });
+        const body = await res.json();
+        expect(res.status).toBe(202);
+        expect(body.token).toBeDefined();
+      });
+    });
+  });
+});

--- a/packages/api/src/__tests__/contract/provider.verification.pact.test.ts
+++ b/packages/api/src/__tests__/contract/provider.verification.pact.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Pact Provider Verification – BlueCollarAPI
+ * Closes #430
+ *
+ * Verifies that the running API satisfies all consumer pacts.
+ * Run with: pnpm test:contract:provider
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import { Verifier } from '@pact-foundation/pact';
+import path from 'path';
+import { createServer } from 'http';
+import app from '../../app.js';
+
+let server: ReturnType<typeof createServer>;
+let port: number;
+
+beforeAll(async () => {
+  server = createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => {
+      port = (server.address() as { port: number }).port;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('Provider Verification – BlueCollarAPI', () => {
+  it('satisfies all consumer pacts', async () => {
+    const verifier = new Verifier({
+      provider: 'BlueCollarAPI',
+      providerBaseUrl: `http://localhost:${port}`,
+      pactUrls: [path.resolve(__dirname, '../../../pacts')],
+      logLevel: 'warn',
+      stateHandlers: {
+        'workers exist': async () => {
+          // State setup handled by test DB seed; no-op in unit mode
+        },
+        'worker with id worker-id-1 exists': async () => {
+          // no-op
+        },
+        'categories exist': async () => {
+          // no-op
+        },
+        'user with email test@example.com exists': async () => {
+          // no-op
+        },
+      },
+    });
+
+    await verifier.verifyProvider();
+  }, 60_000);
+});


### PR DESCRIPTION
- Add consumer contract tests for workers, categories, and auth endpoints
- Add provider verification test with state handlers
- Add contract-tests.yml CI workflow (consumer → provider pipeline)
- Add CONTRACT_TESTING.md documentation

Closes #430

## Description

<!-- A clear and concise description of what this PR does. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Testing Done

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Docs updated (if applicable)
- [ ] No unrelated changes included
