### PR TITLE
feat: on-chain reputation system with weighted scoring and history

### DIFF
--- a/packages/api/src/controllers/workers.ts
+++ b/packages/api/src/controllers/workers.ts
@@ -7,6 +7,7 @@ import { workerSerializer } from '../serializers/index.js'
 import type { CreateWorkerBody, UpdateWorkerBody, WorkerQuery } from '../interfaces/index.js'
 import { invalidateCachePattern } from '../middleware/cache.js'
 import { processImage, deleteImages } from '../utils/imageProcessor.js'
+import { getWorkerReputation, syncReputationToDb } from '../services/stellar.service.js'
 
 // Haversine distance in km between two lat/lng points
 function haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
@@ -382,5 +383,51 @@ export async function advancedSearch(req: Request, res: Response) {
     })
   } catch (error) {
     return handleError(res, error)
+  }
+}
+
+/**
+ * GET /api/workers/:id/reputation
+ * Get the on-chain reputation summary for a worker.
+ *
+ * Returns the worker's verified status, average rating, review count, and
+ * Stellar contract id so the frontend can display trust signals without
+ * requiring a live Stellar RPC call.
+ *
+ * @param req - Route param `id`.
+ * @param res - JSON `{ data: ReputationSummary, status, code }`.
+ */
+export async function getReputation(req: Request, res: Response) {
+  try {
+    const data = await getWorkerReputation(req.params.id)
+    return res.json({ data, status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}
+
+/**
+ * POST /api/workers/:id/reputation/sync
+ * Sync a worker's on-chain reputation data into the local database.
+ *
+ * Called by trusted back-end processes (e.g. a Stellar event listener) after
+ * an on-chain reputation change. Requires `admin` role.
+ *
+ * Body: `{ avgRating: number, reviewCount: number, reputation: number }`
+ *
+ * @param req - Route param `id`. Body: `{ avgRating, reviewCount, reputation }`.
+ * @param res - JSON `{ data: Worker, status, code }`.
+ */
+export async function syncReputation(req: Request, res: Response) {
+  try {
+    const { avgRating, reviewCount, reputation } = req.body as {
+      avgRating: number
+      reviewCount: number
+      reputation: number
+    }
+    const data = await syncReputationToDb(req.params.id, avgRating, reviewCount, reputation)
+    return res.json({ data, status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
   }
 }

--- a/packages/api/src/routes/workers.ts
+++ b/packages/api/src/routes/workers.ts
@@ -11,6 +11,8 @@ import {
   deleteWorker,
   toggleActivation,
   advancedSearch,
+  getReputation,
+  syncReputation,
 } from '../controllers/workers.js'
 import { toggleBookmark } from '../controllers/bookmarks.js'
 import { createWorkerReview, deleteReview, listWorkerReviews } from './reviews.js'
@@ -106,5 +108,10 @@ router.post('/:id/analytics/view', trackView)
 router.get('/:id/analytics', authenticate, authorize('curator', 'admin'), getAnalytics)
 router.get('/:id/analytics/trends', authenticate, authorize('curator', 'admin'), getViewTrends)
 router.get('/:id/analytics', withAuth(['curator', 'admin']), getAnalytics)
+
+// Reputation (#677)
+router.get('/:id/reputation', cacheMiddleware(TTL.SHORT), getReputation)
+router.post('/:id/reputation/sync', authenticate, authorize('admin'), syncReputation)
+router.post('/:id/reputation/sync', withAuth('admin'), syncReputation)
 
 export default router

--- a/packages/api/src/services/stellar.service.ts
+++ b/packages/api/src/services/stellar.service.ts
@@ -11,3 +11,74 @@ export async function registerOnChain(workerId: string, contractId: string) {
     include: { category: true, curator: true }
   })
 }
+
+/**
+ * Sync a worker's on-chain reputation data into the local WorkerAnalytics row.
+ *
+ * This is called after any off-chain event (review submitted, tip recorded) that
+ * should also be reflected in the database so the REST API can serve up-to-date
+ * reputation data without requiring a live Stellar RPC call on every request.
+ *
+ * @param workerId  - Database worker id.
+ * @param avgRating - New average rating (0-10000 basis points).
+ * @param reviewCount - Total review count.
+ * @param reputation  - Computed on-chain reputation score (0-10000 basis points).
+ */
+export async function syncReputationToDb(
+  workerId: string,
+  avgRating: number,
+  reviewCount: number,
+  reputation: number,
+) {
+  const worker = await db.worker.findUnique({ where: { id: workerId } })
+  if (!worker) throw new AppError('Worker not found', 404)
+
+  await db.workerAnalytics.upsert({
+    where: { workerId },
+    update: {
+      avgRating: avgRating / 100,         // convert bps → 0-100 scale
+      reviewCount,
+    },
+    create: {
+      workerId,
+      avgRating: avgRating / 100,
+      reviewCount,
+    },
+  })
+
+  return db.worker.update({
+    where: { id: workerId },
+    data: { stellarContractId: worker.stellarContractId },
+    include: { category: true, curator: true },
+  })
+}
+
+/**
+ * Get the combined on-chain reputation summary for a worker from the local DB.
+ * This is a lightweight read-path that does not need a live Stellar RPC call.
+ *
+ * @param workerId - Database worker id.
+ * @returns Reputation summary object, or null if not found.
+ */
+export async function getWorkerReputation(workerId: string) {
+  const [worker, analytics] = await Promise.all([
+    db.worker.findUnique({
+      where: { id: workerId },
+      select: { id: true, isVerified: true, stellarContractId: true },
+    }),
+    db.workerAnalytics.findUnique({
+      where: { workerId },
+      select: { avgRating: true, reviewCount: true },
+    }),
+  ])
+
+  if (!worker) throw new AppError('Worker not found', 404)
+
+  return {
+    workerId,
+    isVerified: worker.isVerified,
+    stellarContractId: worker.stellarContractId ?? null,
+    avgRating: analytics?.avgRating ?? 0,
+    reviewCount: analytics?.reviewCount ?? 0,
+  }
+}

--- a/packages/contracts/contracts/registry/src/lib.rs
+++ b/packages/contracts/contracts/registry/src/lib.rs
@@ -210,6 +210,34 @@ pub struct Badge {
     pub active: bool,
 }
 
+/// A single immutable reputation history entry (#677).
+#[contracttype]
+#[derive(Clone)]
+pub struct ReputationEvent {
+    /// Previous reputation score.
+    pub previous_score: u32,
+    /// New reputation score after this event.
+    pub new_score: u32,
+    /// Human-readable reason (e.g. "review", "slash", "job_completion").
+    pub reason: Symbol,
+    /// Ledger timestamp when this event was recorded.
+    pub timestamp: u64,
+}
+
+/// Aggregated inputs used to compute the weighted reputation score (#677).
+#[contracttype]
+#[derive(Clone)]
+pub struct ReputationInputs {
+    /// Total tips/payments received (used as job-completion proxy).
+    pub tip_count: u32,
+    /// Running sum of review ratings (basis points) for weighted-average calc.
+    pub rating_sum: u64,
+    /// Total number of ratings submitted.
+    pub rating_count: u32,
+    /// Timestamp of the most recent review (for recency decay).
+    pub last_review_at: u64,
+}
+
 /// Result of a single registration attempt in [`RegistryContract::batch_register`].
 #[contracttype]
 #[derive(Clone)]
@@ -294,6 +322,10 @@ pub enum DataKey {
     WorkerCount,
     /// Persistent storage — pending upgrade record for the timelock mechanism.
     PendingUpgrade,
+    /// Persistent storage — `Vec<ReputationEvent>` history keyed by worker id (#677).
+    ReputationHistory(Symbol),
+    /// Persistent storage — [`ReputationInputs`] keyed by worker id (#677).
+    ReputationInputs(Symbol),
 }
 
 // =============================================================================
@@ -1164,10 +1196,322 @@ fn role_to_id_with_env(env: &Env, role: &Symbol) -> u64 {
             .get(&DataKey::Worker(id.clone()))
             .expect("Worker not found");
 
+        let prev = worker.reputation;
         worker.reputation = score;
         env.storage().persistent().set(&DataKey::Worker(id.clone()), &worker);
 
+        Self::append_reputation_history(&env, &id, prev, score, Symbol::new(&env, "manual"));
+
         env.events().publish((symbol_short!("RepUpd"), id), score);
+    }
+
+    // -------------------------------------------------------------------------
+    // Reputation system (#677)
+    // -------------------------------------------------------------------------
+
+    /// Weights (out of 100) for the three reputation factors.
+    const REP_WEIGHT_QUALITY: u32 = 60;   // review quality (avg rating)
+    const REP_WEIGHT_VOLUME: u32 = 25;    // tip/job-completion volume
+    const REP_WEIGHT_RECENCY: u32 = 15;   // how recent the last review is
+
+    /// Recency half-life in seconds (~90 days).
+    const RECENCY_HALF_LIFE_SECS: u64 = 7_776_000;
+
+    /// Maximum tip count considered for volume score (caps at 10_000 bps).
+    const MAX_TIP_VOLUME: u32 = 50;
+
+    /// Maximum history entries stored per worker.
+    const MAX_HISTORY_LEN: u32 = 100;
+
+    /// Minimum rating sum to trigger a slash (quality below this threshold).
+    /// Below 3000 bps avg with at least 3 reviews triggers automatic slashing.
+    const SLASH_THRESHOLD_RATING: u32 = 3_000;
+    const SLASH_MIN_REVIEWS: u32 = 3;
+
+    /// Compute the weighted reputation score from [`ReputationInputs`].
+    ///
+    /// Formula:
+    /// - quality_score  = avg_rating (bps) × 0.60
+    /// - volume_score   = min(tip_count / MAX_TIP_VOLUME, 1) × 10000 × 0.25
+    /// - recency_score  = decay(last_review_at, now) × 10000 × 0.15
+    ///   where decay = 0.5 ^ (elapsed / HALF_LIFE)  (approximated as linear for gas efficiency)
+    ///
+    /// Returns a score in basis points (0–10000).
+    fn compute_weighted_reputation(inputs: &ReputationInputs, now: u64) -> u32 {
+        // quality component
+        let avg_rating = if inputs.rating_count == 0 {
+            0u32
+        } else {
+            (inputs.rating_sum / inputs.rating_count as u64) as u32
+        };
+        let quality = avg_rating
+            .checked_mul(Self::REP_WEIGHT_QUALITY)
+            .expect("overflow")
+            / 100;
+
+        // volume component — saturate at MAX_TIP_VOLUME tips
+        let vol_bps = (inputs.tip_count.min(Self::MAX_TIP_VOLUME) as u64)
+            .checked_mul(10_000)
+            .expect("overflow")
+            / Self::MAX_TIP_VOLUME as u64;
+        let volume = (vol_bps as u32)
+            .checked_mul(Self::REP_WEIGHT_VOLUME)
+            .expect("overflow")
+            / 100;
+
+        // recency component — linear decay approximation
+        let recency = if inputs.last_review_at == 0 || now <= inputs.last_review_at {
+            0u32
+        } else {
+            let elapsed = now - inputs.last_review_at;
+            // decay = max(0, 1 - elapsed/half_life)
+            let decay_bps: u32 = if elapsed >= Self::RECENCY_HALF_LIFE_SECS {
+                0
+            } else {
+                (10_000u64
+                    .checked_mul(Self::RECENCY_HALF_LIFE_SECS - elapsed)
+                    .expect("overflow")
+                    / Self::RECENCY_HALF_LIFE_SECS) as u32
+            };
+            decay_bps
+                .checked_mul(Self::REP_WEIGHT_RECENCY)
+                .expect("overflow")
+                / 100
+        };
+
+        quality.checked_add(volume).expect("overflow")
+               .checked_add(recency).expect("overflow")
+               .min(10_000)
+    }
+
+    /// Append an entry to the immutable reputation history (capped at MAX_HISTORY_LEN).
+    fn append_reputation_history(env: &Env, id: &Symbol, previous: u32, new_score: u32, reason: Symbol) {
+        let mut history: Vec<ReputationEvent> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ReputationHistory(id.clone()))
+            .unwrap_or(Vec::new(env));
+
+        // Drop oldest entry if at capacity
+        if history.len() >= Self::MAX_HISTORY_LEN {
+            let mut trimmed: Vec<ReputationEvent> = Vec::new(env);
+            for i in 1..history.len() {
+                trimmed.push_back(history.get(i).unwrap());
+            }
+            history = trimmed;
+        }
+
+        history.push_back(ReputationEvent {
+            previous_score: previous,
+            new_score,
+            reason,
+            timestamp: env.ledger().timestamp(),
+        });
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReputationHistory(id.clone()), &history);
+    }
+
+    /// Submit a user review for a worker (#677).
+    ///
+    /// Anyone may submit a review. The rating is recorded in [`ReputationInputs`]
+    /// and the worker's `reputation` and `avg_rating` are recalculated immediately.
+    ///
+    /// # Parameters
+    /// - `reviewer`: Address of the reviewer; `require_auth()` is enforced.
+    /// - `worker_id`: The worker's unique identifier.
+    /// - `rating`: Rating in basis points (0–10000).
+    ///
+    /// # Panics
+    /// - `"Worker not found"` if the worker does not exist.
+    /// - `"Rating out of range"` if `rating > 10000`.
+    /// - `"Contract is paused"` if paused.
+    ///
+    /// # Events
+    /// Emits `("RevSub", worker_id)` with data `(reviewer, rating, new_reputation)`.
+    pub fn submit_review(env: Env, reviewer: Address, worker_id: Symbol, rating: u32) {
+        reviewer.require_auth();
+        Self::require_not_paused(&env);
+        assert!(rating <= 10_000, "Rating out of range");
+
+        let mut worker: Worker = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Worker(worker_id.clone()))
+            .expect("Worker not found");
+
+        let now = env.ledger().timestamp();
+
+        // Update ReputationInputs
+        let mut inputs: ReputationInputs = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ReputationInputs(worker_id.clone()))
+            .unwrap_or(ReputationInputs {
+                tip_count: 0,
+                rating_sum: 0,
+                rating_count: 0,
+                last_review_at: 0,
+            });
+
+        inputs.rating_sum = inputs.rating_sum.checked_add(rating as u64).expect("overflow");
+        inputs.rating_count = inputs.rating_count.checked_add(1).expect("overflow");
+        inputs.last_review_at = now;
+
+        let new_score = Self::compute_weighted_reputation(&inputs, now);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReputationInputs(worker_id.clone()), &inputs);
+
+        // Update worker aggregate fields
+        let prev_rep = worker.reputation;
+        worker.review_count = worker.review_count.checked_add(1).expect("overflow");
+        worker.avg_rating = (inputs.rating_sum / inputs.rating_count as u64) as u32;
+        worker.reputation = new_score;
+
+        // Slash check: avg below threshold with enough reviews
+        if worker.avg_rating < Self::SLASH_THRESHOLD_RATING && worker.review_count >= Self::SLASH_MIN_REVIEWS {
+            let slashed = worker.reputation / 2;
+            Self::append_reputation_history(&env, &worker_id, worker.reputation, slashed, Symbol::new(&env, "slash"));
+            worker.reputation = slashed;
+            env.events().publish(
+                (Symbol::new(&env, "RepSlashed"), worker_id.clone()),
+                (worker.avg_rating, slashed),
+            );
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Worker(worker_id.clone()), &worker);
+
+        Self::append_reputation_history(&env, &worker_id, prev_rep, new_score, Symbol::new(&env, "review"));
+
+        env.events().publish(
+            (symbol_short!("RevSub"), worker_id),
+            (reviewer, rating, worker.reputation),
+        );
+    }
+
+    /// Record a completed job/tip payment to boost a worker's volume score (#677).
+    ///
+    /// Called by the Market contract (or admin) after a successful tip transfer.
+    /// Increments `tip_count` in [`ReputationInputs`] and recalculates reputation.
+    ///
+    /// # Parameters
+    /// - `caller`: Must hold `ROLE_REP_MGR`; `require_auth()` is enforced.
+    /// - `worker_id`: The worker's unique identifier.
+    ///
+    /// # Panics
+    /// - `"Missing role"` if `caller` does not hold `ROLE_REP_MGR`.
+    /// - `"Worker not found"` if the worker does not exist.
+    ///
+    /// # Events
+    /// Emits `("JobComp", worker_id)` with data `(tip_count, new_reputation)`.
+    pub fn record_job_completion(env: Env, caller: Address, worker_id: Symbol) {
+        let rep_mgr_role = Self::role_symbol(&env, ROLE_REP_MGR_CACHED);
+        Self::require_role(&env, &rep_mgr_role, &caller);
+        Self::require_not_paused(&env);
+
+        let mut worker: Worker = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Worker(worker_id.clone()))
+            .expect("Worker not found");
+
+        let now = env.ledger().timestamp();
+
+        let mut inputs: ReputationInputs = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ReputationInputs(worker_id.clone()))
+            .unwrap_or(ReputationInputs {
+                tip_count: 0,
+                rating_sum: 0,
+                rating_count: 0,
+                last_review_at: 0,
+            });
+
+        inputs.tip_count = inputs.tip_count.checked_add(1).expect("overflow");
+
+        let new_score = Self::compute_weighted_reputation(&inputs, now);
+        let prev_rep = worker.reputation;
+        worker.reputation = new_score;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReputationInputs(worker_id.clone()), &inputs);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Worker(worker_id.clone()), &worker);
+
+        Self::append_reputation_history(&env, &worker_id, prev_rep, new_score, Symbol::new(&env, "job_comp"));
+
+        env.events().publish(
+            (symbol_short!("JobComp"), worker_id),
+            (inputs.tip_count, new_score),
+        );
+    }
+
+    /// Slash a worker's reputation for poor performance (#677).
+    ///
+    /// Reduces the reputation score by `slash_bps` basis points (floor 0).
+    /// Only callable by an address with `ROLE_REP_MGR`.
+    ///
+    /// # Parameters
+    /// - `caller`: Must hold `ROLE_REP_MGR`.
+    /// - `worker_id`: The worker's unique identifier.
+    /// - `slash_bps`: Basis points to subtract (capped so score floor is 0).
+    ///
+    /// # Panics
+    /// - `"Missing role"` if `caller` does not hold `ROLE_REP_MGR`.
+    /// - `"Worker not found"` if the worker does not exist.
+    /// - `"Slash amount out of range"` if `slash_bps > 10000`.
+    ///
+    /// # Events
+    /// Emits `("RepSlash", worker_id)` with data `(slash_bps, new_reputation)`.
+    pub fn slash_reputation(env: Env, caller: Address, worker_id: Symbol, slash_bps: u32) {
+        let rep_mgr_role = Self::role_symbol(&env, ROLE_REP_MGR_CACHED);
+        Self::require_role(&env, &rep_mgr_role, &caller);
+        Self::require_not_paused(&env);
+        assert!(slash_bps <= 10_000, "Slash amount out of range");
+
+        let mut worker: Worker = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Worker(worker_id.clone()))
+            .expect("Worker not found");
+
+        let prev = worker.reputation;
+        worker.reputation = worker.reputation.saturating_sub(slash_bps);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Worker(worker_id.clone()), &worker);
+
+        Self::append_reputation_history(&env, &worker_id, prev, worker.reputation, Symbol::new(&env, "slash"));
+
+        env.events().publish(
+            (symbol_short!("RepSlash"), worker_id),
+            (slash_bps, worker.reputation),
+        );
+    }
+
+    /// Get the immutable reputation history for a worker (#677).
+    ///
+    /// Returns up to the last [`MAX_HISTORY_LEN`] events in chronological order.
+    pub fn get_reputation_history(env: Env, worker_id: Symbol) -> Vec<ReputationEvent> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReputationHistory(worker_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Get the raw reputation inputs for a worker (#677).
+    pub fn get_reputation_inputs(env: Env, worker_id: Symbol) -> Option<ReputationInputs> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReputationInputs(worker_id))
     }
 
     /// Update a worker's review count and average rating. Admin only.

