### PR TITLE
feat(api): versioning, pino logging, geo search fix, fts (#504-507)

### DIFF
--- a/packages/api/DOCUMENTATION.json
+++ b/packages/api/DOCUMENTATION.json
@@ -3,10 +3,11 @@
   "info": {
     "title": "BlueCollar API",
     "version": "1.0.0",
-    "description": "REST API for the BlueCollar decentralised skilled-worker platform built on Stellar."
+    "description": "REST API for the BlueCollar decentralised skilled-worker platform built on Stellar.\n\n## API Versioning\n\nBlueCollar uses **URL-based versioning**. All endpoints are prefixed with `/api/v1/`.\n\n| Version | Base Path    | Status      | Sunset Date |\n|---------|--------------|-------------|-------------|\n| v1      | `/api/v1/*`  | ✅ Current  | —           |\n| —       | `/api/*`     | ⚠️ Deprecated | 2027-01-01 |\n\nRequests to unversioned `/api/*` paths receive a `301` redirect to `/api/v1/*` plus deprecation headers:\n```\nDeprecation: true\nWarning: 299 - \"Unversioned API path is deprecated. Use /api/v1/* instead.\"\nSunset: Sat, 01 Jan 2027 00:00:00 GMT\n```\n\nUse `GET /api/v1/version` to discover the current API version at runtime."
   },
   "servers": [
-    { "url": "http://localhost:3000/api", "description": "Local development" }
+    { "url": "http://localhost:3000/api/v1", "description": "Local development (v1)" },
+    { "url": "http://localhost:3000/api", "description": "Local development (deprecated — redirects to v1)" }
   ],
   "components": {
     "securitySchemes": {
@@ -84,6 +85,33 @@
     }
   },
   "paths": {
+    "/version": {
+      "get": {
+        "tags": ["Meta"],
+        "summary": "Get current API version",
+        "description": "Returns the current API version, supported versions, and deprecation info.",
+        "responses": {
+          "200": {
+            "description": "Version info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": { "type": "string", "example": "1.0.0" },
+                    "apiVersion": { "type": "string", "example": "v1" },
+                    "status": { "type": "string", "example": "current" },
+                    "supported": { "type": "array", "items": { "type": "string" }, "example": ["v1"] },
+                    "deprecated": { "type": "array", "items": { "type": "string" }, "example": [] },
+                    "sunset": { "type": "string", "nullable": true, "example": null }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/auth/register": {
       "post": {
         "tags": ["Auth"],

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -23,6 +23,14 @@ import paymentRoutes from './routes/payments.js'
 import { auditMiddleware } from './middleware/audit.js'
 import { versionMiddleware, deprecationWarning } from './middleware/version.js'
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const { version: API_VERSION } = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')
+)
 
 const app = express()
 
@@ -42,20 +50,39 @@ app.use(versionMiddleware)
 
 app.use(auditMiddleware)
 
-app.use('/api/auth', authRoutes)
-app.use('/api/categories', categoryRoutes)
-app.use('/api/workers', workerRoutes)
-app.use('/api/admin', adminRoutes)
-app.use('/api/users', userRoutes)
-app.use('/api/disputes', disputeRoutes)
-app.use('/api/recommendations', recommendationRoutes)
-app.use('/api/webhooks', webhookRoutes)
-app.use('/api/verifications', verificationRoutes)
-app.use('/api/audit', auditRoutes)
-app.use('/api', responseTimeRoutes)
-app.use('/api/workers', insuranceRoutes)
-app.use('/api/referrals', referralRoutes)
-app.use('/api/payments', paymentRoutes)
+// ── Versioned routes (v1) ─────────────────────────────────────────────────────
+app.use('/api/v1/auth', authRoutes)
+app.use('/api/v1/categories', categoryRoutes)
+app.use('/api/v1/workers', workerRoutes)
+app.use('/api/v1/admin', adminRoutes)
+app.use('/api/v1/users', userRoutes)
+app.use('/api/v1/disputes', disputeRoutes)
+app.use('/api/v1/recommendations', recommendationRoutes)
+app.use('/api/v1/webhooks', webhookRoutes)
+app.use('/api/v1/verifications', verificationRoutes)
+app.use('/api/v1/audit', auditRoutes)
+app.use('/api/v1', responseTimeRoutes)
+app.use('/api/v1/workers', insuranceRoutes)
+app.use('/api/v1/referrals', referralRoutes)
+app.use('/api/v1/payments', paymentRoutes)
+
+// ── Version endpoint ──────────────────────────────────────────────────────────
+app.get('/api/v1/version', (_req, res) => {
+  res.json({
+    version: API_VERSION,
+    apiVersion: 'v1',
+    status: 'current',
+    supported: ['v1'],
+    deprecated: [],
+    sunset: null,
+  })
+})
+
+// ── Redirect unversioned /api/* → /api/v1/* with deprecation headers ──────────
+app.use('/api', deprecationWarning, (req, res) => {
+  const target = `/api/v1${req.path}${req.search ?? (Object.keys(req.query).length ? '?' + new URLSearchParams(req.query as any).toString() : '')}`
+  res.redirect(301, target)
+})
 
 app.get('/health', async (_req, res) => {
   const checks: Record<string, { status: 'ok' | 'error'; latencyMs?: number; error?: string }> = {}

--- a/packages/api/src/controllers/users.ts
+++ b/packages/api/src/controllers/users.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express'
 import argon2 from 'argon2'
 import { db } from '../db.js'
 import { sanitizeUser } from '../models/user.model.js'
+import { logger } from '../config/logger.js'
 
 // ── Profile update ────────────────────────────────────────────────────────────
 
@@ -28,7 +29,7 @@ export async function updateProfile(req: Request, res: Response) {
     })
     return res.json({ data: sanitizeUser(user), status: 'success', code: 200 })
   } catch (error) {
-    console.error('[updateProfile] error:', error)
+    logger.error({ err: error }, '[updateProfile] error')
     return res.status(500).json({ status: 'error', message: 'Failed to update profile', code: 500 })
   }
 }
@@ -66,7 +67,7 @@ export async function changePassword(req: Request, res: Response) {
     await db.user.update({ where: { id: userId }, data: { password: hashed } })
     return res.json({ status: 'success', message: 'Password updated', code: 200 })
   } catch (error) {
-    console.error('[changePassword] error:', error)
+    logger.error({ err: error }, '[changePassword] error')
     return res.status(500).json({ status: 'error', message: 'Failed to change password', code: 500 })
   }
 }
@@ -81,7 +82,7 @@ export async function deleteAccount(req: Request, res: Response) {
     await db.user.delete({ where: { id: userId } })
     return res.json({ status: 'success', message: 'Account deleted', code: 200 })
   } catch (error) {
-    console.error('[deleteAccount] error:', error)
+    logger.error({ err: error }, '[deleteAccount] error')
     return res.status(500).json({ status: 'error', message: 'Failed to delete account', code: 500 })
   }
 }
@@ -106,7 +107,7 @@ export async function savePushSubscription(req: Request, res: Response) {
 
     return res.json({ data: subscription, status: 'success', code: 201 })
   } catch (error) {
-    console.error('[savePushSubscription] error:', error)
+    logger.error({ err: error }, '[savePushSubscription] error')
     return res.status(500).json({ status: 'error', message: 'Failed to save subscription', code: 500 })
   }
 }
@@ -127,7 +128,7 @@ export async function deletePushSubscription(req: Request, res: Response) {
 
     return res.json({ status: 'success', message: 'Unsubscribed', code: 200 })
   } catch (error) {
-    console.error('[deletePushSubscription] error:', error)
+    logger.error({ err: error }, '[deletePushSubscription] error')
     return res.status(500).json({ status: 'error', message: 'Failed to unsubscribe', code: 500 })
   }
 }

--- a/packages/api/src/controllers/workers.ts
+++ b/packages/api/src/controllers/workers.ts
@@ -40,15 +40,18 @@ export async function listWorkers(req: Request, res: Response) {
     const workers = await db.worker.findMany({
       where: {
         isActive: true,
-        latitude: { gte: userLat - delta, lte: userLat + delta },
-        longitude: { gte: userLng - delta, lte: userLng + delta },
+        location: {
+          lat: { gte: userLat - delta, lte: userLat + delta },
+          lng: { gte: userLng - delta, lte: userLng + delta },
+        },
         ...(category ? { categoryId: String(category) } : {}),
       },
-      include: { category: true },
+      include: { category: true, location: true },
     })
 
     const withDistance = workers
-      .map(w => ({ ...w, distanceKm: haversine(userLat, userLng, w.latitude!, w.longitude!) }))
+      .filter(w => w.location?.lat != null && w.location?.lng != null)
+      .map(w => ({ ...w, distanceKm: haversine(userLat, userLng, w.location!.lat!, w.location!.lng!) }))
       .filter(w => w.distanceKm <= radiusKm)
       .sort((a, b) => a.distanceKm - b.distanceKm)
 

--- a/packages/api/src/mailer/index.ts
+++ b/packages/api/src/mailer/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { transporter } from './transport.js'
+import { logger } from '../config/logger.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -60,7 +61,7 @@ export async function sendModerationEmail(
     html: `<p>Hi <strong>${firstName}</strong>, your review has been <strong>${action}</strong> by our moderation team.</p>`,
   })
   if ((transporter as any).options?.jsonTransport) {
-    console.log('[mailer] Moderation email (dev stub):', JSON.parse((info as any).message))
+    logger.debug({ message: JSON.parse((info as any).message) }, '[mailer] Moderation email (dev stub)')
   }
 }
 

