### PR TITLE
feat(app): meet WCAG 2.1 AA with screen-reader + keyboard support

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,92 @@
+name: Accessibility
+
+# WCAG 2.1 AA accessibility checks for the web app: component-level axe unit
+# tests (blocking) and full-page axe scans via Playwright (non-blocking report).
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/app/**"
+      - ".github/workflows/accessibility.yml"
+  pull_request:
+    paths:
+      - "packages/app/**"
+      - ".github/workflows/accessibility.yml"
+  workflow_dispatch:
+
+env:
+  CI: "true"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Component-level accessibility unit tests (axe-core via vitest). Blocking.
+  # ---------------------------------------------------------------------------
+  a11y-unit:
+    name: Component a11y tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run accessibility unit tests
+        run: pnpm --filter @bluecollar/app test:a11y
+
+  # ---------------------------------------------------------------------------
+  # Full-page accessibility scan (axe-core via Playwright). Non-blocking; the
+  # scan report is uploaded as an artifact for review.
+  # ---------------------------------------------------------------------------
+  a11y-e2e:
+    name: Full-page a11y scan
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @bluecollar/app exec playwright install --with-deps chromium
+
+      - name: Seed local env
+        working-directory: packages/app
+        run: cp .env.example .env.local || true
+
+      - name: Start dev server
+        working-directory: packages/app
+        run: pnpm exec next dev -p 3001 &
+
+      - name: Wait for server
+        run: npx --yes wait-on http://localhost:3001 --timeout 120000
+
+      - name: Run Playwright accessibility scan
+        working-directory: packages/app
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost:3001
+        run: pnpm exec playwright test accessibility
+
+      - name: Upload accessibility report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: accessibility-report
+          path: |
+            packages/app/playwright-report
+            packages/app/a11y-reports
+          if-no-files-found: ignore

--- a/packages/app/src/__tests__/accessibility.test.tsx
+++ b/packages/app/src/__tests__/accessibility.test.tsx
@@ -1,13 +1,16 @@
 /**
- * Automated accessibility tests using axe-core (WCAG 2.1 AA compliance).
+ * Automated accessibility tests using axe-core (WCAG 2.1 AA compliance),
+ * plus keyboard-navigation and focus-management checks.
  *
  * Tests render each key component/page fragment and run axe against it.
  * Any axe violation causes the test to fail with a descriptive message.
  */
 
-import { render } from '@testing-library/react'
-import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
 import axe from 'axe-core'
+import React from 'react'
 
 // ─── Shared mocks ─────────────────────────────────────────────────────────────
 
@@ -19,7 +22,7 @@ vi.mock('next/link', () => ({
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/',
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
 }))
 
@@ -27,65 +30,30 @@ vi.mock('next-themes', () => ({
   useTheme: () => ({ resolvedTheme: 'light', setTheme: vi.fn() }),
 }))
 
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (key: string) => key,
+  useMessages: () => ({}),
+}))
+
 vi.mock('next/image', () => ({
   default: ({ src, alt, ...props }: any) => <img src={src} alt={alt} {...props} />,
 }))
 