--- a/packages/contracts/contracts/registry/src/test.rs
+++ b/packages/contracts/contracts/registry/src/test.rs
@@ -28,9 +28,208 @@ use soroban_sdk::{
     Address, BytesN, Env, String, Symbol,
 };
 
-// ---------------------------------------------------------------------------
-// Shared fixture
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// 5. Reputation system tests (#677)
+// ===========================================================================
+
+mod reputation_system {
+    use super::*;
+
+    fn setup() -> UpgradeFixture {
+        let f = UpgradeFixture::new();
+        f.client().add_curator(&f.admin, &f.curator);
+        f
+    }
+
+    #[test]
+    fn submit_review_updates_reputation_and_avg_rating() {
+        let f = setup();
+        let id = f.register("worker1");
+        let reviewer = Address::generate(&f.env);
+
+        f.client().submit_review(&reviewer, &id, &8_000);
+
+        let w = f.client().get_worker(&id).unwrap();
+        assert_eq!(w.avg_rating, 8_000);
+        assert_eq!(w.review_count, 1);
+        assert!(w.reputation > 0, "reputation should be non-zero after review");
+    }
+
+    #[test]
+    fn submit_multiple_reviews_weighted_average() {
+        let f = setup();
+        let id = f.register("worker1");
+        let r1 = Address::generate(&f.env);
+        let r2 = Address::generate(&f.env);
+
+        f.client().submit_review(&r1, &id, &6_000);
+        f.client().submit_review(&r2, &id, &8_000);
+
+        let w = f.client().get_worker(&id).unwrap();
+        // avg = (6000 + 8000) / 2 = 7000
+        assert_eq!(w.avg_rating, 7_000);
+        assert_eq!(w.review_count, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Rating out of range")]
+    fn submit_review_out_of_range_panics() {
+        let f = setup();
+        let id = f.register("worker1");
+        let reviewer = Address::generate(&f.env);
+        f.client().submit_review(&reviewer, &id, &10_001);
+    }
+
+    #[test]
+    fn record_job_completion_increments_tip_count_and_score() {
+        let f = setup();
+        let id = f.register("worker1");
+
+        f.client().record_job_completion(&f.admin, &id);
+
+        let inputs = f.client().get_reputation_inputs(&id).unwrap();
+        assert_eq!(inputs.tip_count, 1);
+
+        let w = f.client().get_worker(&id).unwrap();
+        assert!(w.reputation > 0);
+    }
+
+    #[test]
+    fn record_multiple_completions_saturate_volume_score() {
+        let f = setup();
+        let id = f.register("worker1");
+
+        // Record MAX_TIP_VOLUME completions to saturate the volume component
+        for _ in 0..50 {
+            f.client().record_job_completion(&f.admin, &id);
+        }
+        let inputs = f.client().get_reputation_inputs(&id).unwrap();
+        assert_eq!(inputs.tip_count, 50);
+    }
+
+    #[test]
+    #[should_panic(expected = "Missing role")]
+    fn record_job_completion_requires_rep_mgr() {
+        let f = setup();
+        let id = f.register("worker1");
+        let stranger = Address::generate(&f.env);
+        f.client().record_job_completion(&stranger, &id);
+    }
+
+    #[test]
+    fn slash_reputation_reduces_score() {
+        let f = setup();
+        let id = f.register("worker1");
+        // Set a baseline reputation first
+        f.client().update_reputation(&f.admin, &id, &5_000);
+
+        f.client().slash_reputation(&f.admin, &id, &2_000);
+
+        let w = f.client().get_worker(&id).unwrap();
+        assert_eq!(w.reputation, 3_000);
+    }
+
+    #[test]
+    fn slash_reputation_floors_at_zero() {
+        let f = setup();
+        let id = f.register("worker1");
+        f.client().update_reputation(&f.admin, &id, &500);
+
+        f.client().slash_reputation(&f.admin, &id, &2_000);
+
+        let w = f.client().get_worker(&id).unwrap();
+        assert_eq!(w.reputation, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Slash amount out of range")]
+    fn slash_reputation_out_of_range_panics() {
+        let f = setup();
+        let id = f.register("worker1");
+        f.client().slash_reputation(&f.admin, &id, &10_001);
+    }
+
+    #[test]
+    #[should_panic(expected = "Missing role")]
+    fn slash_requires_rep_mgr() {
+        let f = setup();
+        let id = f.register("worker1");
+        let stranger = Address::generate(&f.env);
+        f.client().slash_reputation(&stranger, &id, &1_000);
+    }
+
+    #[test]
+    fn reputation_history_is_recorded_on_review() {
+        let f = setup();
+        let id = f.register("worker1");
+        let reviewer = Address::generate(&f.env);
+
+        f.client().submit_review(&reviewer, &id, &8_000);
+        let history = f.client().get_reputation_history(&id);
+        assert!(history.len() >= 1, "history should have at least one entry");
+
+        let entry = history.get(history.len() - 1).unwrap();
+        assert_eq!(entry.previous_score, 0);
+    }
+
+    #[test]
+    fn reputation_history_recorded_on_slash() {
+        let f = setup();
+        let id = f.register("worker1");
+        f.client().update_reputation(&f.admin, &id, &4_000);
+        f.client().slash_reputation(&f.admin, &id, &1_000);
+
+        let history = f.client().get_reputation_history(&id);
+        let last = history.get(history.len() - 1).unwrap();
+        assert_eq!(last.new_score, 3_000);
+    }
+
+    #[test]
+    fn reputation_history_recorded_on_job_completion() {
+        let f = setup();
+        let id = f.register("worker1");
+
+        f.client().record_job_completion(&f.admin, &id);
+        let history = f.client().get_reputation_history(&id);
+        assert!(history.len() >= 1);
+    }
+
+    #[test]
+    fn auto_slash_triggered_on_low_avg_rating() {
+        let f = setup();
+        let id = f.register("worker1");
+        let r1 = Address::generate(&f.env);
+        let r2 = Address::generate(&f.env);
+        let r3 = Address::generate(&f.env);
+
+        // Three reviews averaging below 3000 bps (SLASH_THRESHOLD_RATING)
+        f.client().submit_review(&r1, &id, &1_000);
+        f.client().submit_review(&r2, &id, &2_000);
+        f.client().submit_review(&r3, &id, &1_500);
+
+        let w = f.client().get_worker(&id).unwrap();
+        // avg = (1000+2000+1500)/3 = 1500 — below threshold → auto-slashed
+        assert!(w.avg_rating < 3_000);
+        // reputation should have been halved from the auto-slash
+        let history = f.client().get_reputation_history(&id);
+        let has_slash = history.iter().any(|e| e.reason == Symbol::new(&f.env, "slash"));
+        assert!(has_slash, "expected a slash event in history");
+    }
+
+    #[test]
+    fn get_reputation_inputs_returns_none_for_new_worker() {
+        let f = setup();
+        let id = f.register("worker1");
+        assert!(f.client().get_reputation_inputs(&id).is_none());
+    }
+
+    #[test]
+    fn get_reputation_history_empty_for_new_worker() {
+        let f = setup();
+        let id = f.register("worker1");
+        assert_eq!(f.client().get_reputation_history(&id).len(), 0);
+    }
+}
 
 /// A registry contract with the bootstrap admin holding every operational role.
 struct UpgradeFixture {


### PR DESCRIPTION
## Summary

Implements a comprehensive on-chain reputation system for the BlueCollar Registry contract, as described in issue #677.

## What's changed

### Registry contract (`packages/contracts/contracts/registry/src/lib.rs`)

**New types**
- `ReputationEvent` — immutable history entry (previous score, new score, reason, timestamp)
- `ReputationInputs` — aggregated inputs driving the weighted score (tip_count, rating_sum, rating_count, last_review_at)

**New storage keys**
- `DataKey::ReputationHistory(Symbol)` — append-only vec of history entries, capped at 100
- `DataKey::ReputationInputs(Symbol)` — live inputs used by the scoring formula

**New functions**
| Function | Auth | Purpose |
|---|---|---|
| `submit_review(reviewer, worker_id, rating)` | anyone | Submit a rating; recalculates reputation immediately |
| `record_job_completion(caller, worker_id)` | ROLE_REP_MGR | Increment tip/completion count from payment flow |
| `slash_reputation(caller, worker_id, slash_bps)` | ROLE_REP_MGR | Manual slash with floor at 0 |
| `get_reputation_history(worker_id)` | view | Queryable, immutable history |
| `get_reputation_inputs(worker_id)` | view | Raw scoring inputs |

**Reputation formula** (weights sum to 100)
- Quality 60% — weighted average of all review ratings
- Volume 25% — saturates at 50 tips/completions
- Recency 15% — linear decay with a 90-day half-life

**Auto-slash** — `submit_review` automatically halves the score when avg rating falls below 3000 bps with ≥ 3 reviews, and emits a `RepSlashed` event.

**History** — every reputation change (review, job completion, manual update, slash) appends an immutable `ReputationEvent` entry, capped at 100 entries per worker.

### Tests (`packages/contracts/contracts/registry/src/test.rs`)

New `reputation_system` module with 14 tests covering all new functions, edge cases, and the auto-slash trigger.

### API (`packages/api/`)

- `stellar.service.ts` — `syncReputationToDb` and `getWorkerReputation` helpers
- `controllers/workers.ts` — `getReputation` and `syncReputation` handlers
- `routes/workers.ts` — new routes:
  - `GET  /api/workers/:id/reputation` — public, cached
  - `POST /api/workers/:id/reputation/sync` — admin-only (for event-listener sync)

## Closes #677