--- a/packages/api/src/middleware/errorHandler.ts
+++ b/packages/api/src/middleware/errorHandler.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
 import { AppError, ErrorCode } from '../utils/AppError.js'
+import { logger } from '../config/logger.js'
 
 /**
  * Global error handling middleware for Express.
@@ -67,13 +68,12 @@ export function notFoundHandler(req: Request, _res: Response, next: NextFunction
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function logError(err: Error, req: Request) {
-  console.error('[ERROR]', {
+  logger.error({
     message: err.message,
     stack: err.stack,
     url: req.url,
     method: req.method,
-    timestamp: new Date().toISOString(),
-  })
+  }, '[ERROR]')
 }
 
 interface PrismaClientKnownRequestError {

--- a/packages/api/src/services/push.service.ts
+++ b/packages/api/src/services/push.service.ts
@@ -1,5 +1,6 @@
 import webpush from 'web-push'
 import { db } from '../db.js'
+import { logger } from '../config/logger.js'
 
 const vapidPublicKey = process.env.VAPID_PUBLIC_KEY
 const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY
@@ -21,7 +22,7 @@ export async function sendPushNotification(
   payload: PushNotificationPayload
 ): Promise<void> {
   if (!vapidPublicKey || !vapidPrivateKey) {
-    console.warn('[PushService] VAPID keys not configured, skipping push notification')
+    logger.warn('[PushService] VAPID keys not configured, skipping push notification')
     return
   }
 
@@ -37,7 +38,7 @@ export async function sendPushNotification(
         JSON.stringify(payload)
       )
     } catch (error) {
-      console.error('[PushService] error sending notification:', error)
+      logger.error({ err: error }, '[PushService] error sending notification')
       // Remove invalid subscription
       if (error instanceof Error && error.message.includes('410')) {
         await db.pushSubscription.delete({ where: { id: sub.id } })

--- a/packages/api/src/services/vault.ts
+++ b/packages/api/src/services/vault.ts
@@ -1,4 +1,5 @@
 import * as NodeVault from 'node-vault';
+import { logger } from '../config/logger.js'
 
 const vault = new NodeVault({
   endpoint: process.env.VAULT_ADDR || 'http://localhost:8200',
@@ -10,7 +11,7 @@ export async function getSecret(path: string): Promise<Record<string, string>> {
     const secret = await vault.read(`kv/data/bluecollar/${path}`);
     return secret.data.data;
   } catch (error) {
-    console.error(`Failed to retrieve secret: ${path}`, error);
+    logger.error({ err: error, path }, 'Failed to retrieve secret')
     throw error;
   }
 }
@@ -19,7 +20,7 @@ export async function setSecret(path: string, data: Record<string, string>): Pro
   try {
     await vault.write(`kv/data/bluecollar/${path}`, { data });
   } catch (error) {
-    console.error(`Failed to set secret: ${path}`, error);
+    logger.error({ err: error, path }, 'Failed to set secret')
     throw error;
   }
 }
@@ -27,9 +28,9 @@ export async function setSecret(path: string, data: Record<string, string>): Pro
 export async function rotateSecret(path: string, newData: Record<string, string>): Promise<void> {
   try {
     await setSecret(path, newData);
-    console.log(`Secret rotated: ${path}`);
+    logger.info({ path }, 'Secret rotated')
   } catch (error) {
-    console.error(`Failed to rotate secret: ${path}`, error);
+    logger.error({ err: error, path }, 'Failed to rotate secret')
     throw error;
   }
 }
@@ -37,9 +38,9 @@ export async function rotateSecret(path: string, newData: Record<string, string>
 export async function deleteSecret(path: string): Promise<void> {
   try {
     await vault.delete(`kv/data/bluecollar/${path}`);
-    console.log(`Secret deleted: ${path}`);
+    logger.info({ path }, 'Secret deleted')
   } catch (error) {
-    console.error(`Failed to delete secret: ${path}`, error);
+    logger.error({ err: error, path }, 'Failed to delete secret')
     throw error;
   }
 }
@@ -49,7 +50,7 @@ export async function listSecrets(path: string): Promise<string[]> {
     const result = await vault.list(`kv/metadata/bluecollar/${path}`);
     return result.data.keys;
   } catch (error) {
-    console.error(`Failed to list secrets: ${path}`, error);
+    logger.error({ err: error, path }, 'Failed to list secrets')
     throw error;
   }
 }


### PR DESCRIPTION
Closes  #507 — API Versioning
  
  - app.ts: All routes moved from /api/* to /api/v1/*. Added a GET /api/v1/version
  endpoint returning version, status, and supported versions. Added a catch-all /api
   handler that applies deprecationWarning headers and issues a 301 redirect to the
  equivalent /api/v1/* path.
  - DOCUMENTATION.json: Updated servers to point to /api/v1, added versioning strategy
  to the info.description, and added the /version path entry.
  
 Closes #506 — Pino Structured Logging
  
  Pino was already installed and src/config/logger.ts + requestLogger.ts already
  existed. Replaced remaining console.* calls in production code with the Pino logger
  singleton:
  
  - middleware/errorHandler.ts — console.error → logger.error
  - controllers/users.ts — 5× console.error → logger.error
  - services/push.service.ts — console.warn/console.error → logger.warn/logger.error
  - mailer/index.ts — console.log → logger.debug
  - services/vault.ts — all console.* → structured logger.*
  
  Script/seed/test files were left alone (they're not production runtime code).
  
 Closes #505 — Geolocation / Proximity Search
  
  The controller had a bug: it queried w.latitude/w.longitude directly on Worker, but
  those fields don't exist — lat/lng live on the Location relation. Fixed the findMany
   where clause to filter via location: { lat: {...}, lng: {...} } and the distance
  calculation to use w.location!.lat!/w.location!.lng!.
  
 Closes #504 — Full-Text Search
  
  Already fully implemented: Prisma migration with tsvector column + GIN index + DB
  trigger, listWorkersFullText in worker.service.ts, ?search= query param in the
  controller, and tests in workers.test.ts, worker.service.test.ts,
  integration/worker.test.ts, and security.test.ts. No changes needed.