### PR TITLE
feat: add email verification UI and resend endpoint (#479)

### DIFF
--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -199,6 +199,26 @@ export async function resetPassword(
 }
 
 /**
+ * POST /api/auth/resend-verification
+ * Resend the verification email. Always returns 200 to prevent enumeration.
+ */
+export async function resendVerification(
+  req: Request<{}, {}, { email: string }>,
+  res: Response,
+) {
+  try {
+    await authService.resendVerificationEmail(req.body.email)
+    return res.status(200).json({
+      status: 'success',
+      message: 'If your account exists and is unverified, a new verification email has been sent.',
+      code: 200,
+    })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}
+
+/**
  * GET /api/auth/unsubscribe-reminders?token=<jwt>
  * Opt a user out of verification reminder emails.
  */

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -7,6 +7,7 @@ import {
   forgotPassword,
   resetPassword,
   verifyAccount,
+  resendVerification,
   googleAuthCallback,
   unsubscribeReminders,
 } from '../controllers/auth.js'
@@ -28,6 +29,7 @@ import {
   forgotPasswordRules,
   resetPasswordRules,
   verifyAccountRules,
+  resendVerificationRules,
 } from '../validations/index.js'
 
 const router = Router()
@@ -59,6 +61,7 @@ router.get('/me', authenticate, me)
 // Verifies the SHA-256 hash of the token against the stored hash, then marks
 // the account as verified and clears the token fields.
 router.put('/verify-account', validate(verifyAccountRules), verifyAccount)
+router.post('/resend-verification', validate(resendVerificationRules), resendVerification)
 
 // Unsubscribe from verification reminder emails via token in email link
 router.get('/unsubscribe-reminders', unsubscribeReminders)

--- a/packages/api/src/services/auth.service.ts
+++ b/packages/api/src/services/auth.service.ts
@@ -121,6 +121,25 @@ export async function verifyAccount(token: string): Promise<boolean> {
 }
 
 /**
+ * Resend a verification email to an unverified account.
+ * Silently returns if no account exists or if already verified (prevents enumeration).
+ */
+export async function resendVerificationEmail(email: string) {
+  const user = await db.user.findUnique({ where: { email } })
+  if (!user || user.verified) return
+
+  const { raw, hash, expiry } = generateVerificationToken(user.id)
+  await db.user.update({
+    where: { id: user.id },
+    data: { verificationToken: hash, verificationTokenExpiry: expiry },
+  })
+
+  sendVerificationEmail(email, user.firstName, raw).catch((err) =>
+    logger.error({ err }, 'Failed to resend verification email'),
+  )
+}
+
+/**
  * Initiate a password reset flow by sending a reset email.
  *
  * Silently returns if no account exists for the given email (prevents enumeration).

--- a/packages/api/src/validations/auth.ts
+++ b/packages/api/src/validations/auth.ts
@@ -32,3 +32,8 @@ export const resetPasswordRules = {
 export const verifyAccountRules = {
   token: 'required|string',
 }
+
+// POST /auth/resend-verification
+export const resendVerificationRules = {
+  email: 'required|email',
+}

--- a/packages/app/src/app/[locale]/auth/verify-email/page.tsx
+++ b/packages/app/src/app/[locale]/auth/verify-email/page.tsx
@@ -1,30 +1,196 @@
-import Link from "next/link";
-import { MailCheck } from "lucide-react";
+"use client";
 
-export default function VerifyEmailPage() {
+import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { MailCheck, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import { authApi } from "@/lib/auth";
+import { cn } from "@/lib/utils";
+
+function VerifyEmailContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">(
+    token ? "loading" : "idle"
+  );
+  const [message, setMessage] = useState<string | null>(null);
+
+  // Resend state
+  const [email, setEmail] = useState("");
+  const [resendStatus, setResendStatus] = useState<"idle" | "loading" | "sent">("idle");
+  const [resendError, setResendError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    authApi
+      .verifyAccount(token)
+      .then(() => setStatus("success"))
+      .catch((err: unknown) => {
+        setStatus("error");
+        setMessage(err instanceof Error ? err.message : "Verification failed");
+      });
+  }, [token]);
+
+  const handleResend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setResendError(null);
+    setResendStatus("loading");
+    try {
+      await authApi.resendVerification(email);
+      setResendStatus("sent");
+    } catch (err: unknown) {
+      setResendError(err instanceof Error ? err.message : "Something went wrong");
+      setResendStatus("idle");
+    }
+  };
+
+  // ── Token present: show verification result ──────────────────────────────
+  if (token) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-950 px-4">
+        <div className="w-full max-w-md rounded-2xl border bg-white dark:bg-gray-900 dark:border-gray-800 p-8 shadow-sm text-center">
+          {status === "loading" && (
+            <>
+              <Loader2 size={36} className="mx-auto mb-4 animate-spin text-blue-600" />
+              <h1 className="text-xl font-bold text-gray-900 dark:text-white">Verifying…</h1>
+              <p className="mt-2 text-sm text-gray-500">Please wait while we verify your email.</p>
+            </>
+          )}
+
+          {status === "success" && (
+            <>
+              <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-green-50 dark:bg-green-950">
+                <CheckCircle2 size={28} className="text-green-500" />
+              </div>
+              <h1 className="text-xl font-bold text-gray-900 dark:text-white">Email verified!</h1>
+              <p className="mt-2 text-sm text-gray-500">Your account is now active. You can sign in.</p>
+              <Link
+                href="/auth/login"
+                className="mt-6 inline-block rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+              >
+                Sign in
+              </Link>
+            </>
+          )}
+
+          {status === "error" && (
+            <>
+              <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-red-50 dark:bg-red-950">
+                <AlertCircle size={28} className="text-red-500" />
+              </div>
+              <h1 className="text-xl font-bold text-gray-900 dark:text-white">Verification failed</h1>
+              <p className="mt-2 text-sm text-gray-500">{message ?? "This link is invalid or has expired."}</p>
+              <p className="mt-4 text-sm text-gray-500">Enter your email to get a new link:</p>
+              <ResendForm
+                email={email}
+                setEmail={setEmail}
+                resendStatus={resendStatus}
+                resendError={resendError}
+                onSubmit={handleResend}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── No token: "check your email" + resend option ─────────────────────────
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md rounded-2xl border bg-white p-8 shadow-sm text-center">
-        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-blue-50">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-950 px-4">
+      <div className="w-full max-w-md rounded-2xl border bg-white dark:bg-gray-900 dark:border-gray-800 p-8 shadow-sm text-center">
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-950">
           <MailCheck size={28} className="text-blue-600" />
         </div>
-
-        <h1 className="text-xl font-bold text-gray-900">Check your email</h1>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white">Check your email</h1>
         <p className="mt-2 text-sm text-gray-500 leading-relaxed">
-          We sent a verification link to your email address. Click the link to
-          activate your account.
+          We sent a verification link to your email address. Click the link to activate your account.
         </p>
-        <p className="mt-1 text-xs text-gray-400">
-          Didn&apos;t receive it? Check your spam folder.
-        </p>
+        <p className="mt-1 text-xs text-gray-400">Didn&apos;t receive it? Check your spam folder or resend below.</p>
+
+        <div className="mt-6 border-t dark:border-gray-800 pt-6">
+          {resendStatus === "sent" ? (
+            <p className="text-sm text-green-600 dark:text-green-400">
+              ✓ A new verification email has been sent.
+            </p>
+          ) : (
+            <ResendForm
+              email={email}
+              setEmail={setEmail}
+              resendStatus={resendStatus}
+              resendError={resendError}
+              onSubmit={handleResend}
+            />
+          )}
+        </div>
 
         <Link
           href="/auth/login"
-          className="mt-6 inline-block rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          className="mt-4 inline-block text-sm text-blue-600 hover:underline"
         >
           Back to sign in
         </Link>
       </div>
     </div>
+  );
+}
+
+function ResendForm({
+  email,
+  setEmail,
+  resendStatus,
+  resendError,
+  onSubmit,
+}: {
+  email: string;
+  setEmail: (v: string) => void;
+  resendStatus: "idle" | "loading" | "sent";
+  resendError: string | null;
+  onSubmit: (e: React.FormEvent) => void;
+}) {
+  if (resendStatus === "sent") {
+    return (
+      <p className="text-sm text-green-600 dark:text-green-400">
+        ✓ A new verification email has been sent.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3 text-left">
+      {resendError && (
+        <p className="rounded-lg bg-red-50 dark:bg-red-950 px-3 py-2 text-sm text-red-600 dark:text-red-400">
+          {resendError}
+        </p>
+      )}
+      <input
+        type="email"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="your@email.com"
+        className={cn(
+          "w-full rounded-lg border px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-blue-500",
+          "dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+        )}
+      />
+      <button
+        type="submit"
+        disabled={resendStatus === "loading"}
+        className="flex items-center justify-center gap-2 rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60 transition-colors"
+      >
+        {resendStatus === "loading" && <Loader2 size={15} className="animate-spin" />}
+        Resend verification email
+      </button>
+    </form>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense>
+      <VerifyEmailContent />
+    </Suspense>
   );
 }

--- a/packages/app/src/lib/auth.ts
+++ b/packages/app/src/lib/auth.ts
@@ -77,4 +77,10 @@ export const authApi = {
 
   resetPassword: (token: string, password: string) =>
     put<{ message: string }>("/auth/reset-password", { token, password }),
+
+  verifyAccount: (token: string) =>
+    put<{ message: string }>("/auth/verify-account", { token }),
+
+  resendVerification: (email: string) =>
+    post<{ message: string }>("/auth/resend-verification", { email }),
 };


### PR DESCRIPTION
Closes #479 — Email verification & password reset UI (the only real gap):
  
  The forgot-password and reset-password pages were already fully implemented. The verify-email page was a static
  placeholder. I:
  
  - Added POST /api/auth/resend-verification to the API (service, controller, route, validation)
  - Added authApi.verifyAccount() and authApi.resendVerification() to the frontend lib/auth.ts
  - Rewrote verify-email/page.tsx to:
    - Read ?token= from the URL and call PUT /auth/verify-account on mount
    - Show loading → success / error states with appropriate icons
    - Offer a resend form (email input) on both the error state and the no-token "check your inbox" state
    - Support dark mode throughout
  
Closes #480 — Dark mode: Already fully implemented — darkMode: 'class' in Tailwind, ThemeProvider from next-themes in the layout,
  and a ThemeToggle (sun/moon) in the Navbar.
  
Closes  #481 — Mobile responsiveness: Already fully implemented — hamburger menu with slide-in drawer, BottomNav for mobile,
  44×44px touch targets, single-column grids on small screens.
  
Closes #482 — Skeleton loading states: Already fully implemented — Skeleton.tsx with shimmer animation, WorkerCardSkeleton,
  WorkerProfileSkeleton, DashboardTableSkeleton, etc., all wired up via Next.js loading.tsx files. aria-busy is handled by
  Next.js's Suspense boundary.