### PR TITLE
feat: add staging environment with CI/CD workflow and smoke tests

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,66 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches: [develop]
+
+env:
+  PNPM_VERSION: 9
+
+jobs:
+  deploy-staging:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Write staging env files
+        run: |
+          echo "${{ secrets.STAGING_API_ENV }}" > packages/api/.env.staging
+          echo "${{ secrets.STAGING_APP_ENV }}" > packages/app/.env.staging
+
+      - name: Deploy staging stack
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          script: |
+            cd /opt/bluecollar
+            git pull origin develop
+            echo "${{ secrets.STAGING_API_ENV }}" > packages/api/.env.staging
+            echo "${{ secrets.STAGING_APP_ENV }}" > packages/app/.env.staging
+            docker compose -f docker-compose.staging.yml pull
+            docker compose -f docker-compose.staging.yml up -d --build
+            docker compose -f docker-compose.staging.yml exec -T api npx prisma migrate deploy
+
+  smoke-tests:
+    name: Smoke Tests
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Wait for staging to be ready
+        run: sleep 20
+
+      - name: Run smoke tests
+        run: bash deploy/scripts/smoke-tests-staging.sh
+        env:
+          STAGING_API_URL: ${{ secrets.STAGING_API_URL }}
+          STAGING_APP_URL: ${{ secrets.STAGING_APP_URL }}

--- a/deploy/scripts/smoke-tests-staging.sh
+++ b/deploy/scripts/smoke-tests-staging.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+API_URL="${STAGING_API_URL:-http://localhost:3000}"
+APP_URL="${STAGING_APP_URL:-http://localhost:3001}"
+
+echo "🧪 Running staging smoke tests..."
+echo "   API: $API_URL"
+echo "   App: $APP_URL"
+
+check() {
+  local label=$1 url=$2 expected=$3
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null || echo "000")
+  if [ "$code" != "$expected" ]; then
+    echo "❌ $label — expected $expected, got $code ($url)"
+    exit 1
+  fi
+  echo "✅ $label ($code)"
+}
+
+check "API health"      "$API_URL/health"         "200"
+check "API categories"  "$API_URL/api/categories"  "200"
+check "App homepage"    "$APP_URL/"                "200"
+
+echo "✅ All staging smoke tests passed."

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,86 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-bluecollar}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-staging-change-me}
+      POSTGRES_DB: ${POSTGRES_DB:-bluecollar_staging}
+    volumes:
+      - db_staging_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-bluecollar} -d ${POSTGRES_DB:-bluecollar_staging}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - staging
+
+  api:
+    build:
+      context: .
+      dockerfile: packages/api/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - packages/api/.env.staging
+    environment:
+      NODE_ENV: staging
+      PORT: 3000
+      DATABASE_URL: postgresql://${POSTGRES_USER:-bluecollar}:${POSTGRES_PASSWORD:-staging-change-me}@db:5432/${POSTGRES_DB:-bluecollar_staging}
+    expose:
+      - '3000'
+    ports:
+      - '3000:3000'
+    command: ['sh', '-c', 'npx prisma migrate deploy && node dist/index.js']
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:3000/health || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '3'
+    networks:
+      - staging
+
+  app:
+    image: node:20-alpine
+    working_dir: /workspace/packages/app
+    restart: unless-stopped
+    depends_on:
+      - api
+    env_file:
+      - packages/app/.env.staging
+    environment:
+      NODE_ENV: staging
+      PORT: 3001
+    volumes:
+      - ./:/workspace
+    command:
+      ['sh', '-c', 'corepack enable && pnpm install --frozen-lockfile && pnpm build && pnpm start -p 3001']
+    expose:
+      - '3001'
+    ports:
+      - '3001:3001'
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '3'
+    networks:
+      - staging
+
+volumes:
+  db_staging_data:
+
+networks:
+  staging:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,29 @@ services:
       - "4318:4318"   # OTLP HTTP
       - "8888:8888"   # Collector metrics
 
