### PR TITLE
feat: error serializer refactor and contract upgrade guide

### DIFF
--- a/packages/api/src/middleware/errorHandler.ts
+++ b/packages/api/src/middleware/errorHandler.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 import { AppError, ErrorCode } from '../utils/AppError.js'
 import { logger } from '../config/logger.js'
-import { getTraceId } from '../monitoring/tracing.js'
+import { serializeError } from '../serializers/error.serializer.js'
 
 /**
  * Global error handling middleware for Express.
@@ -18,57 +18,14 @@ export function errorHandler(
   res: Response,
   _next: NextFunction,
 ) {
-  // ── CORS rejection ────────────────────────────────────────────────────────
-  if (err instanceof Error && err.message.startsWith('CORS:')) {
-    return res.status(403).json({
-      status: 'error',
-      message: 'Forbidden: origin not allowed',
-      code: 403,
-      errorCode: ErrorCode.FORBIDDEN,
-    })
+  const { statusCode, body } = serializeError(err)
+
+  if (statusCode >= 500) {
+    const error = err instanceof Error ? err : new Error(String(err))
+    logger.error({ message: error.message, stack: error.stack, url: req.url, method: req.method }, '[ERROR]')
   }
 
-  // ── Prisma error mapping ──────────────────────────────────────────────────
-  if (isPrismaError(err)) {
-    const mapped = mapPrismaError(err)
-    return res.status(mapped.statusCode).json({
-      status: 'error',
-      message: mapped.message,
-      code: mapped.statusCode,
-      errorCode: mapped.errorCode,
-      traceId: getTraceId(),
-    })
-  }
-
-  // ── Operational AppError ──────────────────────────────────────────────────
-  if (err instanceof AppError && err.isOperational) {
-    if (err.statusCode >= 500) {
-      logError(err, req)
-    }
-    return res.status(err.statusCode).json({
-      status: 'error',
-      message: err.message,
-      code: err.statusCode,
-      errorCode: err.errorCode,
-      traceId: getTraceId(),
-    })
-  }
-
-  // ── Unexpected / programmer error ─────────────────────────────────────────
-  const error = err instanceof Error ? err : new Error(String(err))
-  logError(error, req)
-
-  return res.status(500).json({
-    status: 'error',
-    message: 'Internal Server Error',
-    code: 500,
-    errorCode: ErrorCode.INTERNAL_ERROR,
-    traceId: getTraceId(),
-    ...(process.env.NODE_ENV === 'development' && {
-      stack: error.stack,
-      originalMessage: error.message,
-    }),
-  })
+  return res.status(statusCode).json(body)
 }
 
 /**
@@ -77,47 +34,4 @@ export function errorHandler(
  */
 export function notFoundHandler(req: Request, _res: Response, next: NextFunction) {
   next(new AppError(`Route ${req.method} ${req.url} not found`, 404, true, ErrorCode.NOT_FOUND))
-}
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function logError(err: Error, req: Request) {
-  logger.error({
-    message: err.message,
-    stack: err.stack,
-    url: req.url,
-    method: req.method,
-  }, '[ERROR]')
-}
-
-interface PrismaClientKnownRequestError {
-  code: string
-  meta?: Record<string, unknown>
-}
-
-function isPrismaError(err: unknown): err is PrismaClientKnownRequestError {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'code' in err &&
-    typeof (err as Record<string, unknown>).code === 'string' &&
-    (err as Record<string, unknown>).code?.toString().startsWith('P')
-  )
-}
-
-function mapPrismaError(err: PrismaClientKnownRequestError): {
-  statusCode: number
-  message: string
-  errorCode: ErrorCode
-} {
-  switch (err.code) {
-    case 'P2002':
-      return { statusCode: 409, message: 'A record with that value already exists', errorCode: ErrorCode.CONFLICT }
-    case 'P2025':
-      return { statusCode: 404, message: 'Record not found', errorCode: ErrorCode.NOT_FOUND }
-    case 'P2003':
-      return { statusCode: 400, message: 'Related record not found', errorCode: ErrorCode.VALIDATION_ERROR }
-    default:
-      return { statusCode: 500, message: 'Database error', errorCode: ErrorCode.INTERNAL_ERROR }
-  }
 }