-vi.mock('lucide-react', () => ({
-  Menu: () => <span aria-hidden="true" />,
-  Wallet: () => <span aria-hidden="true" />,
-  ChevronDown: () => <span aria-hidden="true" />,
-  User: () => <span aria-hidden="true" />,
-  Sun: () => <span aria-hidden="true" />,
-  Moon: () => <span aria-hidden="true" />,
-  MapPin: () => <span aria-hidden="true" />,
-  BadgeCheck: ({ 'aria-label': label }: any) => <span aria-label={label} />,
-  Star: () => <span aria-hidden="true" />,
-  X: () => <span aria-hidden="true" />,
-  Search: () => <span aria-hidden="true" />,
-  Bell: () => <span aria-hidden="true" />,
-  Home: () => <span aria-hidden="true" />,
-  Briefcase: () => <span aria-hidden="true" />,
-  Settings: () => <span aria-hidden="true" />,
-  LogOut: () => <span aria-hidden="true" />,
-  LayoutDashboard: () => <span aria-hidden="true" />,
-  Globe: () => <span aria-hidden="true" />,
-  ChevronRight: () => <span aria-hidden="true" />,
-  ExternalLink: () => <span aria-hidden="true" />,
-  AlertCircle: () => <span aria-hidden="true" />,
-  CheckCircle: () => <span aria-hidden="true" />,
-  Info: () => <span aria-hidden="true" />,
-  Loader2: () => <span aria-hidden="true" />,
-  Eye: () => <span aria-hidden="true" />,
-  EyeOff: () => <span aria-hidden="true" />,
-  Upload: () => <span aria-hidden="true" />,
-  Camera: () => <span aria-hidden="true" />,
-  Trash2: () => <span aria-hidden="true" />,
-  Edit: () => <span aria-hidden="true" />,
-  Plus: () => <span aria-hidden="true" />,
-  Minus: () => <span aria-hidden="true" />,
-  Copy: () => <span aria-hidden="true" />,
-  QrCode: () => <span aria-hidden="true" />,
-  Bookmark: () => <span aria-hidden="true" />,
-  BookmarkCheck: () => <span aria-hidden="true" />,
-  Share2: () => <span aria-hidden="true" />,
-  Filter: () => <span aria-hidden="true" />,
-  SlidersHorizontal: () => <span aria-hidden="true" />,
-  Grid: () => <span aria-hidden="true" />,
-  List: () => <span aria-hidden="true" />,
-  ArrowLeft: () => <span aria-hidden="true" />,
-  ArrowRight: () => <span aria-hidden="true" />,
-  RefreshCw: () => <span aria-hidden="true" />,
-  Zap: () => <span aria-hidden="true" />,
-  Shield: () => <span aria-hidden="true" />,
-  Award: () => <span aria-hidden="true" />,
-  TrendingUp: () => <span aria-hidden="true" />,
-  Clock: () => <span aria-hidden="true" />,
-  Calendar: () => <span aria-hidden="true" />,
-  Phone: () => <span aria-hidden="true" />,
-  Mail: () => <span aria-hidden="true" />,
-  MessageSquare: () => <span aria-hidden="true" />,
-}))
+// Mock every lucide icon as a decorative (aria-hidden) span via a Proxy, so we
+// never have to enumerate icon names. Icons given an explicit aria-label keep it.
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const Icon = ({ 'aria-label': label, 'aria-hidden': hidden }: any) =>
+    label ? <span aria-label={label} role="img" /> : <span aria-hidden={hidden ?? 'true'} />
+  // Replace every real lucide export with a decorative icon so we keep all
+  // named exports (vitest validates named imports against the mock).
+  const mock: Record<string, unknown> = {}
+  for (const key of Object.keys(actual)) {
+    mock[key] = typeof (actual as any)[key] === 'function' ? Icon : (actual as any)[key]
+  }
+  return mock
+})
 
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: vi.fn(() => ({
@@ -113,12 +81,31 @@ vi.mock('@/context/AuthContext', () => ({
   })),
 }))
 
