### PR TITLE
feat: add Portuguese i18n support

### DIFF
--- a/packages/app/CONTRIBUTING.md
+++ b/packages/app/CONTRIBUTING.md
@@ -32,6 +32,14 @@ pnpm dev   # starts on :3001
 - Page-level components live in `src/app/` following Next.js App Router conventions
 - Use Tailwind utility classes; avoid inline styles
 
+## Translation Workflow
+
+- Supported locales are defined in `src/lib/i18n.ts`. Add new locales there first so middleware, navigation, and tests stay in sync.
+- User-facing copy belongs in `src/messages/<locale>.json`. Keep matching keys across every locale file.
+- Client components should read copy with `useTranslations`; server components should use `getTranslations`.
+- Use `localizedPath()` or `switchLocalePath()` from `src/lib/i18n.ts` when building internal links or changing language.
+- Run `npm test -- --run src/__tests__/i18n.test.ts src/__tests__/Navbar.test.tsx` after changing translations or locale navigation.
+
 ## Design
 
 Figma design file: [BlueCollar UI Kit](https://www.figma.com/file/bluecollar-ui) *(request access from a maintainer)*

--- a/packages/app/next.config.mjs
+++ b/packages/app/next.config.mjs
@@ -1,6 +1,6 @@
 import createNextIntlPlugin from 'next-intl/plugin'
 
-const withNextIntl = createNextIntlPlugin()
+const withNextIntl = createNextIntlPlugin('./src/i18n.ts')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/packages/app/src/__tests__/Navbar.test.tsx
+++ b/packages/app/src/__tests__/Navbar.test.tsx
@@ -11,8 +11,26 @@ vi.mock('next/link', () => ({
 }))
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/',
+  usePathname: () => '/en',
   useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (key: string) => ({
+    adminAnalytics: 'Admin Analytics',
+    closeMenu: 'Close menu',
+    connectWallet: 'Connect Wallet',
+    connecting: 'Connecting...',
+    dashboard: 'Dashboard',
+    language: 'Language',
+    login: 'Login',
+    logout: 'Logout',
+    openMenu: 'Open menu',
+    profile: 'Profile',
+    register: 'Register',
+    toggleTheme: 'Toggle theme',
+  }[key] ?? key),
 }))
 
 const mockLogout = vi.fn()
@@ -26,6 +44,10 @@ vi.mock('@/hooks/useWallet', () => ({
   useWallet: () => ({ address: null, connecting: false, connect: mockConnect }),
 }))
 