--- a/packages/api/src/serializers/error.serializer.ts
+++ b/packages/api/src/serializers/error.serializer.ts
@@ -1,0 +1,75 @@
+import { AppError, ErrorCode } from '../utils/AppError.js'
+import { getTraceId } from '../monitoring/tracing.js'
+
+export interface ErrorResponse {
+  status: 'error'
+  message: string
+  code: number
+  errorCode: ErrorCode
+  traceId?: string
+  stack?: string
+  originalMessage?: string
+}
+
+interface PrismaClientKnownRequestError {
+  code: string
+  meta?: Record<string, unknown>
+}
+
+function isPrismaError(err: unknown): err is PrismaClientKnownRequestError {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    typeof (err as Record<string, unknown>).code === 'string' &&
+    (err as Record<string, unknown>).code?.toString().startsWith('P')
+  )
+}
+
+function mapPrismaError(err: PrismaClientKnownRequestError): { statusCode: number; message: string; errorCode: ErrorCode } {
+  switch (err.code) {
+    case 'P2002': return { statusCode: 409, message: 'A record with that value already exists', errorCode: ErrorCode.CONFLICT }
+    case 'P2025': return { statusCode: 404, message: 'Record not found', errorCode: ErrorCode.NOT_FOUND }
+    case 'P2003': return { statusCode: 400, message: 'Related record not found', errorCode: ErrorCode.VALIDATION_ERROR }
+    default:      return { statusCode: 500, message: 'Database error', errorCode: ErrorCode.INTERNAL_ERROR }
+  }
+}
+
+export interface SerializedError {
+  statusCode: number
+  body: ErrorResponse
+}
+
+export function serializeError(err: unknown): SerializedError {
+  const traceId = getTraceId()
+
+  if (err instanceof Error && err.message.startsWith('CORS:')) {
+    return {
+      statusCode: 403,
+      body: { status: 'error', message: 'Forbidden: origin not allowed', code: 403, errorCode: ErrorCode.FORBIDDEN },
+    }
+  }
+
+  if (isPrismaError(err)) {
+    const { statusCode, message, errorCode } = mapPrismaError(err)
+    return { statusCode, body: { status: 'error', message, code: statusCode, errorCode, traceId } }
+  }
+
+  if (err instanceof AppError && err.isOperational) {
+    return {
+      statusCode: err.statusCode,
+      body: { status: 'error', message: err.message, code: err.statusCode, errorCode: err.errorCode, traceId },
+    }
+  }
+
+  const error = err instanceof Error ? err : new Error(String(err))
+  const body: ErrorResponse = {
+    status: 'error',
+    message: 'Internal Server Error',
+    code: 500,
+    errorCode: ErrorCode.INTERNAL_ERROR,
+    traceId,
+    ...(process.env.NODE_ENV === 'development' && { stack: error.stack, originalMessage: error.message }),
+  }
+  return { statusCode: 500, body }
+}

--- a/packages/api/src/serializers/serializers.test.ts
+++ b/packages/api/src/serializers/serializers.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { userSerializer } from '../serializers/user.serializer.js'
 import { categorySerializer } from '../serializers/category.serializer.js'
 import { workerSerializer } from '../serializers/worker.serializer.js'
