### PR TITLE
feat: implement typed event emitter system

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -5,6 +5,7 @@ import passport from './config/passport.js'
 import { redis, cacheMetrics } from './config/redis.js'
 import { db } from './db.js'
 import { requestLogger } from './middleware/requestLogger.js'
+import { registerEventHandlers } from './events/index.js'
 import authRoutes from './routes/auth.js'
 import categoryRoutes from './routes/categories.js'
 import workerRoutes from './routes/workers.js'
@@ -24,6 +25,9 @@ import { versionMiddleware, deprecationWarning } from './middleware/version.js'
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js'
 
 const app = express()
+
+// Register application event handlers
+registerEventHandlers()
 
 // Connect Redis (non-blocking — app starts even if Redis is down)
 redis.connect().catch(() => {})

--- a/packages/api/src/events/app-events.ts
+++ b/packages/api/src/events/app-events.ts
@@ -1,0 +1,32 @@
+import { EventEmitter } from 'node:events'
+import type { AppEvents, AppEventName } from './event-types.js'
+
+/**
+ * Type-safe wrapper around Node's EventEmitter.
+ * Provides `emit`, `on`, and `off` with full payload inference.
+ */
+class AppEventEmitter {
+  private emitter = new EventEmitter()
+
+  on<E extends AppEventName>(event: E, listener: (payload: AppEvents[E]) => void): this {
+    this.emitter.on(event, listener)
+    return this
+  }
+
+  off<E extends AppEventName>(event: E, listener: (payload: AppEvents[E]) => void): this {
+    this.emitter.off(event, listener)
+    return this
+  }
+
+  once<E extends AppEventName>(event: E, listener: (payload: AppEvents[E]) => void): this {
+    this.emitter.once(event, listener)
+    return this
+  }
+
+  emit<E extends AppEventName>(event: E, payload: AppEvents[E]): boolean {
+    return this.emitter.emit(event, payload)
+  }
+}
+
+/** Singleton event bus — import this wherever you need to emit or listen. */
+export const appEvents = new AppEventEmitter()

--- a/packages/api/src/events/event-handlers.ts
+++ b/packages/api/src/events/event-handlers.ts
@@ -1,0 +1,48 @@
+/**
+ * Event handlers — register side-effects for application events.
+ * Call `registerEventHandlers()` once at app startup.
+ */
+import { appEvents } from './app-events.js'
+import logger from '../config/logger.js'
+
+export function registerEventHandlers(): void {
+  appEvents.on('worker.created', ({ workerId, curatorId }) => {
+    logger.info({ workerId, curatorId }, 'worker.created')
+  })
+
+  appEvents.on('worker.updated', ({ workerId }) => {
+    logger.info({ workerId }, 'worker.updated')
+  })
+
+  appEvents.on('worker.deleted', ({ workerId }) => {
+    logger.info({ workerId }, 'worker.deleted')
+  })
+
+  appEvents.on('worker.toggled', ({ workerId, isActive }) => {
+    logger.info({ workerId, isActive }, 'worker.toggled')
+  })
+
+  appEvents.on('user.registered', ({ userId, email }) => {
+    logger.info({ userId, email }, 'user.registered')
+  })
+
+  appEvents.on('user.verified', ({ userId }) => {
+    logger.info({ userId }, 'user.verified')
+  })
+
+  appEvents.on('review.created', ({ reviewId, workerId, rating }) => {
+    logger.info({ reviewId, workerId, rating }, 'review.created')
+  })
+
+  appEvents.on('payment.completed', ({ fromUserId, toWorkerId, amount }) => {
+    logger.info({ fromUserId, toWorkerId, amount }, 'payment.completed')
+  })
+
+  appEvents.on('job.created', ({ jobId, postedById }) => {
+    logger.info({ jobId, postedById }, 'job.created')
+  })
+
+  appEvents.on('job.applied', ({ jobId, workerId }) => {
+    logger.info({ jobId, workerId }, 'job.applied')
+  })
+}

--- a/packages/api/src/events/event-types.ts
+++ b/packages/api/src/events/event-types.ts
@@ -1,0 +1,28 @@
+/**
+ * All application event names and their payload types.
+ * Add new events here to keep the system type-safe.
+ */
+export interface AppEvents {
+  // Worker lifecycle
+  'worker.created':  { workerId: string; curatorId: string }
+  'worker.updated':  { workerId: string; curatorId: string }
+  'worker.deleted':  { workerId: string }
+  'worker.toggled':  { workerId: string; isActive: boolean }
+
+  // User lifecycle
+  'user.registered': { userId: string; email: string }
+  'user.verified':   { userId: string }
+  'user.login':      { userId: string }
+
+  // Reviews
+  'review.created':  { reviewId: string; workerId: string; authorId: string; rating: number }
+
+  // Payments
+  'payment.completed': { fromUserId: string; toWorkerId: string; amount: number; token: string }
+
+  // Jobs
+  'job.created':     { jobId: string; postedById: string }
+  'job.applied':     { jobId: string; workerId: string }
+}
+
+export type AppEventName = keyof AppEvents

