### PR TITLE
feat(mailer): consolidate email template helpers (#660 #661)

### DIFF
--- a/packages/api/src/mailer/index.ts
+++ b/packages/api/src/mailer/index.ts
@@ -1,39 +1,28 @@
-import { readFileSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { transporter } from './transport.js'
 import { logger } from '../config/logger.js'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-function loadTemplate(name: string): string {
-  return readFileSync(join(__dirname, 'templates', name), 'utf-8')
-}
+import { render } from './templateEngine.js'
 
 const APP_URL = process.env.APP_URL ?? 'http://localhost:3000'
 const FROM = `BlueCollar <${process.env.MAIL_USER}>`
 
 export async function sendVerificationEmail(to: string, name: string, token: string) {
-  const html = loadTemplate('verify-email.html')
-    .replace(/{{name}}/g, name)
-    .replace(/{{verificationLink}}/g, `${APP_URL}/api/auth/verify-account?token=${token}`)
-
+  const html = render('verify-email.html', {
+    name,
+    verificationLink: `${APP_URL}/api/auth/verify-account?token=${token}`,
+  })
   await transporter.sendMail({ from: FROM, to, subject: 'Verify your BlueCollar email', html })
 }
 
 export async function sendPasswordResetEmail(to: string, name: string, token: string) {
-  const html = loadTemplate('reset-password.html')
-    .replace(/{{name}}/g, name)
-    .replace(/{{resetLink}}/g, `${APP_URL}/reset-password?token=${token}`)
-
+  const html = render('reset-password.html', {
+    name,
+    resetLink: `${APP_URL}/reset-password?token=${token}`,
+  })
   await transporter.sendMail({ from: FROM, to, subject: 'Reset your BlueCollar password', html })
 }
 
 export async function sendWelcomeEmail(to: string, name: string) {
-  const html = loadTemplate('welcome.html')
-    .replace(/{{name}}/g, name)
-    .replace(/{{appUrl}}/g, APP_URL)
-
+  const html = render('welcome.html', { name, appUrl: APP_URL })
   await transporter.sendMail({ from: FROM, to, subject: 'Welcome to BlueCollar 🎉', html })
 }
 

--- a/packages/api/src/mailer/templateEngine.test.ts
+++ b/packages/api/src/mailer/templateEngine.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }))
+
+import { readFileSync } from 'node:fs'
+import { render } from './templateEngine.js'
+
+const mockReadFileSync = vi.mocked(readFileSync)
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('render', () => {
+  it('replaces all placeholders with provided vars', () => {
+    mockReadFileSync.mockReturnValue('<p>Hi {{name}}, click {{link}}</p>' as any)
+    const result = render('test.html', { name: 'Alice', link: 'https://example.com' })
+    expect(result).toBe('<p>Hi Alice, click https://example.com</p>')
+  })
+
+  it('replaces multiple occurrences of the same placeholder', () => {
+    mockReadFileSync.mockReturnValue('<p>{{name}} — {{name}}</p>' as any)
+    const result = render('test.html', { name: 'Bob' })
+    expect(result).toBe('<p>Bob — Bob</p>')
+  })
+
+  it('leaves unmatched placeholders untouched when var is missing', () => {
+    mockReadFileSync.mockReturnValue('<p>Hi {{name}}, token={{token}}</p>' as any)
+    const result = render('test.html', { name: 'Carol' })
+    expect(result).toBe('<p>Hi Carol, token={{token}}</p>')
+  })
+
+  it('returns the raw template unchanged when vars is empty', () => {
+    const raw = '<p>Hello {{name}}</p>'
+    mockReadFileSync.mockReturnValue(raw as any)
+    const result = render('test.html', {})
+    expect(result).toBe(raw)
+  })
+
+  it('passes the correct file path to readFileSync', () => {
+    mockReadFileSync.mockReturnValue('' as any)
+    render('welcome.html', {})
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('welcome.html'),
+      'utf-8',
+    )
+  })
+})

--- a/packages/api/src/mailer/templateEngine.ts
+++ b/packages/api/src/mailer/templateEngine.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export function render(templateName: string, vars: Record<string, string>): string {
+  let html = readFileSync(join(__dirname, 'templates', templateName), 'utf-8')
+  for (const [key, value] of Object.entries(vars)) {
+    html = html.replaceAll(`{{${key}}}`, value)
+  }
+  return html
+}


### PR DESCRIPTION
## Summary

Extracts the repeated template-loading and variable-interpolation logic from the mailer into a shared `templateEngine.ts` utility.

## Changes

- **New:** `packages/api/src/mailer/templateEngine.ts` — exports a single `render(templateName, vars)` function that reads an HTML template file and replaces all `{{key}}` placeholders with the provided values
- **Updated:** `sendVerificationEmail`, `sendPasswordResetEmail`, `sendWelcomeEmail` in `index.ts` now delegate to `render()`; the local `loadTemplate` helper and its `fs`/`path`/`url` imports are removed
- **New:** `packages/api/src/mailer/templateEngine.test.ts` — 5 unit tests covering successful render, repeated placeholders, missing variable (left untouched), empty vars, and correct file path forwarding

## What was NOT changed

- Email content, subjects, and recipients are identical
- The 4 remaining mailer functions that use inline HTML strings are untouched

## Tests

All 5 new unit tests pass (`pnpm vitest run src/mailer/templateEngine.test.ts`).

Closes #660
Closes #661