+import { serializeError } from '../serializers/error.serializer.js'
+import { AppError, ErrorCode } from '../utils/AppError.js'
 
 const mockUser: any = {
   id: 'u1', email: 'a@b.com', firstName: 'Jane', lastName: 'Doe',
@@ -59,5 +61,67 @@ describe('WorkerSerializer', () => {
     expect(result.category).toMatchObject({ id: 'c1', name: 'Plumber' })
     expect(result.curator).not.toHaveProperty('password')
     expect(result.curator?.email).toBe('a@b.com')
+  })
+})
+
+describe('ErrorSerializer', () => {
+  it('serializes an operational AppError', () => {
+    const err = new AppError('Not found', 404, true, ErrorCode.NOT_FOUND)
+    const { statusCode, body } = serializeError(err)
+    expect(statusCode).toBe(404)
+    expect(body.status).toBe('error')
+    expect(body.message).toBe('Not found')
+    expect(body.errorCode).toBe(ErrorCode.NOT_FOUND)
+    expect(body.code).toBe(404)
+  })
+
+  it('returns 500 for a non-operational AppError', () => {
+    const err = new AppError('Crash', 500, false, ErrorCode.INTERNAL_ERROR)
+    const { statusCode, body } = serializeError(err)
+    expect(statusCode).toBe(500)
+    expect(body.message).toBe('Internal Server Error')
+    expect(body.errorCode).toBe(ErrorCode.INTERNAL_ERROR)
+  })
+
+  it('returns 500 for an unknown error', () => {
+    const { statusCode, body } = serializeError(new Error('boom'))
+    expect(statusCode).toBe(500)
+    expect(body.status).toBe('error')
+    expect(body.errorCode).toBe(ErrorCode.INTERNAL_ERROR)
+  })
+
+  it('maps Prisma P2002 to 409 CONFLICT', () => {
+    const prismaErr = { code: 'P2002', meta: {} }
+    const { statusCode, body } = serializeError(prismaErr)
+    expect(statusCode).toBe(409)
+    expect(body.errorCode).toBe(ErrorCode.CONFLICT)
+  })
+
+  it('maps Prisma P2025 to 404 NOT_FOUND', () => {
+    const prismaErr = { code: 'P2025' }
+    const { statusCode, body } = serializeError(prismaErr)
+    expect(statusCode).toBe(404)
+    expect(body.errorCode).toBe(ErrorCode.NOT_FOUND)
+  })
+
+  it('maps Prisma P2003 to 400 VALIDATION_ERROR', () => {
+    const prismaErr = { code: 'P2003' }
+    const { statusCode, body } = serializeError(prismaErr)
+    expect(statusCode).toBe(400)
+    expect(body.errorCode).toBe(ErrorCode.VALIDATION_ERROR)
+  })
+
+  it('maps unknown Prisma error to 500', () => {
+    const prismaErr = { code: 'P9999' }
+    const { statusCode, body } = serializeError(prismaErr)
+    expect(statusCode).toBe(500)
+    expect(body.errorCode).toBe(ErrorCode.INTERNAL_ERROR)
+  })
+
+  it('returns 403 for CORS errors', () => {
+    const corsErr = new Error('CORS: origin not allowed')
+    const { statusCode, body } = serializeError(corsErr)
+    expect(statusCode).toBe(403)
+    expect(body.errorCode).toBe(ErrorCode.FORBIDDEN)
   })
 })