--- a/packages/api/src/events/events.test.ts
+++ b/packages/api/src/events/events.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { appEvents } from '../events/app-events.js'
+
+describe('AppEventEmitter', () => {
+  it('emits and receives typed events', () => {
+    const handler = vi.fn()
+    appEvents.on('worker.created', handler)
+    appEvents.emit('worker.created', { workerId: 'w1', curatorId: 'u1' })
+    expect(handler).toHaveBeenCalledWith({ workerId: 'w1', curatorId: 'u1' })
+    appEvents.off('worker.created', handler)
+  })
+
+  it('once() fires only once', () => {
+    const handler = vi.fn()
+    appEvents.once('worker.deleted', handler)
+    appEvents.emit('worker.deleted', { workerId: 'w2' })
+    appEvents.emit('worker.deleted', { workerId: 'w2' })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('off() removes listener', () => {
+    const handler = vi.fn()
+    appEvents.on('worker.toggled', handler)
+    appEvents.off('worker.toggled', handler)
+    appEvents.emit('worker.toggled', { workerId: 'w3', isActive: false })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('supports multiple event types', () => {
+    const workerHandler = vi.fn()
+    const userHandler = vi.fn()
+    appEvents.on('worker.updated', workerHandler)
+    appEvents.on('user.registered', userHandler)
+    appEvents.emit('worker.updated', { workerId: 'w4', curatorId: 'u2' })
+    appEvents.emit('user.registered', { userId: 'u3', email: 'a@b.com' })
+    expect(workerHandler).toHaveBeenCalledOnce()
+    expect(userHandler).toHaveBeenCalledOnce()
+    appEvents.off('worker.updated', workerHandler)
+    appEvents.off('user.registered', userHandler)
+  })
+})

--- a/packages/api/src/events/index.ts
+++ b/packages/api/src/events/index.ts
@@ -1,0 +1,3 @@
+export * from './event-types.js'
+export * from './app-events.js'
+export * from './event-handlers.js'

--- a/packages/api/src/services/worker.service.ts
+++ b/packages/api/src/services/worker.service.ts
@@ -3,6 +3,7 @@ import { AppError } from './AppError.js'
 import { formatWorker } from '../models/worker.model.js'
 import type { CreateWorkerBody, UpdateWorkerBody } from '../interfaces/index.js'
 import { publishEvent } from './webhook.service.js'
+import { appEvents } from '../events/app-events.js'
 
 const workerInclude = { category: true, curator: true } as const
 
@@ -261,18 +262,21 @@ export async function getWorker(id: string) {
 export async function createWorker(data: CreateWorkerBody, curatorId: string) {
   const worker = await db.worker.create({ data: { ...data, curatorId } as any, include: workerInclude })
   publishEvent('worker.created', { worker: formatWorker(worker) }).catch(() => {})
+  appEvents.emit('worker.created', { workerId: worker.id, curatorId })
   return formatWorker(worker)
 }
 
 export async function updateWorker(id: string, data: UpdateWorkerBody) {
   const worker = await db.worker.update({ where: { id }, data: data as any, include: workerInclude })
   publishEvent('worker.updated', { worker: formatWorker(worker) }).catch(() => {})
+  appEvents.emit('worker.updated', { workerId: id, curatorId: worker.curatorId })
   return formatWorker(worker)
 }
 
 export async function deleteWorker(id: string) {
   await db.worker.delete({ where: { id } })
   publishEvent('worker.deleted', { workerId: id }).catch(() => {})
+  appEvents.emit('worker.deleted', { workerId: id })
 }
 
 export async function toggleWorker(id: string) {
@@ -283,5 +287,6 @@ export async function toggleWorker(id: string) {
     data: { isActive: !worker.isActive },
     include: workerInclude,
   })
+  appEvents.emit('worker.toggled', { workerId: id, isActive: updated.isActive })
   return formatWorker(updated)
 }


### PR DESCRIPTION
- Add AppEvents interface with typed event names and payloads
- Add AppEventEmitter class wrapping Node's EventEmitter with type inference
- Export singleton appEvents bus
- Add registerEventHandlers() with log handlers for all events
- Register handlers at app startup in app.ts
- Emit worker.created/updated/deleted/toggled from worker.service.ts
- Add event emitter unit tests

Closes #417

## Description

<!-- A clear and concise description of what this PR does. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Testing Done

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Docs updated (if applicable)
- [ ] No unrelated changes included
