### PR TITLE
feat: implement API response serializers

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -85,8 +85,7 @@
     "supertest": "^7.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.4.0",
-    "vitest": "^1.4.0"
-  }
+    "vitest": "^1.4.0",
     "@stryker-mutator/core": "^8.2.6",
     "@stryker-mutator/vitest-runner": "^8.2.6"
   }

--- a/packages/api/src/controllers/workers.ts
+++ b/packages/api/src/controllers/workers.ts
@@ -3,6 +3,7 @@ import * as workerService from '../services/worker.service.js'
 import { handleError } from '../utils/handleError.js'
 import { db } from '../db.js'
 import { WorkerResource, WorkerCollection } from '../resources/index.js'
+import { workerSerializer } from '../serializers/index.js'
 import type { CreateWorkerBody, UpdateWorkerBody, WorkerQuery } from '../interfaces/index.js'
 import { invalidateCachePattern } from '../middleware/cache.js'
 
@@ -111,7 +112,7 @@ export async function createWorker(req: Request<{}, {}, CreateWorkerBody>, res: 
   try {
     const worker = await workerService.createWorker(req.body, req.user!.id)
     return res.status(201).json({
-      data: WorkerResource(worker as any),
+      data: workerSerializer.serialize(worker as any),
       status: 'success',
       code: 201
     })
@@ -133,7 +134,7 @@ export async function updateWorker(req: Request<{ id: string }, {}, UpdateWorker
     await invalidateCachePattern(`cache:*workers/${req.params.id}*`)
     await invalidateCachePattern(`cache:*workers?*`)
     return res.json({
-      data: WorkerResource(worker as any),
+      data: workerSerializer.serialize(worker as any),
       status: 'success',
       code: 200
     })
@@ -173,7 +174,7 @@ export async function toggleActivation(req: Request, res: Response) {
     await invalidateCachePattern(`cache:*workers/${req.params.id}*`)
     await invalidateCachePattern(`cache:*workers?*`)
     return res.json({
-      data: WorkerResource(updated as any),
+      data: workerSerializer.serialize(updated as any),
       status: 'success',
       code: 200
     })

--- a/packages/api/src/serializers/base.serializer.ts
+++ b/packages/api/src/serializers/base.serializer.ts
@@ -1,0 +1,12 @@
+/**
+ * Base serializer.
+ * Subclasses implement `serialize(record)` to shape a single record.
+ * `collection()` maps an array through `serialize()`.
+ */
+export abstract class BaseSerializer<TInput, TOutput> {
+  abstract serialize(record: TInput): TOutput
+
+  collection(records: TInput[]): TOutput[] {
+    return records.map((r) => this.serialize(r))
+  }
+}

--- a/packages/api/src/serializers/category.serializer.ts
+++ b/packages/api/src/serializers/category.serializer.ts
@@ -1,0 +1,19 @@
+import type { Category } from '@prisma/client'
+import { BaseSerializer } from './base.serializer.js'
+
+export type SerializedCategory = Pick<Category, 'id' | 'name' | 'description' | 'icon' | 'createdAt' | 'updatedAt'>
+
+export class CategorySerializer extends BaseSerializer<Category, SerializedCategory> {
+  serialize(category: Category): SerializedCategory {
+    return {
+      id: category.id,
+      name: category.name,
+      description: category.description,
+      icon: category.icon,
+      createdAt: category.createdAt,
+      updatedAt: category.updatedAt,
+    }
+  }
+}
+
+export const categorySerializer = new CategorySerializer()

--- a/packages/api/src/serializers/index.ts
+++ b/packages/api/src/serializers/index.ts
@@ -1,0 +1,5 @@
+export * from './base.serializer.js'
+export * from './user.serializer.js'
+export * from './category.serializer.js'
+export * from './worker.serializer.js'
+export * from './review.serializer.js'

--- a/packages/api/src/serializers/review.serializer.ts
+++ b/packages/api/src/serializers/review.serializer.ts
@@ -1,0 +1,19 @@
+import type { Review, User } from '@prisma/client'
+import { BaseSerializer } from './base.serializer.js'
+import { userSerializer, type SerializedUser } from './user.serializer.js'
+
+type ReviewWithAuthor = Review & { author?: User | null }
+
+export type SerializedReview = Review & { author?: SerializedUser }
+
+export class ReviewSerializer extends BaseSerializer<ReviewWithAuthor, SerializedReview> {
+  serialize(review: ReviewWithAuthor): SerializedReview {
+    const { author, ...rest } = review
+    return {
+      ...rest,
+      ...(author ? { author: userSerializer.serialize(author) } : {}),
+    }
+  }
+}
+
+export const reviewSerializer = new ReviewSerializer()

--- a/packages/api/src/serializers/serializers.test.ts
+++ b/packages/api/src/serializers/serializers.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { userSerializer } from '../serializers/user.serializer.js'
+import { categorySerializer } from '../serializers/category.serializer.js'
+import { workerSerializer } from '../serializers/worker.serializer.js'
+
+const mockUser: any = {
+  id: 'u1', email: 'a@b.com', firstName: 'Jane', lastName: 'Doe',
+  role: 'user', verified: true, password: 'secret',
+  verificationToken: 'tok', verificationTokenExpiry: new Date(),
+  resetToken: 'rst', resetTokenExpiry: new Date(),
+  twoFactorSecret: 'sec', twoFactorBackupCodes: ['a'],
+  googleId: null, walletAddress: null, avatar: null, bio: null, phone: null,
+  referralCode: null, locationId: null, twoFactorEnabled: false,
+  createdAt: new Date(), updatedAt: new Date(),
+}
+
+const mockCategory: any = {
+  id: 'c1', name: 'Plumber', description: null, icon: null,
+  createdAt: new Date(), updatedAt: new Date(),
+}
+
+const mockWorker: any = {
+  id: 'w1', name: 'Bob', bio: null, avatar: null, phone: null, email: null,
+  walletAddress: null, isActive: true, isVerified: false, stellarContractId: null,
+  searchVector: null, categoryId: 'c1', curatorId: 'u1', locationId: null,
+  createdAt: new Date(), updatedAt: new Date(),
+  category: mockCategory, curator: mockUser,
+}
+
+describe('UserSerializer', () => {
+  it('strips sensitive fields', () => {
+    const result = userSerializer.serialize(mockUser)
+    expect(result).not.toHaveProperty('password')
+    expect(result).not.toHaveProperty('verificationToken')
+    expect(result).not.toHaveProperty('resetToken')
+    expect(result).not.toHaveProperty('twoFactorSecret')
+    expect(result).not.toHaveProperty('twoFactorBackupCodes')
+    expect(result.email).toBe('a@b.com')
+  })
+
+  it('serializes a collection', () => {
+    const results = userSerializer.collection([mockUser, mockUser])
+    expect(results).toHaveLength(2)
+    results.forEach(r => expect(r).not.toHaveProperty('password'))
+  })
+})
+
+describe('CategorySerializer', () => {
+  it('returns expected fields', () => {
+    const result = categorySerializer.serialize(mockCategory)
+    expect(result).toMatchObject({ id: 'c1', name: 'Plumber' })
+  })
+})
+
+describe('WorkerSerializer', () => {
+  it('strips searchVector and nests relations', () => {
+    const result = workerSerializer.serialize(mockWorker)
+    expect(result).not.toHaveProperty('searchVector')
+    expect(result.category).toMatchObject({ id: 'c1', name: 'Plumber' })
+    expect(result.curator).not.toHaveProperty('password')
+    expect(result.curator?.email).toBe('a@b.com')
+  })
+})

--- a/packages/api/src/serializers/user.serializer.ts
+++ b/packages/api/src/serializers/user.serializer.ts
@@ -1,0 +1,22 @@
+import type { User } from '@prisma/client'
+import { BaseSerializer } from './base.serializer.js'
+
+export type SerializedUser = Omit<User, 'password' | 'verificationToken' | 'verificationTokenExpiry' | 'resetToken' | 'resetTokenExpiry' | 'twoFactorSecret' | 'twoFactorBackupCodes'>
+
+export class UserSerializer extends BaseSerializer<User, SerializedUser> {
+  serialize(user: User): SerializedUser {
+    const {
+      password,
+      verificationToken,
+      verificationTokenExpiry,
+      resetToken,
+      resetTokenExpiry,
+      twoFactorSecret,
+      twoFactorBackupCodes,
+      ...safe
+    } = user
+    return safe
+  }
+}
+
+export const userSerializer = new UserSerializer()

--- a/packages/api/src/serializers/worker.serializer.ts
+++ b/packages/api/src/serializers/worker.serializer.ts
@@ -1,0 +1,27 @@
+import type { Worker, Category, User } from '@prisma/client'
+import { BaseSerializer } from './base.serializer.js'
+import { categorySerializer, type SerializedCategory } from './category.serializer.js'
+import { userSerializer, type SerializedUser } from './user.serializer.js'
+
+type WorkerWithRelations = Worker & {
+  category?: Category | null
+  curator?: User | null
+}
+
+export type SerializedWorker = Omit<Worker, 'searchVector'> & {
+  category?: SerializedCategory
+  curator?: SerializedUser
+}
+
+export class WorkerSerializer extends BaseSerializer<WorkerWithRelations, SerializedWorker> {
+  serialize(worker: WorkerWithRelations): SerializedWorker {
+    const { searchVector, category, curator, ...rest } = worker as any
+    return {
+      ...rest,
+      ...(category ? { category: categorySerializer.serialize(category) } : {}),
+      ...(curator  ? { curator:  userSerializer.serialize(curator) }       : {}),
+    }
+  }
+}
+
+export const workerSerializer = new WorkerSerializer()


### PR DESCRIPTION
- Add BaseSerializer abstract class with serialize() and collection() methods
- Add UserSerializer (strips password and all sensitive auth fields)
- Add CategorySerializer (explicit field selection)
- Add WorkerSerializer (strips searchVector, nests category and curator)
- Add ReviewSerializer (nests author via UserSerializer)
- Update workers controller to use workerSerializer instead of WorkerResource
- Fix malformed package.json (stryker deps were outside devDependencies block)
- Add serializer unit tests

Closes #416

## Description

<!-- A clear and concise description of what this PR does. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Testing Done

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Docs updated (if applicable)
- [ ] No unrelated changes included