+vi.mock('@/components/NotificationDropdown', () => ({
+  default: () => <button aria-label="Notifications" />,
+}))
+
 // lucide-react stubs
 vi.mock('lucide-react', () => ({
   Menu: () => <span />,
@@ -34,6 +56,8 @@ vi.mock('lucide-react', () => ({
   User: () => <span />,
   Sun: () => <span data-testid="sun-icon" />,
   Moon: () => <span data-testid="moon-icon" />,
+  Globe: () => <span />,
+  X: () => <span />,
 }))
 
 vi.mock('next-themes', () => ({

--- a/packages/app/src/__tests__/i18n.test.ts
+++ b/packages/app/src/__tests__/i18n.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { defaultLocale, isLocale, localizedPath, localeLabels, locales, switchLocalePath } from '@/lib/i18n'
+
+describe('i18n routing helpers', () => {
+  it('includes English and Portuguese locale support', () => {
+    expect(defaultLocale).toBe('en')
+    expect(locales).toContain('en')
+    expect(locales).toContain('pt')
+    expect(localeLabels.pt).toBe('Português')
+  })
+
+  it('validates supported locales', () => {
+    expect(isLocale('pt')).toBe(true)
+    expect(isLocale('de')).toBe(false)
+  })
+
+  it('builds locale-prefixed paths', () => {
+    expect(localizedPath('/', 'pt')).toBe('/pt')
+    expect(localizedPath('/workers', 'pt')).toBe('/pt/workers')
+  })
+
+  it('switches the locale segment while preserving the route', () => {
+    expect(switchLocalePath('/en/workers?category=plumber', 'en', 'pt')).toBe('/pt/workers?category=plumber')
+    expect(switchLocalePath('/en', 'en', 'pt')).toBe('/pt')
+  })
+})

--- a/packages/app/src/app/[locale]/workers/page.tsx
+++ b/packages/app/src/app/[locale]/workers/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getLocale, getTranslations } from "next-intl/server";
 import WorkerInfiniteList from "@/components/WorkerInfiniteList";
+import SearchAutocomplete from "@/components/SearchAutocomplete";
+import { localizedPath } from "@/lib/i18n";
 import type { Worker, Category, ApiResponse } from "@/types";
 
 export const metadata: Metadata = {
@@ -41,9 +44,18 @@ interface PageProps {
   }
 }
 
-const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-
 export default async function WorkersPage({ searchParams }: PageProps) {
+  const locale = await getLocale()
+  const t = await getTranslations('workers.page')
+  const days = [
+    t('days.sun'),
+    t('days.mon'),
+    t('days.tue'),
+    t('days.wed'),
+    t('days.thu'),
+    t('days.fri'),
+    t('days.sat'),
+  ]
   const page = searchParams.page ?? "1"
   const params: Record<string, string> = { page, limit: "20" }
   if (searchParams.category) params.category = searchParams.category
@@ -60,7 +72,7 @@ export default async function WorkersPage({ searchParams }: PageProps) {
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-10">
-      <h1 className="mb-8 text-2xl font-bold text-gray-800">Browse Workers</h1>
+      <h1 className="mb-8 text-2xl font-bold text-gray-800">{t('title')}</h1>
 
       <div className="flex flex-col gap-8 lg:flex-row">
         {/* Sidebar filters */}
@@ -68,21 +80,21 @@ export default async function WorkersPage({ searchParams }: PageProps) {
           <form className="flex flex-col gap-6 rounded-xl border bg-white p-5 shadow-sm">
             {/* Search */}
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-700">Search</label>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">{t('search')}</label>
               <SearchAutocomplete
                 name="search"
                 defaultValue={searchParams.search ?? ""}
-                placeholder="Worker name…"
+                placeholder={t('searchPlaceholder')}
               />
             </div>
 
             {/* Location */}
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-700">Location</label>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">{t('location')}</label>
               <input
                 name="location"
                 defaultValue={searchParams.location ?? ""}
-                placeholder="City or area…"
+                placeholder={t('locationPlaceholder')}
                 className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
               />
             </div>
@@ -90,16 +102,16 @@ export default async function WorkersPage({ searchParams }: PageProps) {
             {/* Min Rating */}
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700">
-                Min Rating
+                {t('minRating')}
               </label>
               <select
                 name="minRating"
                 defaultValue={searchParams.minRating ?? ""}
                 className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="">Any</option>
+                <option value="">{t('any')}</option>
                 {[1, 2, 3, 4, 5].map((r) => (
-                  <option key={r} value={r}>{"★".repeat(r)} {r}+</option>
+                  <option key={r} value={r}>{"★".repeat(r)} {t('ratingOption', { rating: r })}</option>
                 ))}
               </select>
             </div>
@@ -107,15 +119,15 @@ export default async function WorkersPage({ searchParams }: PageProps) {
             {/* Availability */}
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700">
-                Available On
+                {t('availableOn')}
               </label>
               <select
                 name="available"
                 defaultValue={searchParams.available ?? ""}
                 className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="">Any day</option>
-                {DAYS.map((d, i) => (
+                <option value="">{t('anyDay')}</option>
+                {days.map((d, i) => (
                   <option key={i} value={i}>{d}</option>
                 ))}
               </select>
@@ -124,27 +136,27 @@ export default async function WorkersPage({ searchParams }: PageProps) {
             {/* Listed Since (experience proxy) */}
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700">
-                Listed Within
+                {t('listedWithin')}
               </label>
               <select
                 name="listedSince"
                 defaultValue={searchParams.listedSince ?? ""}
                 className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="">Any time</option>
-                <option value="1">Last year</option>
-                <option value="2">Last 2 years</option>
-                <option value="5">Last 5 years</option>
+                <option value="">{t('anyTime')}</option>
+                <option value="1">{t('lastYear')}</option>
+                <option value="2">{t('lastYears', { count: 2 })}</option>
+                <option value="5">{t('lastYears', { count: 5 })}</option>
               </select>
             </div>
 
             {/* Categories */}
             <div>
-              <p className="mb-2 text-sm font-medium text-gray-700">Category</p>
+              <p className="mb-2 text-sm font-medium text-gray-700">{t('category')}</p>
               <div className="flex flex-col gap-2">
                 <label className="flex items-center gap-2 text-sm text-gray-600">
                   <input type="radio" name="category" value="" defaultChecked={!searchParams.category} />
-                  All
+                  {t('all')}
                 </label>
                 {categories.map((c) => (
                   <label key={c.id} className="flex items-center gap-2 text-sm text-gray-600">
@@ -164,13 +176,13 @@ export default async function WorkersPage({ searchParams }: PageProps) {
               type="submit"
               className="rounded-md bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700"
             >
-              Apply Filters
+              {t('applyFilters')}
             </button>
             <Link
-              href="/workers"
+              href={localizedPath('/workers', locale)}
               className="text-center text-xs text-gray-400 hover:text-gray-600"
             >
-              Clear all
+              {t('clearAll')}
             </Link>
           </form>
         </aside>

--- a/packages/app/src/components/BottomNav.tsx
+++ b/packages/app/src/components/BottomNav.tsx
@@ -3,27 +3,35 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Home, Users, Info, LayoutDashboard, User, Settings } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
 import { useAuth } from "@/hooks/useAuth";
 import { cn } from "@/lib/utils";
+import { localizedPath } from "@/lib/i18n";
 
 const BASE_LINKS = [
-  { href: "/", label: "Home", icon: Home },
-  { href: "/workers", label: "Workers", icon: Users },
-  { href: "/about", label: "About", icon: Info },
+  { href: "/", labelKey: "home", icon: Home },
+  { href: "/workers", labelKey: "workers", icon: Users },
+  { href: "/about", labelKey: "about", icon: Info },
 ];
 
 export default function BottomNav() {
   const pathname = usePathname();
+  const locale = useLocale();
+  const t = useTranslations("common");
   const { user } = useAuth();
 
   const links = [
-    ...BASE_LINKS,
+    ...BASE_LINKS.map((link) => ({
+      href: localizedPath(link.href, locale),
+      label: t(link.labelKey),
+      icon: link.icon,
+    })),
     ...(user
       ? [
-          { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-          { href: "/dashboard/settings", label: "Settings", icon: Settings },
+          { href: localizedPath("/dashboard", locale), label: t("dashboard"), icon: LayoutDashboard },
+          { href: localizedPath("/dashboard/settings", locale), label: t("settings"), icon: Settings },
         ]
-      : [{ href: "/auth/login", label: "Account", icon: User }]),
+      : [{ href: localizedPath("/auth/login", locale), label: t("account"), icon: User }]),
   ];
 
   return (

--- a/packages/app/src/components/Footer.tsx
+++ b/packages/app/src/components/Footer.tsx
@@ -1,16 +1,6 @@
 import Link from "next/link";
-
-const LINKS = {
-  quick: [
-    { href: "/workers", label: "Workers" },
-    { href: "/categories", label: "Categories" },
-    { href: "/how-it-works", label: "How It Works" },
-  ],
-  legal: [
-    { href: "/privacy", label: "Privacy Policy" },
-    { href: "/terms", label: "Terms of Service" },
-  ],
-};
+import { getLocale, getTranslations } from "next-intl/server";
+import { localizedPath } from "@/lib/i18n";
 
 function GithubIcon() {
   return (
@@ -28,7 +18,22 @@ function TelegramIcon() {
   );
 }
 
-export default function Footer() {
+export default async function Footer() {
+  const locale = await getLocale();
+  const common = await getTranslations("common");
+  const footer = await getTranslations("footer");
+  const links = {
+    quick: [
+      { href: "/workers", label: common("workers") },
+      { href: "/categories", label: footer("categories") },
+      { href: "/how-it-works", label: footer("howItWorks") },
+    ],
+    legal: [
+      { href: "/privacy", label: footer("privacyPolicy") },
+      { href: "/terms", label: footer("termsOfService") },
+    ],
+  };
+
   return (
     <footer className="border-t bg-gray-50 dark:bg-gray-900 dark:border-gray-800 mt-auto">
       <div className="mx-auto max-w-7xl px-4 py-12">
@@ -37,18 +42,17 @@ export default function Footer() {
           <div className="flex flex-col gap-3">
             <span className="text-lg font-bold text-blue-600">BlueCollar</span>
             <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
-              Find skilled workers near you. A decentralised protocol connecting
-              local tradespeople with the communities that need them.
+              {footer("description")}
             </p>
           </div>
 
           {/* Quick Links */}
           <div>
-            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Quick Links</h3>
+            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">{footer("quickLinks")}</h3>
             <ul className="flex flex-col gap-2">
-              {LINKS.quick.map((l) => (
+              {links.quick.map((l) => (
                 <li key={l.href}>
-                  <Link href={l.href} className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">
+                  <Link href={localizedPath(l.href, locale)} className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">
                     {l.label}
                   </Link>
                 </li>
@@ -58,11 +62,11 @@ export default function Footer() {
 
           {/* Legal */}
           <div>
-            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Legal</h3>
+            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">{footer("legal")}</h3>
             <ul className="flex flex-col gap-2">
-              {LINKS.legal.map((l) => (
+              {links.legal.map((l) => (
                 <li key={l.href}>
-                  <Link href={l.href} className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">
+                  <Link href={localizedPath(l.href, locale)} className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">
                     {l.label}
                   </Link>
                 </li>
@@ -72,7 +76,7 @@ export default function Footer() {
 
           {/* Social */}
           <div>
-            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Community</h3>
+            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">{footer("community")}</h3>
             <div className="flex gap-4">
               <a
                 href="https://t.me/bluecollar"
@@ -97,7 +101,7 @@ export default function Footer() {
         </div>
 
         <div className="mt-10 border-t dark:border-gray-800 pt-6 text-center text-xs text-gray-400">
-          © {new Date().getFullYear()} BlueCollar. All rights reserved.
+          © {new Date().getFullYear()} BlueCollar. {footer("rights")}
         </div>
       </div>
     </footer>

--- a/packages/app/src/components/LanguageSwitcher.tsx
+++ b/packages/app/src/components/LanguageSwitcher.tsx
@@ -1,5 +1,8 @@
+"use client"
+
 import { useLocale } from 'next-intl'
 import { useRouter, usePathname } from 'next/navigation'
+import { localeLabels, locales, switchLocalePath } from '@/lib/i18n'
 import { Button } from './ui/button'
 
 export function LanguageSwitcher() {
@@ -7,27 +10,20 @@ export function LanguageSwitcher() {
   const router = useRouter()
   const pathname = usePathname()
 
-  const languages = [
-    { code: 'en', label: 'English' },
-    { code: 'fr', label: 'Français' },
-    { code: 'es', label: 'Español' }
-  ]
-
   const handleLanguageChange = (newLocale: string) => {
-    const newPathname = pathname.replace(`/${locale}`, `/${newLocale}`)
-    router.push(newPathname)
+    router.push(switchLocalePath(pathname, locale, newLocale))
   }
 
   return (
     <div className="flex gap-2">
-      {languages.map(lang => (
+      {locales.map(code => (
         <Button
-          key={lang.code}
-          variant={locale === lang.code ? 'default' : 'outline'}
+          key={code}
+          variant={locale === code ? 'default' : 'outline'}
           size="sm"
-          onClick={() => handleLanguageChange(lang.code)}
+          onClick={() => handleLanguageChange(code)}
         >
-          {lang.label}
+          {localeLabels[code]}
         </Button>
       ))}
     </div>

--- a/packages/app/src/components/Navbar.tsx
+++ b/packages/app/src/components/Navbar.tsx
@@ -8,25 +8,20 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { useTheme } from "next-themes";
 import { useAuth } from "@/hooks/useAuth";
 import { useWallet } from "@/hooks/useWallet";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
+import { localeLabels, locales, localizedPath, switchLocalePath } from "@/lib/i18n";
 import NotificationDropdown from "@/components/NotificationDropdown";
 
 const NAV_LINKS = [
-  { href: "/", label: "Home" },
-  { href: "/workers", label: "Workers" },
-  { href: "/about", label: "About" },
-];
-
-const LANGUAGES = [
-  { code: "en", label: "English" },
-  { code: "fr", label: "Français" },
-  { code: "es", label: "Español" },
+  { href: "/", labelKey: "home" },
+  { href: "/workers", labelKey: "workers" },
+  { href: "/about", labelKey: "about" },
 ];
 
 function NavLink({ href, label, onClick }: { href: string; label: string; onClick?: () => void }) {
   const pathname = usePathname();
-  const isActive = pathname === href || (href !== "/" && pathname.startsWith(href));
+  const isActive = pathname === href || (href !== "/" && pathname.startsWith(`${href}/`));
   return (
     <Link
       href={href}
@@ -48,6 +43,7 @@ function NavLink({ href, label, onClick }: { href: string; label: string; onClic
 
 function ThemeToggle({ className }: { className?: string }) {
   const { resolvedTheme, setTheme } = useTheme();
+  const t = useTranslations("common");
   return (
     <button
       onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
@@ -55,7 +51,7 @@ function ThemeToggle({ className }: { className?: string }) {
         "rounded-md p-2 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800 min-w-[40px] min-h-[40px] flex items-center justify-center",
         className
       )}
-      aria-label="Toggle theme"
+      aria-label={t("toggleTheme")}
     >
       {resolvedTheme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
     </button>
@@ -65,6 +61,7 @@ function ThemeToggle({ className }: { className?: string }) {
 export default function Navbar() {
   const { user, logout } = useAuth();
   const { address, connecting, connect } = useWallet();
+  const t = useTranslations("common");
   const router = useRouter();
   const locale = useLocale();
   const pathname = usePathname();
@@ -76,19 +73,27 @@ export default function Navbar() {
   // Swipe-to-close gesture
   const touchStartX = useRef<number | null>(null);
   const handleTouchStart = (e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0].clientX;
+    const touch = e.touches[0];
+    if (!touch) return;
+    touchStartX.current = touch.clientX;
   };
   const handleTouchEnd = (e: React.TouchEvent) => {
     if (touchStartX.current === null) return;
-    const delta = e.changedTouches[0].clientX - touchStartX.current;
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    const delta = touch.clientX - touchStartX.current;
     if (delta > 60) setMobileOpen(false); // swipe right to close
     touchStartX.current = null;
   };
 
   const shortAddress = address ? `${address.slice(0, 4)}…${address.slice(-4)}` : null;
+  const navLinks = NAV_LINKS.map((link) => ({
+    href: localizedPath(link.href, locale),
+    label: t(link.labelKey),
+  }));
 
   const handleLanguageChange = (newLocale: string) => {
-    router.push(pathname.replace(`/${locale}`, `/${newLocale}`));
+    router.push(switchLocalePath(pathname, locale, newLocale));
     setMobileOpen(false);
   };
 
@@ -97,13 +102,13 @@ export default function Navbar() {
       <nav className="sticky top-0 z-50 w-full border-b bg-white/90 backdrop-blur dark:bg-gray-900/90 dark:border-gray-800">
         <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
           {/* Brand */}
-          <Link href="/" className="text-xl font-bold text-blue-600">
+          <Link href={localizedPath("/", locale)} className="text-xl font-bold text-blue-600">
             BlueCollar
           </Link>
 
           {/* Desktop nav */}
           <div className="hidden items-center gap-6 md:flex">
-            {NAV_LINKS.map((l) => <NavLink key={l.href} {...l} />)}
+            {navLinks.map((l) => <NavLink key={l.href} {...l} />)}
           </div>
 
           {/* Desktop actions */}
@@ -121,9 +126,9 @@ export default function Navbar() {
               </DropdownMenu.Trigger>
               <DropdownMenu.Portal>
                 <DropdownMenu.Content align="end" sideOffset={6} className="z-50 min-w-[120px] rounded-md border bg-white p-1 shadow-md text-sm dark:bg-gray-900 dark:border-gray-700">
-                  {LANGUAGES.map((lang) => (
-                    <DropdownMenu.Item key={lang.code} onSelect={() => handleLanguageChange(lang.code)} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">
-                      {lang.label}
+                  {locales.map((code) => (
+                    <DropdownMenu.Item key={code} onSelect={() => handleLanguageChange(code)} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">
+                      {localeLabels[code]}
                     </DropdownMenu.Item>
                   ))}
                 </DropdownMenu.Content>
@@ -133,7 +138,7 @@ export default function Navbar() {
             {/* Wallet */}
             <button onClick={connect} disabled={connecting} className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200">
               <Wallet size={15} />
-              {shortAddress ?? (connecting ? "Connecting…" : "Connect Wallet")}
+              {shortAddress ?? (connecting ? t("connecting") : t("connectWallet"))}
             </button>
 
             {/* Auth */}
@@ -148,22 +153,22 @@ export default function Navbar() {
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Portal>
                   <DropdownMenu.Content align="end" sideOffset={6} className="z-50 min-w-[160px] rounded-md border bg-white p-1 shadow-md text-sm dark:bg-gray-900 dark:border-gray-700">
-                    <DropdownMenu.Item onSelect={() => router.push("/profile")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">Profile</DropdownMenu.Item>
+                    <DropdownMenu.Item onSelect={() => router.push(localizedPath("/profile", locale))} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">{t("profile")}</DropdownMenu.Item>
                     {(user.role === "curator" || user.role === "admin") && (
-                      <DropdownMenu.Item onSelect={() => router.push("/dashboard")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">Dashboard</DropdownMenu.Item>
+                      <DropdownMenu.Item onSelect={() => router.push(localizedPath("/dashboard", locale))} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">{t("dashboard")}</DropdownMenu.Item>
                     )}
                     {user.role === "admin" && (
-                      <DropdownMenu.Item onSelect={() => router.push("/dashboard/admin")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">Admin Analytics</DropdownMenu.Item>
+                      <DropdownMenu.Item onSelect={() => router.push(localizedPath("/dashboard/admin", locale))} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">{t("adminAnalytics")}</DropdownMenu.Item>
                     )}
                     <DropdownMenu.Separator className="my-1 h-px bg-gray-100 dark:bg-gray-700" />
-                    <DropdownMenu.Item onSelect={logout} className="cursor-pointer rounded px-3 py-2 text-red-600 hover:bg-red-50 outline-none dark:hover:bg-red-950">Logout</DropdownMenu.Item>
+                    <DropdownMenu.Item onSelect={logout} className="cursor-pointer rounded px-3 py-2 text-red-600 hover:bg-red-50 outline-none dark:hover:bg-red-950">{t("logout")}</DropdownMenu.Item>
                   </DropdownMenu.Content>
                 </DropdownMenu.Portal>
               </DropdownMenu.Root>
             ) : (
               <>
-                <Link href="/auth/login" className="rounded-md px-3 py-1.5 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200">Login</Link>
-                <Link href="/auth/register" className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700">Register</Link>
+                <Link href={localizedPath("/auth/login", locale)} className="rounded-md px-3 py-1.5 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200">{t("login")}</Link>
+                <Link href={localizedPath("/auth/register", locale)} className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700">{t("register")}</Link>
               </>
             )}
           </div>
@@ -172,7 +177,7 @@ export default function Navbar() {
           <button
             className="md:hidden flex items-center justify-center rounded-md p-2 min-w-[44px] min-h-[44px] hover:bg-gray-100 dark:hover:bg-gray-800"
             onClick={() => setMobileOpen(true)}
-            aria-label="Open menu"
+            aria-label={t("openMenu")}
           >
             <Menu size={22} />
           </button>
@@ -201,7 +206,7 @@ export default function Navbar() {
                 <button
                   onClick={() => setMobileOpen(false)}
                   className="flex items-center justify-center rounded-md p-2 min-w-[44px] min-h-[44px] text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
-                  aria-label="Close menu"
+                  aria-label={t("closeMenu")}
                 >
                   <X size={20} />
                 </button>
@@ -211,7 +216,7 @@ export default function Navbar() {
             {/* Scrollable content */}
             <div className="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-1">
               {/* Nav links — large touch targets with active indicator */}
-              {NAV_LINKS.map(({ href, label }) => {
+              {navLinks.map(({ href, label }) => {
                 const isActive = pathname === href || (href !== "/" && pathname.startsWith(href));
                 return (
                   <Link
@@ -234,20 +239,20 @@ export default function Navbar() {
               <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" />
 
               {/* Language */}
-              <p className="px-4 py-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Language</p>
-              {LANGUAGES.map((lang) => (
+              <p className="px-4 py-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">{t("language")}</p>
+              {locales.map((code) => (
                 <button
-                  key={lang.code}
-                  onClick={() => handleLanguageChange(lang.code)}
+                  key={code}
+                  onClick={() => handleLanguageChange(code)}
                   className={cn(
                     "flex items-center gap-3 rounded-lg px-4 py-3 text-sm text-left min-h-[48px] w-full transition-colors",
-                    locale === lang.code
+                    locale === code
                       ? "bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-400"
                       : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
                   )}
                 >
-                  {locale === lang.code && <span className="h-1.5 w-1.5 rounded-full bg-blue-600 dark:bg-blue-400 shrink-0" />}
-                  {lang.label}
+                  {locale === code && <span className="h-1.5 w-1.5 rounded-full bg-blue-600 dark:bg-blue-400 shrink-0" />}
+                  {localeLabels[code]}
                 </button>
               ))}
 
@@ -260,7 +265,7 @@ export default function Navbar() {
                 className="flex items-center gap-3 rounded-lg border px-4 py-3 text-sm font-medium min-h-[48px] hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors"
               >
                 <Wallet size={16} />
-                {shortAddress ?? (connecting ? "Connecting…" : "Connect Wallet")}
+                {shortAddress ?? (connecting ? t("connecting") : t("connectWallet"))}
               </button>
 
               <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" />
@@ -268,31 +273,31 @@ export default function Navbar() {
               {/* Auth */}
               {user ? (
                 <>
-                  <Link href="/profile" onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
+                  <Link href={localizedPath("/profile", locale)} onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
                     <User size={16} className="text-gray-400" />
-                    Profile
+                    {t("profile")}
                   </Link>
                   {(user.role === "curator" || user.role === "admin") && (
-                    <Link href="/dashboard" onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
-                      Dashboard
+                    <Link href={localizedPath("/dashboard", locale)} onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
+                      {t("dashboard")}
                     </Link>
                   )}
                   {user.role === "admin" && (
-                    <Link href="/dashboard/admin" onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
-                      Admin Analytics
+                    <Link href={localizedPath("/dashboard/admin", locale)} onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
+                      {t("adminAnalytics")}
                     </Link>
                   )}
                   <button onClick={() => { logout(); setMobileOpen(false); }} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors w-full text-left">
-                    Logout
+                    {t("logout")}
                   </button>
                 </>
               ) : (
                 <div className="flex flex-col gap-2 pt-1">
-                  <Link href="/auth/login" onClick={() => setMobileOpen(false)} className="rounded-lg border px-4 py-3 text-center text-sm font-medium min-h-[48px] hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
-                    Login
+                  <Link href={localizedPath("/auth/login", locale)} onClick={() => setMobileOpen(false)} className="rounded-lg border px-4 py-3 text-center text-sm font-medium min-h-[48px] hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
+                    {t("login")}
                   </Link>
-                  <Link href="/auth/register" onClick={() => setMobileOpen(false)} className="rounded-lg bg-blue-600 px-4 py-3 text-center text-sm font-medium min-h-[48px] text-white hover:bg-blue-700 transition-colors">
-                    Register
+                  <Link href={localizedPath("/auth/register", locale)} onClick={() => setMobileOpen(false)} className="rounded-lg bg-blue-600 px-4 py-3 text-center text-sm font-medium min-h-[48px] text-white hover:bg-blue-700 transition-colors">
+                    {t("register")}
                   </Link>
                 </div>
               )}

--- a/packages/app/src/features/landing-page/Categories.tsx
+++ b/packages/app/src/features/landing-page/Categories.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+import { getLocale, getTranslations } from 'next-intl/server'
+import { localizedPath } from '@/lib/i18n'
 
 interface Category {
   id: string
@@ -17,17 +19,19 @@ async function getCategories(): Promise<Category[]> {
 }
 
 export default async function Categories() {
+  const locale = await getLocale()
+  const t = await getTranslations('homePage.categories')
   const categories = await getCategories()
 
   return (
     <section>
-      <h2>Browse by Category</h2>
+      <h2>{t('title')}</h2>
       <div className="categories-grid">
         {categories.map((cat) => (
-          <Link key={cat.id} href={`/workers?category=${cat.id}`} className="category-card">
+          <Link key={cat.id} href={`${localizedPath('/workers', locale)}?category=${cat.id}`} className="category-card">
             {cat.icon && <span className="category-icon">{cat.icon}</span>}
             <span className="category-name">{cat.name}</span>
-            <span className="category-badge">{cat._count.workers} workers</span>
+            <span className="category-badge">{t('workerCount', { count: cat._count.workers })}</span>
           </Link>
         ))}
       </div>

--- a/packages/app/src/features/landing-page/FeaturedWorkers.tsx
+++ b/packages/app/src/features/landing-page/FeaturedWorkers.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import { getLocale, getTranslations } from 'next-intl/server'
+import { localizedPath } from '@/lib/i18n'
 
 interface Worker {
   id: string
@@ -40,14 +42,16 @@ export function FeaturedWorkersSkeleton() {
 }
 
 export default async function FeaturedWorkers() {
+  const locale = await getLocale()
+  const t = await getTranslations('homePage.featuredWorkers')
   const workers = await getFeaturedWorkers()
 
   return (
     <section className="px-4 py-16 max-w-6xl mx-auto">
-      <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">Featured Workers</h2>
+      <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">{t('title')}</h2>
 
       {workers.length === 0 ? (
-        <p className="mt-6 text-gray-500">No workers available yet. Check back soon.</p>
+        <p className="mt-6 text-gray-500">{t('noWorkers')}</p>
       ) : (
         <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {workers.map((worker) => (
@@ -74,10 +78,10 @@ export default async function FeaturedWorkers() {
                 </div>
               </div>
               <Link
-                href={`/workers/${worker.id}`}
+                href={localizedPath(`/workers/${worker.id}`, locale)}
                 className="mt-auto text-center rounded-lg border border-blue-700 text-blue-700 font-medium py-2 hover:bg-blue-50 transition-colors"
               >
-                View Profile
+                {t('viewProfile')}
               </Link>
             </div>
           ))}
@@ -86,10 +90,10 @@ export default async function FeaturedWorkers() {
 
       <div className="mt-10 text-center">
         <Link
-          href="/workers"
+          href={localizedPath('/workers', locale)}
           className="inline-block rounded-lg bg-blue-700 text-white font-semibold px-8 py-3 hover:bg-blue-800 transition-colors"
         >
-          See All Workers
+          {t('seeAll')}
         </Link>
       </div>
     </section>

--- a/packages/app/src/features/landing-page/Hero.tsx
+++ b/packages/app/src/features/landing-page/Hero.tsx
@@ -1,10 +1,14 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import { useLocale, useTranslations } from 'next-intl'
 import { useState } from 'react'
+import { localizedPath } from '@/lib/i18n'
 
 export default function Hero() {
   const router = useRouter()
+  const locale = useLocale()
+  const t = useTranslations('homePage.hero')
   const [category, setCategory] = useState('')
   const [location, setLocation] = useState('')
 
@@ -13,16 +17,17 @@ export default function Hero() {
     const params = new URLSearchParams()
     if (category) params.set('category', category)
     if (location) params.set('location', location)
-    router.push(`/workers?${params.toString()}`)
+    const query = params.toString()
+    router.push(`${localizedPath('/workers', locale)}${query ? `?${query}` : ''}`)
   }
 
   return (
     <section className="bg-blue-700 text-white px-4 py-20 text-center">
       <h1 className="text-3xl font-bold leading-tight sm:text-5xl">
-        Find Skilled Workers Near You
+        {t('title')}
       </h1>
       <p className="mt-4 text-lg text-blue-100 sm:text-xl max-w-xl mx-auto">
-        Connect with trusted local tradespeople — plumbers, electricians, carpenters, and more.
+        {t('description')}
       </p>
 
       <form
@@ -31,14 +36,14 @@ export default function Hero() {
       >
         <input
           type="text"
-          placeholder="Category (e.g. Plumber)"
+          placeholder={t('categoryPlaceholder')}
           value={category}
           onChange={(e) => setCategory(e.target.value)}
           className="flex-1 rounded-lg px-4 py-3 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
         />
         <input
           type="text"
-          placeholder="Location (e.g. Lagos)"
+          placeholder={t('locationPlaceholder')}
           value={location}
           onChange={(e) => setLocation(e.target.value)}
           className="flex-1 rounded-lg px-4 py-3 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
@@ -47,7 +52,7 @@ export default function Hero() {
           type="submit"
           className="rounded-lg bg-white text-blue-700 font-semibold px-6 py-3 hover:bg-blue-50 transition-colors"
         >
-          Browse Workers
+          {t('browseWorkers')}
         </button>
       </form>
     </section>

--- a/packages/app/src/features/landing-page/HowItWorks.tsx
+++ b/packages/app/src/features/landing-page/HowItWorks.tsx
@@ -1,26 +1,15 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
 
-const steps = [
-  {
-    icon: '🔍',
-    title: 'Search for a Skill',
-    description: 'Browse categories or search by skill and location to find the right tradesperson.',
-  },
-  {
-    icon: '✅',
-    title: 'Find a Verified Worker',
-    description: 'Every listing is community-curated and anchored on-chain for transparency.',
-  },
-  {
-    icon: '⛓️',
-    title: 'Pay Securely On-Chain',
-    description: 'Send tips and payments directly to workers via Stellar — no middlemen.',
-  },
-]
+interface StepData {
+  icon: string
+  title: string
+  description: string
+}
 
-function Step({ icon, title, description, index }: (typeof steps)[0] & { index: number }) {
+function Step({ icon, title, description, index }: StepData & { index: number }) {
   const ref = useRef<HTMLDivElement>(null)
   const [visible, setVisible] = useState(false)
 
@@ -28,7 +17,7 @@ function Step({ icon, title, description, index }: (typeof steps)[0] & { index: 
     const el = ref.current
     if (!el) return
     const observer = new IntersectionObserver(
-      ([entry]) => { if (entry.isIntersecting) { setVisible(true); observer.disconnect() } },
+      ([entry]) => { if (entry?.isIntersecting) { setVisible(true); observer.disconnect() } },
       { threshold: 0.2 }
     )
     observer.observe(el)
@@ -50,10 +39,29 @@ function Step({ icon, title, description, index }: (typeof steps)[0] & { index: 
 }
 
 export default function HowItWorks() {
+  const t = useTranslations('homePage.howItWorks')
+  const steps = [
+    {
+      icon: '🔍',
+      title: t('steps.search.title'),
+      description: t('steps.search.description'),
+    },
+    {
+      icon: '✅',
+      title: t('steps.verified.title'),
+      description: t('steps.verified.description'),
+    },
+    {
+      icon: '⛓️',
+      title: t('steps.pay.title'),
+      description: t('steps.pay.description'),
+    },
+  ]
+
   return (
     <section className="px-4 py-16 bg-gray-50 dark:bg-gray-950">
       <div className="max-w-4xl mx-auto">
-        <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 sm:text-3xl">How It Works</h2>
+        <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 sm:text-3xl">{t('title')}</h2>
         <div className="mt-12 grid gap-10 sm:grid-cols-3">
           {steps.map((step, i) => (
             <Step key={step.title} {...step} index={i} />

--- a/packages/app/src/i18n.ts
+++ b/packages/app/src/i18n.ts
@@ -1,5 +1,11 @@
 import { getRequestConfig } from 'next-intl/server'
+import { defaultLocale, isLocale } from './lib/i18n'
 
-export default getRequestConfig(async ({ locale }) => ({
-  messages: (await import(`./messages/${locale}.json`)).default
-}))
+export default getRequestConfig(async ({ locale }) => {
+  const activeLocale = locale && isLocale(locale) ? locale : defaultLocale
+
+  return {
+    locale: activeLocale,
+    messages: (await import(`./messages/${activeLocale}.json`)).default
+  }
+})

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -1,0 +1,38 @@
+export const locales = ["en", "pt", "fr", "es"] as const;
+
+export type Locale = (typeof locales)[number];
+
+export const defaultLocale: Locale = "en";
+
+export const localeLabels: Record<Locale, string> = {
+  en: "English",
+  pt: "Português",
+  fr: "Français",
+  es: "Español",
+};
+
+export function isLocale(value: string): value is Locale {
+  return locales.includes(value as Locale);
+}
+
+export function localizedPath(path: string, locale: string) {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  if (normalizedPath === "/") {
+    return `/${locale}`;
+  }
+
+  return `/${locale}${normalizedPath}`;
+}
+
+export function switchLocalePath(pathname: string, currentLocale: string, nextLocale: string) {
+  if (pathname === `/${currentLocale}`) {
+    return `/${nextLocale}`;
+  }
+
+  if (pathname.startsWith(`/${currentLocale}/`)) {
+    return pathname.replace(`/${currentLocale}`, `/${nextLocale}`);
+  }
+
+  return localizedPath(pathname, nextLocale);
+}

--- a/packages/app/src/messages/en.json
+++ b/packages/app/src/messages/en.json
@@ -4,6 +4,8 @@
     "about": "About",
     "workers": "Workers",
     "dashboard": "Dashboard",
+    "settings": "Settings",
+    "account": "Account",
     "logout": "Logout",
     "login": "Login",
     "register": "Register",
@@ -16,7 +18,51 @@
     "save": "Save",
     "delete": "Delete",
     "edit": "Edit",
-    "back": "Back"
+    "back": "Back",
+    "profile": "Profile",
+    "adminAnalytics": "Admin Analytics",
+    "connectWallet": "Connect Wallet",
+    "connecting": "Connecting...",
+    "language": "Language",
+    "toggleTheme": "Toggle theme",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu"
+  },
+  "homePage": {
+    "hero": {
+      "title": "Find Skilled Workers Near You",
+      "description": "Connect with trusted local tradespeople — plumbers, electricians, carpenters, and more.",
+      "categoryPlaceholder": "Category (e.g. Plumber)",
+      "locationPlaceholder": "Location (e.g. Lagos)",
+      "browseWorkers": "Browse Workers"
+    },
+    "categories": {
+      "title": "Browse by Category",
+      "workerCount": "{count, plural, one {# worker} other {# workers}}"
+    },
+    "howItWorks": {
+      "title": "How It Works",
+      "steps": {
+        "search": {
+          "title": "Search for a Skill",
+          "description": "Browse categories or search by skill and location to find the right tradesperson."
+        },
+        "verified": {
+          "title": "Find a Verified Worker",
+          "description": "Every listing is community-curated and anchored on-chain for transparency."
+        },
+        "pay": {
+          "title": "Pay Securely On-Chain",
+          "description": "Send tips and payments directly to workers via Stellar — no middlemen."
+        }
+      }
+    },
+    "featuredWorkers": {
+      "title": "Featured Workers",
+      "noWorkers": "No workers available yet. Check back soon.",
+      "viewProfile": "View Profile",
+      "seeAll": "See All Workers"
+    }
   },
   "workers": {
     "title": "Find Skilled Workers",
@@ -26,7 +72,36 @@
     "contact": "Contact",
     "verified": "Verified On-Chain",
     "rating": "Rating",
-    "reviews": "Reviews"
+    "reviews": "Reviews",
+    "page": {
+      "title": "Browse Workers",
+      "search": "Search",
+      "searchPlaceholder": "Worker name...",
+      "location": "Location",
+      "locationPlaceholder": "City or area...",
+      "minRating": "Min Rating",
+      "any": "Any",
+      "ratingOption": "{rating}+",
+      "availableOn": "Available On",
+      "anyDay": "Any day",
+      "listedWithin": "Listed Within",
+      "anyTime": "Any time",
+      "lastYear": "Last year",
+      "lastYears": "Last {count} years",
+      "category": "Category",
+      "all": "All",
+      "applyFilters": "Apply Filters",
+      "clearAll": "Clear all",
+      "days": {
+        "sun": "Sun",
+        "mon": "Mon",
+        "tue": "Tue",
+        "wed": "Wed",
+        "thu": "Thu",
+        "fri": "Fri",
+        "sat": "Sat"
+      }
+    }
   },
   "auth": {
     "email": "Email",
@@ -47,5 +122,16 @@
     "contactRequests": "Contact Requests",
     "createWorker": "Create Worker",
     "noWorkers": "No workers yet"
+  },
+  "footer": {
+    "description": "Find skilled workers near you. A decentralised protocol connecting local tradespeople with the communities that need them.",
+    "quickLinks": "Quick Links",
+    "categories": "Categories",
+    "howItWorks": "How It Works",
+    "legal": "Legal",
+    "privacyPolicy": "Privacy Policy",
+    "termsOfService": "Terms of Service",
+    "community": "Community",
+    "rights": "All rights reserved."
   }
 }

--- a/packages/app/src/messages/es.json
+++ b/packages/app/src/messages/es.json
@@ -4,6 +4,8 @@
     "about": "Acerca de",
     "workers": "Trabajadores",
     "dashboard": "Panel de control",
+    "settings": "Configuración",
+    "account": "Cuenta",
     "logout": "Cerrar sesión",
     "login": "Iniciar sesión",
     "register": "Registrarse",
@@ -16,7 +18,51 @@
     "save": "Guardar",
     "delete": "Eliminar",
     "edit": "Editar",
-    "back": "Atrás"
+    "back": "Atrás",
+    "profile": "Perfil",
+    "adminAnalytics": "Analítica admin",
+    "connectWallet": "Conectar wallet",
+    "connecting": "Conectando...",
+    "language": "Idioma",
+    "toggleTheme": "Cambiar tema",
+    "openMenu": "Abrir menú",
+    "closeMenu": "Cerrar menú"
+  },
+  "homePage": {
+    "hero": {
+      "title": "Encuentra trabajadores calificados cerca de ti",
+      "description": "Conecta con profesionales locales de confianza — fontaneros, electricistas, carpinteros y más.",
+      "categoryPlaceholder": "Categoría (ej. fontanero)",
+      "locationPlaceholder": "Ubicación (ej. Lagos)",
+      "browseWorkers": "Explorar trabajadores"
+    },
+    "categories": {
+      "title": "Explorar por categoría",
+      "workerCount": "{count, plural, one {# trabajador} other {# trabajadores}}"
+    },
+    "howItWorks": {
+      "title": "Cómo funciona",
+      "steps": {
+        "search": {
+          "title": "Busca una habilidad",
+          "description": "Explora categorías o busca por habilidad y ubicación para encontrar al profesional adecuado."
+        },
+        "verified": {
+          "title": "Encuentra un trabajador verificado",
+          "description": "Cada perfil está curado por la comunidad y anclado on-chain para mayor transparencia."
+        },
+        "pay": {
+          "title": "Paga seguro on-chain",
+          "description": "Envía propinas y pagos directamente a los trabajadores mediante Stellar — sin intermediarios."
+        }
+      }
+    },
+    "featuredWorkers": {
+      "title": "Trabajadores destacados",
+      "noWorkers": "Aún no hay trabajadores disponibles. Vuelve pronto.",
+      "viewProfile": "Ver perfil",
+      "seeAll": "Ver todos los trabajadores"
+    }
   },
   "workers": {
     "title": "Encontrar trabajadores calificados",
@@ -24,9 +70,38 @@
     "noResults": "No se encontraron trabajadores",
     "availability": "Disponibilidad",
     "contact": "Contactar",
-    "verified": "Verificado On-Chain",
+    "verified": "Verificado on-chain",
     "rating": "Calificación",
-    "reviews": "Reseñas"
+    "reviews": "Reseñas",
+    "page": {
+      "title": "Explorar trabajadores",
+      "search": "Buscar",
+      "searchPlaceholder": "Nombre del trabajador...",
+      "location": "Ubicación",
+      "locationPlaceholder": "Ciudad o zona...",
+      "minRating": "Calificación mínima",
+      "any": "Cualquiera",
+      "ratingOption": "{rating}+",
+      "availableOn": "Disponible el",
+      "anyDay": "Cualquier día",
+      "listedWithin": "Publicado en",
+      "anyTime": "Cualquier momento",
+      "lastYear": "El último año",
+      "lastYears": "Últimos {count} años",
+      "category": "Categoría",
+      "all": "Todas",
+      "applyFilters": "Aplicar filtros",
+      "clearAll": "Borrar todo",
+      "days": {
+        "sun": "Dom",
+        "mon": "Lun",
+        "tue": "Mar",
+        "wed": "Mié",
+        "thu": "Jue",
+        "fri": "Vie",
+        "sat": "Sáb"
+      }
+    }
   },
   "auth": {
     "email": "Correo electrónico",
@@ -47,5 +122,16 @@
     "contactRequests": "Solicitudes de contacto",
     "createWorker": "Crear trabajador",
     "noWorkers": "Sin trabajadores aún"
+  },
+  "footer": {
+    "description": "Encuentra trabajadores calificados cerca de ti. Un protocolo descentralizado que conecta profesionales locales con las comunidades que los necesitan.",
+    "quickLinks": "Enlaces rápidos",
+    "categories": "Categorías",
+    "howItWorks": "Cómo funciona",
+    "legal": "Legal",
+    "privacyPolicy": "Política de privacidad",
+    "termsOfService": "Términos del servicio",
+    "community": "Comunidad",
+    "rights": "Todos los derechos reservados."
   }
 }

--- a/packages/app/src/messages/fr.json
+++ b/packages/app/src/messages/fr.json
@@ -4,6 +4,8 @@
     "about": "À propos",
     "workers": "Travailleurs",
     "dashboard": "Tableau de bord",
+    "settings": "Paramètres",
+    "account": "Compte",
     "logout": "Déconnexion",
     "login": "Connexion",
     "register": "S'inscrire",
@@ -16,7 +18,51 @@
     "save": "Enregistrer",
     "delete": "Supprimer",
     "edit": "Modifier",
-    "back": "Retour"
+    "back": "Retour",
+    "profile": "Profil",
+    "adminAnalytics": "Analyses admin",
+    "connectWallet": "Connecter le wallet",
+    "connecting": "Connexion...",
+    "language": "Langue",
+    "toggleTheme": "Changer de thème",
+    "openMenu": "Ouvrir le menu",
+    "closeMenu": "Fermer le menu"
+  },
+  "homePage": {
+    "hero": {
+      "title": "Trouvez des travailleurs qualifiés près de chez vous",
+      "description": "Entrez en contact avec des artisans locaux de confiance — plombiers, électriciens, menuisiers et plus encore.",
+      "categoryPlaceholder": "Catégorie (ex. plombier)",
+      "locationPlaceholder": "Lieu (ex. Lagos)",
+      "browseWorkers": "Parcourir les travailleurs"
+    },
+    "categories": {
+      "title": "Parcourir par catégorie",
+      "workerCount": "{count, plural, one {# travailleur} other {# travailleurs}}"
+    },
+    "howItWorks": {
+      "title": "Comment ça marche",
+      "steps": {
+        "search": {
+          "title": "Recherchez une compétence",
+          "description": "Parcourez les catégories ou recherchez par compétence et lieu pour trouver le bon professionnel."
+        },
+        "verified": {
+          "title": "Trouvez un travailleur vérifié",
+          "description": "Chaque fiche est validée par la communauté et ancrée on-chain pour plus de transparence."
+        },
+        "pay": {
+          "title": "Payez en toute sécurité on-chain",
+          "description": "Envoyez des pourboires et paiements directement aux travailleurs via Stellar — sans intermédiaires."
+        }
+      }
+    },
+    "featuredWorkers": {
+      "title": "Travailleurs en vedette",
+      "noWorkers": "Aucun travailleur disponible pour le moment. Revenez bientôt.",
+      "viewProfile": "Voir le profil",
+      "seeAll": "Voir tous les travailleurs"
+    }
   },
   "workers": {
     "title": "Trouver des travailleurs qualifiés",
@@ -24,9 +70,38 @@
     "noResults": "Aucun travailleur trouvé",
     "availability": "Disponibilité",
     "contact": "Contacter",
-    "verified": "Vérifié On-Chain",
+    "verified": "Vérifié on-chain",
     "rating": "Évaluation",
-    "reviews": "Avis"
+    "reviews": "Avis",
+    "page": {
+      "title": "Parcourir les travailleurs",
+      "search": "Recherche",
+      "searchPlaceholder": "Nom du travailleur...",
+      "location": "Lieu",
+      "locationPlaceholder": "Ville ou zone...",
+      "minRating": "Note minimale",
+      "any": "Toutes",
+      "ratingOption": "{rating}+",
+      "availableOn": "Disponible le",
+      "anyDay": "Tous les jours",
+      "listedWithin": "Inscrit depuis",
+      "anyTime": "N'importe quand",
+      "lastYear": "L'année dernière",
+      "lastYears": "{count} dernières années",
+      "category": "Catégorie",
+      "all": "Toutes",
+      "applyFilters": "Appliquer les filtres",
+      "clearAll": "Tout effacer",
+      "days": {
+        "sun": "Dim",
+        "mon": "Lun",
+        "tue": "Mar",
+        "wed": "Mer",
+        "thu": "Jeu",
+        "fri": "Ven",
+        "sat": "Sam"
+      }
+    }
   },
   "auth": {
     "email": "E-mail",
@@ -47,5 +122,16 @@
     "contactRequests": "Demandes de contact",
     "createWorker": "Créer un travailleur",
     "noWorkers": "Aucun travailleur pour le moment"
+  },
+  "footer": {
+    "description": "Trouvez des travailleurs qualifiés près de chez vous. Un protocole décentralisé qui connecte les artisans locaux aux communautés qui ont besoin d'eux.",
+    "quickLinks": "Liens rapides",
+    "categories": "Catégories",
+    "howItWorks": "Comment ça marche",
+    "legal": "Mentions légales",
+    "privacyPolicy": "Politique de confidentialité",
+    "termsOfService": "Conditions d'utilisation",
+    "community": "Communauté",
+    "rights": "Tous droits réservés."
   }
 }

--- a/packages/app/src/messages/pt.json
+++ b/packages/app/src/messages/pt.json
@@ -1,0 +1,137 @@
+{
+  "common": {
+    "home": "Início",
+    "about": "Sobre",
+    "workers": "Trabalhadores",
+    "dashboard": "Painel",
+    "settings": "Definições",
+    "account": "Conta",
+    "logout": "Terminar sessão",
+    "login": "Entrar",
+    "register": "Registar",
+    "search": "Pesquisar",
+    "filter": "Filtrar",
+    "loading": "A carregar...",
+    "error": "Erro",
+    "success": "Sucesso",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "back": "Voltar",
+    "profile": "Perfil",
+    "adminAnalytics": "Análises de administração",
+    "connectWallet": "Ligar carteira",
+    "connecting": "A ligar...",
+    "language": "Idioma",
+    "toggleTheme": "Alternar tema",
+    "openMenu": "Abrir menu",
+    "closeMenu": "Fechar menu"
+  },
+  "homePage": {
+    "hero": {
+      "title": "Encontre trabalhadores qualificados perto de si",
+      "description": "Ligue-se a profissionais locais de confiança — canalizadores, eletricistas, carpinteiros e muito mais.",
+      "categoryPlaceholder": "Categoria (ex. canalizador)",
+      "locationPlaceholder": "Localização (ex. Lagos)",
+      "browseWorkers": "Ver trabalhadores"
+    },
+    "categories": {
+      "title": "Explorar por categoria",
+      "workerCount": "{count, plural, one {# trabalhador} other {# trabalhadores}}"
+    },
+    "howItWorks": {
+      "title": "Como funciona",
+      "steps": {
+        "search": {
+          "title": "Pesquise uma competência",
+          "description": "Explore categorias ou pesquise por competência e localização para encontrar o profissional certo."
+        },
+        "verified": {
+          "title": "Encontre um trabalhador verificado",
+          "description": "Cada perfil é curado pela comunidade e registado on-chain para maior transparência."
+        },
+        "pay": {
+          "title": "Pague com segurança on-chain",
+          "description": "Envie gorjetas e pagamentos diretamente aos trabalhadores através da Stellar — sem intermediários."
+        }
+      }
+    },
+    "featuredWorkers": {
+      "title": "Trabalhadores em destaque",
+      "noWorkers": "Ainda não há trabalhadores disponíveis. Volte em breve.",
+      "viewProfile": "Ver perfil",
+      "seeAll": "Ver todos os trabalhadores"
+    }
+  },
+  "workers": {
+    "title": "Encontrar trabalhadores qualificados",
+    "description": "Descubra trabalhadores de confiança na sua área",
+    "noResults": "Nenhum trabalhador encontrado",
+    "availability": "Disponibilidade",
+    "contact": "Contacto",
+    "verified": "Verificado on-chain",
+    "rating": "Avaliação",
+    "reviews": "Avaliações",
+    "page": {
+      "title": "Explorar trabalhadores",
+      "search": "Pesquisar",
+      "searchPlaceholder": "Nome do trabalhador...",
+      "location": "Localização",
+      "locationPlaceholder": "Cidade ou zona...",
+      "minRating": "Avaliação mínima",
+      "any": "Qualquer",
+      "ratingOption": "{rating}+",
+      "availableOn": "Disponível em",
+      "anyDay": "Qualquer dia",
+      "listedWithin": "Listado nos últimos",
+      "anyTime": "Qualquer altura",
+      "lastYear": "Último ano",
+      "lastYears": "Últimos {count} anos",
+      "category": "Categoria",
+      "all": "Todas",
+      "applyFilters": "Aplicar filtros",
+      "clearAll": "Limpar tudo",
+      "days": {
+        "sun": "Dom",
+        "mon": "Seg",
+        "tue": "Ter",
+        "wed": "Qua",
+        "thu": "Qui",
+        "fri": "Sex",
+        "sat": "Sáb"
+      }
+    }
+  },
+  "auth": {
+    "email": "E-mail",
+    "password": "Palavra-passe",
+    "firstName": "Nome",
+    "lastName": "Apelido",
+    "loginTitle": "Entrar no BlueCollar",
+    "registerTitle": "Criar conta",
+    "forgotPassword": "Esqueceu-se da palavra-passe?",
+    "noAccount": "Ainda não tem conta?",
+    "haveAccount": "Já tem uma conta?",
+    "signInWithGoogle": "Entrar com Google"
+  },
+  "dashboard": {
+    "title": "Painel",
+    "myWorkers": "Os meus trabalhadores",
+    "bookmarks": "Favoritos",
+    "contactRequests": "Pedidos de contacto",
+    "createWorker": "Criar trabalhador",
+    "noWorkers": "Ainda não há trabalhadores"
+  },
+  "footer": {
+    "description": "Encontre trabalhadores qualificados perto de si. Um protocolo descentralizado que liga profissionais locais às comunidades que precisam deles.",
+    "quickLinks": "Links rápidos",
+    "categories": "Categorias",
+    "howItWorks": "Como funciona",
+    "legal": "Legal",
+    "privacyPolicy": "Política de privacidade",
+    "termsOfService": "Termos de serviço",
+    "community": "Comunidade",
+    "rights": "Todos os direitos reservados."
+  }
+}

--- a/packages/app/src/middleware.ts
+++ b/packages/app/src/middleware.ts
@@ -1,9 +1,8 @@
 import createMiddleware from 'next-intl/middleware'
 import { NextRequest, NextResponse } from "next/server";
+import { defaultLocale, isLocale, locales } from "@/lib/i18n";
 
 const PROTECTED = ["/dashboard"];
-const locales = ['en', 'fr', 'es']
-const defaultLocale = 'en'
 
 const intlMiddleware = createMiddleware({
   locales,
@@ -27,7 +26,8 @@ export function middleware(req: NextRequest) {
 
   if (!token) {
     const loginUrl = req.nextUrl.clone();
-    const locale = pathname.split('/')[1] || defaultLocale
+    const requestedLocale = pathname.split('/')[1] ?? defaultLocale
+    const locale = isLocale(requestedLocale) ? requestedLocale : defaultLocale
     loginUrl.pathname = `/${locale}/auth/login`;
     loginUrl.searchParams.set("redirect", pathname);
     return NextResponse.redirect(loginUrl);


### PR DESCRIPTION
## Summary
- Adds Portuguese locale support and shared locale metadata for middleware/navigation
- Points next-intl at the request config and localizes core navigation, footer, landing, and workers filter copy
- Documents the translation workflow and adds coverage for locale routing helpers plus updated navbar tests

## Verification
- npm test -- --run src/__tests__/i18n.test.ts src/__tests__/Navbar.test.tsx
- npm run type-check (fails on pre-existing unrelated strictness errors in accessibility tests, admin toast usage, QRCode import, push notifications, etc.; no errors from this patch remain)
- npm run build from a clean path (gets past next-intl config, then fails on the same pre-existing type issues)

Closes #484