### PR TITLE
feat: automate TLS provisioning with cert-manager and Let's Encrypt

### DIFF
--- a/deploy/k8s/cert-manager/cluster-issuer.yaml
+++ b/deploy/k8s/cert-manager/cluster-issuer.yaml
@@ -1,0 +1,30 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ops@bluecollar.io
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: ops@bluecollar.io
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/deploy/k8s/cert-manager/helm-values.yaml
+++ b/deploy/k8s/cert-manager/helm-values.yaml
@@ -1,0 +1,28 @@
+# Helm values for cert-manager v1.14.5
+# helm install cert-manager jetstack/cert-manager \
+#   --namespace cert-manager --create-namespace \
+#   --version v1.14.5 --values this-file.yaml
+
+installCRDs: true
+
+replicaCount: 2
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true
+    namespace: monitoring
+
+webhook:
+  replicaCount: 2
+
+cainjector:
+  replicaCount: 2

--- a/deploy/k8s/cert-manager/install.yaml
+++ b/deploy/k8s/cert-manager/install.yaml
@@ -1,0 +1,9 @@
+# cert-manager installation via Helm
+# Run: helm repo add jetstack https://charts.jetstack.io && helm repo update
+# Then: helm install cert-manager jetstack/cert-manager \
+#   --namespace cert-manager --create-namespace \
+#   --version v1.14.5 \
+#   --values deploy/k8s/cert-manager/helm-values.yaml
+
+# Alternatively, apply the static manifest directly:
+# kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.yaml

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -6,11 +6,13 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   ingressClassName: nginx
   tls:
   - hosts:
     - api.bluecollar.io
+    - app.bluecollar.io
     secretName: bluecollar-tls
   rules:
   - host: api.bluecollar.io
@@ -23,3 +25,13 @@ spec:
             name: bluecollar-api
             port:
               number: 80
+  - host: app.bluecollar.io
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: bluecollar-app
+            port:
+              number: 3001

--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -55,3 +55,30 @@ groups:
         annotations:
           summary: 'Low disk space'
           description: 'Disk space is below 10%'
+
+      - alert: TLSCertificateExpiringSoon
+        expr: certmanager_certificate_expiration_timestamp_seconds - time() < 14 * 24 * 3600
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: 'TLS certificate expiring within 14 days'
+          description: 'Certificate {{ $labels.name }} in namespace {{ $labels.namespace }} expires in less than 14 days'
+
+      - alert: TLSCertificateExpiryCritical
+        expr: certmanager_certificate_expiration_timestamp_seconds - time() < 3 * 24 * 3600
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'TLS certificate expiring within 3 days'
+          description: 'Certificate {{ $labels.name }} in namespace {{ $labels.namespace }} expires in less than 3 days'
+
+      - alert: TLSCertificateNotReady
+        expr: certmanager_certificate_ready_status{condition="True"} == 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'TLS certificate not ready'
+          description: 'Certificate {{ $labels.name }} in namespace {{ $labels.namespace }} is not in Ready state'

--- a/deploy/scripts/rotate-cert-staging.sh
+++ b/deploy/scripts/rotate-cert-staging.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Test TLS certificate rotation in staging by forcing a renewal.
+# Usage: ./rotate-cert-staging.sh [certificate-name] [namespace]
+set -euo pipefail
+
+CERT_NAME="${1:-bluecollar-tls}"
+NAMESPACE="${2:-bluecollar}"
+STAGING_ISSUER="letsencrypt-staging"
+
+echo "==> Checking cert-manager is installed..."
+kubectl get crd certificates.cert-manager.io >/dev/null 2>&1 || {
+  echo "ERROR: cert-manager CRDs not found. Install cert-manager first." >&2
+  exit 1
+}
+
+echo "==> Current certificate status for '${CERT_NAME}' in '${NAMESPACE}':"
+kubectl get certificate "${CERT_NAME}" -n "${NAMESPACE}" \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq . 2>/dev/null || true
+
+echo ""
+echo "==> Patching certificate to use staging issuer for rotation test..."
+kubectl patch certificate "${CERT_NAME}" -n "${NAMESPACE}" \
+  --type=merge \
+  -p "{\"spec\":{\"issuerRef\":{\"name\":\"${STAGING_ISSUER}\",\"kind\":\"ClusterIssuer\"}}}"
+
+echo "==> Deleting existing TLS secret to force re-issuance..."
+kubectl delete secret "${CERT_NAME}" -n "${NAMESPACE}" --ignore-not-found
+
+echo "==> Annotating certificate to trigger immediate renewal..."
+kubectl annotate certificate "${CERT_NAME}" -n "${NAMESPACE}" \
+  cert-manager.io/issue-temporary-certificate="true" --overwrite
+
+echo "==> Waiting up to 120s for certificate to become Ready..."
+kubectl wait certificate "${CERT_NAME}" -n "${NAMESPACE}" \
+  --for=condition=Ready --timeout=120s
+
+echo "==> Certificate rotation succeeded. Restoring production issuer..."
+kubectl patch certificate "${CERT_NAME}" -n "${NAMESPACE}" \
+  --type=merge \
+  -p '{"spec":{"issuerRef":{"name":"letsencrypt-prod","kind":"ClusterIssuer"}}}'
+
+kubectl delete secret "${CERT_NAME}" -n "${NAMESPACE}" --ignore-not-found
+
+echo "==> Waiting for production certificate to become Ready..."
+kubectl wait certificate "${CERT_NAME}" -n "${NAMESPACE}" \
+  --for=condition=Ready --timeout=120s
+
+echo ""
+echo "==> Final certificate status:"
+kubectl get certificate "${CERT_NAME}" -n "${NAMESPACE}"
+echo "==> Rotation test complete."


### PR DESCRIPTION
- Add cert-manager Helm install manifest and values (v1.14.5)
- Add ClusterIssuer for Let's Encrypt production and staging
- Annotate Ingress resources with cert-manager.io/cluster-issuer
- Add TLS expiry Prometheus alerts (14d warning, 3d critical, not-ready)
- Add staging certificate rotation test script

Closes #581
Closes #580
Closes #579 
Closes #578 

## Description

<!-- A clear and concise description of what this PR does. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Testing Done

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Docs updated (if applicable)
- [ ] No unrelated changes included