+  loki:
+    image: grafana/loki:2.9.4
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki.yml
+    volumes:
+      - ./deploy/loki/loki.yml:/etc/loki/loki.yml:ro
+      - ./deploy/loki/alerts.yml:/etc/loki/rules/fake/alerts.yml:ro
+      - loki_data:/loki
+    ports:
+      - "3100:3100"
+
+  promtail:
+    image: grafana/promtail:2.9.4
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/promtail.yml
+    volumes:
+      - ./deploy/promtail/promtail.yml:/etc/promtail/promtail.yml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - loki
+
 volumes:
   db_data:
   redis_data:
+  loki_data:

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -310,6 +310,55 @@ Example Docker logging options (already included in compose example):
 - `max-size=10m`
 - `max-file=5`
 
+## 5.3 Centralized Logging with Grafana Loki
+
+BlueCollar ships Loki + Promtail in `docker-compose.yml` for centralized log aggregation.
+
+### Services
+
+| Service  | Port | Purpose                          |
+|----------|------|----------------------------------|
+| Loki     | 3100 | Log storage and query engine     |
+| Promtail | —    | Log collector (Docker SD)        |
+
+Promtail uses Docker service discovery to tail all container stdout/stderr and labels each stream with `service` and `container`. JSON fields (`level`, `msg`, `err`) are promoted to Loki labels for the `api` service.
+
+### Grafana Setup
+
+The Loki datasource is auto-provisioned at `deploy/grafana/provisioning/datasources/loki.yml`. The **BlueCollar Log Explorer** dashboard (`deploy/grafana/dashboards/logs-explorer.json`) is loaded automatically when Grafana mounts `deploy/grafana/dashboards/` as its dashboard directory.
+
+### Common LogQL Queries
+
+```logql
+# All API logs
+{service="api"}
+
+# Only ERROR-level lines
+{service="api"} | json | level="error"
+
+# Filter by keyword
+{service="api"} |= "database"
+
+# Error rate per minute (for alerting / graphs)
+sum(rate({service="api"} |~ "(?i)error" [1m]))
+
+# Logs from a specific container
+{container="blue-collar-api-1"}
+
+# All containers, last 100 lines
+{container=~".+"}
+
+# Auth failures
+{service="api"} |= "Unauthorized"
+
+# Slow requests (>1000 ms, if API logs responseTime)
+{service="api"} | json | responseTime > 1000
+```
+
+### Alert: HighErrorLogRate
+
+Defined in `deploy/loki/alerts.yml`. Fires when the API emits more than **10 ERROR log lines per minute** for at least 1 minute. Alerts are forwarded to Alertmanager at `http://alertmanager:9093`.
+
 ## 5.3 Alerting
 
 Create alerts for:
@@ -376,3 +425,50 @@ Recovery sequence:
 - Rollback plan confirmed
 
 This deployment guide should be updated whenever infrastructure, contract IDs, or traffic architecture changes.
+
+
+## 8. Staging Environment
+
+Staging mirrors production configuration but targets Stellar **testnet** and an isolated database. It is deployed automatically on every merge to `develop`.
+
+### Services
+
+| Service | URL |
+|---------|-----|
+| API     | `https://api-staging.bluecollar.app` |
+| App     | `https://staging.bluecollar.app` |
+
+### Local Setup
+
+```bash
+cp packages/api/.env.staging.example  packages/api/.env.staging
+cp packages/app/.env.staging.example  packages/app/.env.staging
+# Fill in real values, then:
+docker compose -f docker-compose.staging.yml up -d --build
+```
+
+### Environment Variables
+
+- `packages/api/.env.staging.example` — API staging variables (Stellar testnet, staging DB)
+- `packages/app/.env.staging.example` — App staging variables (`NEXT_PUBLIC_STELLAR_NETWORK=TESTNET`)
+
+### CI/CD
+
+`.github/workflows/deploy-staging.yml` triggers on push to `develop`:
+
+1. Writes env files from GitHub secrets (`STAGING_API_ENV`, `STAGING_APP_ENV`)
+2. SSHes into the staging host and runs `docker compose -f docker-compose.staging.yml up -d --build`
+3. Runs `prisma migrate deploy` inside the API container
+4. Runs `deploy/scripts/smoke-tests-staging.sh` — checks `/health`, `/api/categories`, and the app homepage
+
+### Required GitHub Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `STAGING_HOST` | Staging server IP / hostname |
+| `STAGING_USER` | SSH username |
+| `STAGING_SSH_KEY` | Private SSH key |
+| `STAGING_API_ENV` | Full contents of `packages/api/.env.staging` |
+| `STAGING_APP_ENV` | Full contents of `packages/app/.env.staging` |
+| `STAGING_API_URL` | Public API URL for smoke tests |
+| `STAGING_APP_URL` | Public App URL for smoke tests |