--- a/packages/contracts/UPGRADE_GUIDE.md
+++ b/packages/contracts/UPGRADE_GUIDE.md
@@ -1,0 +1,172 @@
+# Contract Upgrade Guide
+
+This guide covers upgrading the deployed BlueCollar Soroban contracts (Registry and Market) without redeploying — preserving the contract ID and all on-chain storage.
+
+## Prerequisites
+
+- [Rust](https://rustup.rs/) with `wasm32-unknown-unknown` target
+- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli) installed
+- A funded account with the `ROLE_UPGRADER` role on the contract you are upgrading
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install --locked stellar-cli
+```
+
+---
+
+## Upgrade Process
+
+Both contracts follow the same three-step process: **build → install → execute**.
+
+### Step 1 — Build the new WASM
+
+```bash
+# Registry
+make build-registry
+
+# Market
+make build-market
+```
+
+Output files:
+- `target/wasm32-unknown-unknown/release/bluecollar_registry.wasm`
+- `target/wasm32-unknown-unknown/release/bluecollar_market.wasm`
+
+### Step 2 — Install the WASM on-chain
+
+`install` uploads the WASM bytecode and returns its hash. The contract is **not** upgraded yet.
+
+```bash
+# Registry
+stellar contract install \
+  --wasm target/wasm32-unknown-unknown/release/bluecollar_registry.wasm \
+  --source <YOUR_SECRET_KEY> \
+  --network testnet
+# → outputs: <NEW_WASM_HASH>
+
+# Market
+stellar contract install \
+  --wasm target/wasm32-unknown-unknown/release/bluecollar_market.wasm \
+  --source <YOUR_SECRET_KEY> \
+  --network testnet
+# → outputs: <NEW_WASM_HASH>
+```
+
+Replace `--network testnet` with `--network mainnet` for production.
+
+### Step 3 — Propose and execute the upgrade (timelock)
+
+The Registry contract uses a **48-hour timelock** (`TIMELOCK_LEDGERS = 34,560` ledgers at ~5 s/ledger). The Market contract supports direct upgrade via `upgrade`.
+
+#### Registry Contract (timelock)
+
+```bash
+# 3a. Propose the upgrade (requires ROLE_UPGRADER)
+stellar contract invoke \
+  --id <REGISTRY_CONTRACT_ID> \
+  --source <UPGRADER_SECRET_KEY> \
+  --network testnet \
+  -- propose_upgrade \
+  --admin <UPGRADER_ADDRESS> \
+  --new_wasm_hash <NEW_WASM_HASH>
+
+# 3b. After ~48 hours, execute the upgrade (callable by anyone)
+stellar contract invoke \
+  --id <REGISTRY_CONTRACT_ID> \
+  --source <ANY_ACCOUNT_SECRET_KEY> \
+  --network testnet \
+  -- execute_upgrade
+```
+
+#### Market Contract (direct)
+
+```bash
+stellar contract invoke \
+  --id <MARKET_CONTRACT_ID> \
+  --source <ADMIN_SECRET_KEY> \
+  --network testnet \
+  -- upgrade \
+  --new_wasm_hash <NEW_WASM_HASH>
+```
+
+The `admin` argument must match the signing key (`--source`), as `require_auth()` is enforced on-chain.
+
+---
+
+## Schema Migration
+
+If the upgrade changes the storage layout, run `migrate` after the WASM is applied.
+
+```bash
+# Check current schema version
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_SECRET_KEY> \
+  --network testnet \
+  -- get_schema_version
+
+# Run migration (admin only; expected_version must equal current version)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_SECRET_KEY> \
+  --network testnet \
+  -- migrate \
+  --admin <ADMIN_ADDRESS> \
+  --expected_version 1
+```
+
+`migrate` is idempotent-safe: it panics with `"Wrong schema version"` if called twice or out of order.
+
+---
+
+## Cancelling a Pending Upgrade (Registry only)
+
+```bash
+stellar contract invoke \
+  --id <REGISTRY_CONTRACT_ID> \
+  --source <UPGRADER_SECRET_KEY> \
+  --network testnet \
+  -- cancel_upgrade \
+  --admin <UPGRADER_ADDRESS>
+```
+
+---
+
+## Checking Upgrade Status (Registry only)
+
+```bash
+stellar contract invoke \
+  --id <REGISTRY_CONTRACT_ID> \
+  --source <ANY_ACCOUNT_SECRET_KEY> \
+  --network testnet \
+  -- get_pending_upgrade
+```
+
+Returns the pending `wasm_hash` and `execute_after_ledger`, or `None` if no upgrade is pending.
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Missing role` | Signing key does not hold `ROLE_UPGRADER` | Grant the role via `grant_role` from an admin account |
+| `Upgrade already pending` | `propose_upgrade` called twice | Cancel the existing proposal first with `cancel_upgrade`, or wait and execute it |
+| `Timelock not expired` | `execute_upgrade` called before 48 hours have elapsed | Check `get_pending_upgrade` for `execute_after_ledger` and wait |
+| `No pending upgrade` | `execute_upgrade` or `cancel_upgrade` called with nothing pending | Propose an upgrade first |
+| `Not initialized` | Contract has not been initialised | Call `initialize` before any admin operation |
+| `Wrong schema version` | `migrate` called with incorrect `expected_version` | Query `get_schema_version` and pass the current version |
+| `Contract is paused` | Contract is paused | Unpause via `unpause` (requires `ROLE_PAUSER`) before upgrading |
+
+### Verifying the upgrade succeeded
+
+After `execute_upgrade` (Registry) or `upgrade` (Market), confirm the new WASM is active:
+
+```bash
+stellar contract info \
+  --id <CONTRACT_ID> \
+  --network testnet
+```
+
+The reported WASM hash should match `<NEW_WASM_HASH>`.


### PR DESCRIPTION
- #658: extract error formatting into error.serializer.ts; update errorHandler to delegate to serializeError; add unit tests covering AppError, Prisma (P2002/P2025/P2003/unknown), CORS, and generic errors
- #659: add packages/contracts/UPGRADE_GUIDE.md with step-by-step Registry (timelock) and Market upgrade flows, schema migration, cancel/status commands, and troubleshooting table

Closes #658 
Closes #659 