+vi.mock('@/lib/api', () => ({
+  sendContactRequest: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@/context/NotificationContext', () => ({
+  useNotifications: () => ({
+    notifications: [],
+    unreadCount: 0,
+    markRead: vi.fn(),
+    markAllRead: vi.fn(),
+    addNotification: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}))
+
+// jsdom has no canvas; stub getContext so chart/qr components don't throw noise.
+beforeAll(() => {
+  if (typeof HTMLCanvasElement !== 'undefined') {
+    HTMLCanvasElement.prototype.getContext = vi.fn() as any
+  }
+})
+
 // ─── axe helper ───────────────────────────────────────────────────────────────
 
-/**
- * Run axe on the rendered container and return violations.
- * Configured for WCAG 2.1 AA.
- */
+/** Run axe on the rendered container (WCAG 2.1 AA) and return violations. */
 async function runAxe(container: Element) {
   const results = await axe.run(container, {
     runOnly: {
@@ -138,13 +125,21 @@ function formatViolations(violations: axe.Result[]): string {
     .join('\n')
 }
 
-// ─── Tests ────────────────────────────────────────────────────────────────────
+/** Render a component and assert it has zero axe violations. */
+async function expectNoViolations(ui: React.ReactElement) {
+  const { container } = render(ui)
+  const violations = await runAxe(container)
+  expect(violations, formatViolations(violations)).toHaveLength(0)
+}
+
+// ─── Component axe tests ────────────────────────────────────────────────────
 
 describe('Accessibility (WCAG 2.1 AA)', () => {
-  describe('WorkerCard', () => {
-    it('has no axe violations', async () => {
-      const { default: WorkerCard } = await import('@/components/WorkerCard')
-      const { container } = render(
+  it('WorkerCard has no violations', async () => {
+    const { default: WorkerCard } = await import('@/components/WorkerCard')
+    const { CompareProvider } = await import('@/context/CompareContext')
+    await expectNoViolations(
+      <CompareProvider>
         <WorkerCard
           worker={{
             id: 'w1',
@@ -154,87 +149,147 @@ describe('Accessibility (WCAG 2.1 AA)', () => {
             bio: 'Expert plumber',
             location: 'Lagos, Nigeria',
           }}
-        />,
-      )
-      const violations = await runAxe(container)
-      expect(violations, formatViolations(violations)).toHaveLength(0)
-    })
+        />
+      </CompareProvider>,
+    )
   })
 
-  describe('Navbar (logged out)', () => {
-    it('has no axe violations', async () => {
-      const { default: Navbar } = await import('@/components/Navbar')
-      const { container } = render(<Navbar />)
-      const violations = await runAxe(container)
-      expect(violations, formatViolations(violations)).toHaveLength(0)
-    })
+  it('Navbar (logged out) has no violations', async () => {
+    const { default: Navbar } = await import('@/components/Navbar')
+    await expectNoViolations(<Navbar />)
   })
 
-  describe('Footer', () => {
-    it('has no axe violations', async () => {
-      const { default: Footer } = await import('@/components/Footer')
-      const { container } = render(<Footer />)
-      const violations = await runAxe(container)
-      expect(violations, formatViolations(violations)).toHaveLength(0)
-    })
+  it('Footer has no violations', async () => {
+    const { default: Footer } = await import('@/components/Footer')
+    await expectNoViolations(<Footer />)
   })
 
-  describe('EmptyState', () => {
-    it('has no axe violations', async () => {
-      const { default: EmptyState } = await import('@/components/EmptyState')
-      const { container } = render(
-        <EmptyState title="No workers found" description="Try adjusting your search." />,
-      )
-      const violations = await runAxe(container)
-      expect(violations, formatViolations(violations)).toHaveLength(0)
-    })
+  it('EmptyState has no violations', async () => {
+    const { default: EmptyState } = await import('@/components/EmptyState')
+    await expectNoViolations(<EmptyState variant="no-workers" />)
   })
 
-  describe('StarRating', () => {
-    it('has no axe violations', async () => {
-      const { default: StarRating } = await import('@/components/StarRating')
-      const { container } = render(<StarRating rating={4} />)
-      const violations = await runAxe(container)
-      expect(violations, formatViolations(violations)).toHaveLength(0)
-    })
+  it('StarRating has no violations and exposes an accessible label', async () => {
+    const { default: StarRating } = await import('@/components/StarRating')
+    const { container } = render(<StarRating rating={4} />)
+    expect(screen.getByRole('img', { name: '4 out of 5 stars' })).toBeInTheDocument()
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
   })
 
-  describe('FormField', () => {
-    it('has no axe violations with label and input', async () => {
-      const { default: FormField } = await import('@/components/FormField')
-      const { container } = render(
-        <FormField label="Email address" name="email" type="email" />,
-      )
-      const violations = await runAxe(container)
-      expect(violations, formatViolations(violations)).toHaveLength(0)
-    })
+  it('FormField has no violations', async () => {
+    const { default: FormField } = await import('@/components/FormField')
+    await expectNoViolations(<FormField label="Email address" name="email" type="email" />)
   })
 
-  describe('PasswordStrength', () => {
-    it('has no axe violations', async () => {
-      const { default: PasswordStrength } = await import('@/components/PasswordStrength')
-      const { container } = render(<PasswordStrength password="Test123!" />)
-      const violations = await runAxe(container)
-      expect(violations, formatViolations(violations)).toHaveLength(0)
-    })
+  it('PasswordStrength has no violations', async () => {
+    const { default: PasswordStrength } = await import('@/components/PasswordStrength')
+    await expectNoViolations(<PasswordStrength password="Test123!" />)
   })
 
-  describe('ReviewCard', () => {
-    it('has no axe violations', async () => {
-      const { default: ReviewCard } = await import('@/components/ReviewCard')
-      const { container } = render(
-        <ReviewCard
-          review={{
-            id: 'r1',
-            rating: 5,
-            comment: 'Excellent work!',
-            author: { name: 'Alice Smith' },
-            createdAt: '2024-01-01T00:00:00Z',
-          }}
-        />,
-      )
-      const violations = await runAxe(container)
-      expect(violations, formatViolations(violations)).toHaveLength(0)
-    })
+  it('ReviewCard has no violations', async () => {
+    const { default: ReviewCard } = await import('@/components/ReviewCard')
+    await expectNoViolations(
+      <ReviewCard
+        review={{
+          id: 'r1',
+          rating: 5,
+          comment: 'Excellent work!',
+          workerId: 'w1',
+          authorId: 'a1',
+          createdAt: '2024-01-01T00:00:00Z',
+          author: { id: 'a1', firstName: 'Alice', lastName: 'Smith' },
+        }}
+      />,
+    )
+  })
+
+  it('IconButton has no violations', async () => {
+    const { IconButton } = await import('@/components/IconButton')
+    await expectNoViolations(
+      <IconButton aria-label="Open menu">
+        <span aria-hidden="true" />
+      </IconButton>,
+    )
+  })
+
+  it('CategoryBadge has no violations', async () => {
+    const { CategoryBadge } = await import('@/components/CategoryBadge')
+    await expectNoViolations(<CategoryBadge slug="plumbing" />)
+  })
+
+  it('BottomNav (logged in) has no violations', async () => {
+    const { useAuth } = await import('@/hooks/useAuth')
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'u1', firstName: 'Sam', lastName: 'Doe', email: 's@e.com' },
+      logout: vi.fn(),
+      token: 't',
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+    } as any)
+    const { default: BottomNav } = await import('@/components/BottomNav')
+    await expectNoViolations(<BottomNav />)
+  })
+
+  it('ContactModal trigger has no violations', async () => {
+    const { default: ContactModal } = await import('@/components/ContactModal')
+    await expectNoViolations(<ContactModal workerId="w1" workerName="Jane Doe" />)
+  })
+})
+
+// ─── Keyboard navigation ──────────────────────────────────────────────────────
+
+describe('Keyboard navigation', () => {
+  it('IconButton is focusable and activates with Enter and Space', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    const { IconButton } = await import('@/components/IconButton')
+    render(
+      <IconButton aria-label="Refresh" onClick={onClick}>
+        <span aria-hidden="true" />
+      </IconButton>,
+    )
+
+    const button = screen.getByRole('button', { name: 'Refresh' })
+    await user.tab()
+    expect(button).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+    await user.keyboard(' ')
+    expect(onClick).toHaveBeenCalledTimes(2)
+  })
+
+  it('Navbar links are reachable in tab order', async () => {
+    const user = userEvent.setup()
+    const { default: Navbar } = await import('@/components/Navbar')
+    render(<Navbar />)
+    // Tabbing should land on a focusable element (a link or button), not be trapped.
+    await user.tab()
+    expect(document.activeElement).not.toBe(document.body)
+  })
+})
+
+// ─── Focus management for dynamic content ───────────────────────────────────────
+
+describe('Focus management', () => {
+  it('ContactModal moves focus into the dialog when opened and labels its close button', async () => {
+    const user = userEvent.setup()
+    const { default: ContactModal } = await import('@/components/ContactModal')
+    render(<ContactModal workerId="w1" workerName="Jane Doe" />)
+
+    await user.click(screen.getByRole('button', { name: /contact/i }))
+
+    // Radix moves focus into the dialog and exposes it as role="dialog".
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true))
+
+    // The icon-only close control has an accessible name.
+    expect(screen.getByRole('button', { name: /close dialog/i })).toBeInTheDocument()
+
+    // Opened dialog itself is free of axe violations.
+    const violations = await runAxe(dialog)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
   })
 })

--- a/packages/app/src/app/[locale]/layout.tsx
+++ b/packages/app/src/app/[locale]/layout.tsx
@@ -25,6 +25,9 @@ export default async function LocaleLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <body>
+        <a href="#main-content" className="skip-to-main">
+          Skip to main content
+        </a>
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem storageKey="bc_theme">
             <AuthProvider>
@@ -32,7 +35,9 @@ export default async function LocaleLayout({
                 <CompareProvider>
                   <WebVitalsReporter />
                   <OfflineBanner />
-                  {children}
+                  <div id="main-content" tabIndex={-1}>
+                    {children}
+                  </div>
                   <CompareDrawer />
                   <OnboardingTour />
                 </CompareProvider>

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -1,4 +1,7 @@
 @import "tailwindcss";
+/* App-wide accessibility base styles + WCAG-AA contrast tokens. */
+@import "../styles/contrast-tokens.css";
+@import "../styles/accessibility.css";
 
 @layer base {
   :root {

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -52,6 +52,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
+        <a href="#main-content" className="skip-to-main">
+          Skip to main content
+        </a>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem storageKey="bc_theme">
           <AuthProvider>
             <WalletProvider>
@@ -59,7 +62,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 <OfflineBanner />
                 <ServiceWorkerRegister />
                 <WebVitalsReporter />
-                {children}
+                <div id="main-content" tabIndex={-1}>
+                  {children}
+                </div>
                 <PushNotificationPrompt />
               </OnboardingProvider>
             </WalletProvider>

--- a/packages/app/src/components/ContactModal.tsx
+++ b/packages/app/src/components/ContactModal.tsx
@@ -67,14 +67,17 @@ export default function ContactModal({ workerId, workerName }: Props) {
                 Send a message to get in touch.
               </Dialog.Description>
             </div>
-            <Dialog.Close className="rounded-md p-1 text-gray-400 hover:text-gray-600 transition-colors">
-              <X size={18} />
+            <Dialog.Close
+              aria-label="Close dialog"
+              className="rounded-md p-1 text-gray-400 hover:text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              <X size={18} aria-hidden="true" />
             </Dialog.Close>
           </div>
 
           {status === "success" ? (
-            <div className="mt-6 flex flex-col items-center gap-3 py-4 text-center">
-              <CheckCircle2 size={36} className="text-green-500" />
+            <div role="status" className="mt-6 flex flex-col items-center gap-3 py-4 text-center">
+              <CheckCircle2 size={36} className="text-green-500" aria-hidden="true" />
               <p className="text-sm font-medium text-gray-800">Message sent!</p>
               <p className="text-xs text-gray-500">
                 {workerName} will be notified and may reach out to you.
@@ -99,11 +102,14 @@ export default function ContactModal({ workerId, workerName }: Props) {
                 />
                 <div className="mt-1 flex justify-between">
                   {error ? (
-                    <p className="text-xs text-red-500">{error}</p>
+                    <p role="alert" className="text-xs text-red-500">{error}</p>
                   ) : (
                     <span />
                   )}
-                  <span className={`text-xs ${message.length > 1000 ? "text-red-500" : "text-gray-400"}`}>
+                  <span
+                    aria-live="polite"
+                    className={`text-xs ${message.length > 1000 ? "text-red-500" : "text-gray-400"}`}
+                  >
                     {message.length}/1000
                   </span>
                 </div>

--- a/packages/app/src/components/StarRating.tsx
+++ b/packages/app/src/components/StarRating.tsx
@@ -11,11 +11,16 @@ interface StarRatingProps {
 /** Renders filled/empty stars for a numeric rating. */
 export default function StarRating({ rating, max = 5, size = 14, className }: StarRatingProps) {
   return (
-    <span className={cn("flex items-center gap-0.5", className)} aria-label={`${rating} out of ${max} stars`}>
+    <span
+      role="img"
+      aria-label={`${rating} out of ${max} stars`}
+      className={cn("flex items-center gap-0.5", className)}
+    >
       {Array.from({ length: max }, (_, i) => (
         <Star
           key={i}
           size={size}
+          aria-hidden="true"
           className={i < Math.round(rating) ? "text-yellow-400" : "text-gray-200"}
           fill={i < Math.round(rating) ? "currentColor" : "none"}
         />

--- a/packages/app/src/components/TipModal.tsx
+++ b/packages/app/src/components/TipModal.tsx
@@ -156,8 +156,11 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                 Reward {workerName} for excellent service
               </Dialog.Description>
             </div>
-            <Dialog.Close className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
-              <X size={20} />
+            <Dialog.Close
+              aria-label="Close dialog"
+              className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              <X size={20} aria-hidden="true" />
             </Dialog.Close>
           </div>
 

--- a/packages/app/src/components/ui/dialog.tsx
+++ b/packages/app/src/components/ui/dialog.tsx
@@ -34,8 +34,9 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogClose className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">
-        <X className="h-4 w-4" />
+      <DialogClose className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+        <X className="h-4 w-4" aria-hidden="true" />
+        <span className="sr-only">Close</span>
       </DialogClose>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/packages/app/src/styles/accessibility.css
+++ b/packages/app/src/styles/accessibility.css
@@ -1,7 +1,9 @@
 /*
- * WCAG 2.1 AA Accessibility Fixes
+ * WCAG 2.1 AA accessibility base styles.
+ * Imported from app/globals.css so these rules apply app-wide.
  */
 
+/* Visible, high-contrast focus indicator for keyboard users only. */
 :focus-visible {
   outline: 3px solid #2563eb;
   outline-offset: 2px;
@@ -12,6 +14,7 @@
   outline: none;
 }
 
+/* Skip link: hidden until focused, then revealed at the top-left. */
 .skip-to-main {
   position: absolute;
   left: -9999px;
@@ -28,24 +31,51 @@
   left: 0;
 }
 
-button,
-a,
-[role="button"],
-input[type="checkbox"],
-input[type="radio"] {
-  min-height: 44px;
-  min-width: 44px;
+/*
+ * Touch-target sizing (WCAG 2.5.5). Only enforced on coarse pointers (touch)
+ * so desktop layouts and inline text links are unaffected.
+ */
+@media (pointer: coarse) {
+  button,
+  [role="button"],
+  input[type="checkbox"],
+  input[type="radio"] {
+    min-height: 44px;
+    min-width: 44px;
+  }
 }
 
-body {
-  color: #111827;
-}
-
+/* Honor the user's reduced-motion preference. */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
   *::after {
     animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Strengthen focus and borders when the user requests more contrast. */
+@media (prefers-contrast: more) {
+  :focus-visible {
+    outline-width: 4px;
+    outline-color: #1d4ed8;
+  }
+  *,
+  *::before,
+  *::after {
+    border-color: currentColor;
+  }
+}
+
+/*
+ * Windows High Contrast / forced-colors mode: keep focus indicators visible
+ * using system colors instead of custom ones that get overridden.
+ */
+@media (forced-colors: active) {
+  :focus-visible {
+    outline: 3px solid Highlight;
   }
 }

--- a/packages/app/tailwind.config.ts
+++ b/packages/app/tailwind.config.ts
@@ -5,7 +5,27 @@ const config: Config = {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
     extend: {
+      // Accessibility: media-query variants for user contrast preferences so
+      // components can opt into stronger styling, e.g. `contrast-more:border-2`.
+      screens: {
+        'contrast-more': { raw: '(prefers-contrast: more)' },
+        'contrast-less': { raw: '(prefers-contrast: less)' },
+      },
+      // WCAG-AA verified text/brand colors (see src/styles/contrast-tokens.css).
+      // `a11y` ring color is used for the keyboard focus indicator.
+      ringColor: {
+        a11y: '#2563eb',
+      },
+      outlineColor: {
+        a11y: '#2563eb',
+      },
       colors: {
+        // WCAG-AA accessible foreground tokens (>= 4.5:1 on white).
+        'text-accessible': {
+          primary: '#111827',
+          secondary: '#374151',
+          muted: '#4b5563',
+        },
         brand: {
           50:  '#eff6ff',
           100: '#dbeafe',


### PR DESCRIPTION
Audit and harden the web app's accessibility, wire up dormant a11y
infrastructure, and prove compliance with automated tests + CI.

Component fixes (axe-verified):
- StarRating: aria-label sat on a roleless <span> (axe aria-prohibited-attr);
  add role="img" and aria-hidden on the decorative star icons
- icon-only close buttons had no accessible name â add aria-label / sr-only
  "Close" and aria-hidden icons in ui/dialog, ContactModal, and TipModal
- ContactModal dynamic content: role="alert" on validation errors,
  role="status" on the success state, aria-live on the character counter

Wire up + fix dormant a11y stylesheets (were never imported):
- import styles/accessibility.css and styles/contrast-tokens.css in globals.css
- accessibility.css: drop the dark-mode-breaking `body { color }`, scope the
  44px touch-target rule to (pointer: coarse), and add prefers-reduced-motion,
  prefers-contrast, and forced-colors support
- add a skip-to-main link + #main-content focus target to both root layouts
- tailwind.config.ts: contrast-more/contrast-less screens and accessible
  focus-ring / text color tokens
  
  closes #689 