--- a/packages/api/.env.staging.example
+++ b/packages/api/.env.staging.example
@@ -1,0 +1,39 @@
+# ─── Staging API Environment Variables ───────────────────────────────────────
+# Copy to packages/api/.env.staging and fill in real values.
+# Never commit .env.staging — only this .env.staging.example file.
+
+DATABASE_URL="postgresql://bluecollar:staging-change-me@db:5432/bluecollar_staging"
+TEST_DATABASE_URL="postgresql://bluecollar:staging-change-me@db:5432/bluecollar_staging_test"
+
+JWT_SECRET="staging-jwt-secret-change-me"
+
+PORT=3000
+NODE_ENV="staging"
+LOG_LEVEL="debug"
+
+APP_URL="https://staging.bluecollar.app"
+ALLOWED_ORIGINS="https://staging.bluecollar.app"
+
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX=200
+
+REDIS_URL="redis://redis:6379"
+
+UPLOAD_DIR="storage/uploads"
+MAX_FILE_SIZE=5242880
+
+GOOGLE_CLIENT_ID="your-staging-google-client-id.apps.googleusercontent.com"
+GOOGLE_CLIENT_SECRET="your-staging-google-client-secret"
+
+MAIL_HOST="smtp.example.com"
+MAIL_PORT=587
+MAIL_USER="staging-no-reply@example.com"
+MAIL_PASS="your-staging-smtp-password"
+
+VAPID_PUBLIC_KEY=""
+VAPID_PRIVATE_KEY=""
+
+# Stellar testnet — staging always uses testnet
+HORIZON_URL="https://horizon-testnet.stellar.org"
+REGISTRY_CONTRACT_ID="your-testnet-registry-contract-id"
+MARKET_CONTRACT_ID="your-testnet-market-contract-id"

--- a/packages/app/.env.staging.example
+++ b/packages/app/.env.staging.example
@@ -1,0 +1,13 @@
+# ─── Staging App Environment Variables ───────────────────────────────────────
+# Copy to packages/app/.env.staging and fill in real values.
+# Never commit .env.staging — only this .env.staging.example file.
+
+NEXT_PUBLIC_API_URL="https://api-staging.bluecollar.app/api"
+
+# Staging always uses Stellar testnet
+NEXT_PUBLIC_STELLAR_NETWORK="TESTNET"
+
+NEXT_PUBLIC_MARKET_CONTRACT_ID="your-testnet-market-contract-id"
+NEXT_PUBLIC_REGISTRY_CONTRACT_ID="your-testnet-registry-contract-id"
+
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=""


### PR DESCRIPTION
- Add docker-compose.staging.yml mirroring prod config (Stellar testnet, isolated DB)
- Add packages/api/.env.staging.example and packages/app/.env.staging.example
- Add .github/workflows/deploy-staging.yml triggered on push to develop
- Add deploy/scripts/smoke-tests-staging.sh (health, categories, app homepage)
- Document staging setup in docs/PRODUCTION_DEPLOYMENT.md (section 8)

Closes #575
Closes #576
Closes #577 
Closes #574 

## Description

<!-- A clear and concise description of what this PR does. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Testing Done

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] Tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Docs updated (if applicable)
- [ ] No unrelated changes included
