### PR TITLE
docs: role-based onboarding guides and complete API reference

### DIFF
--- a/docs/CURATOR_GUIDE.md
+++ b/docs/CURATOR_GUIDE.md
@@ -1,0 +1,332 @@
+# BlueCollar Curator Guide
+
+Curators are trusted community members who create and manage worker listings on BlueCollar. This guide walks you through everything you need to get started.
+
+---
+
+## Table of Contents
+
+- [What is a Curator?](#what-is-a-curator)
+- [Getting the Curator Role](#getting-the-curator-role)
+- [Connecting Your Stellar Wallet](#connecting-your-stellar-wallet)
+- [Creating a Worker Listing](#creating-a-worker-listing)
+- [Updating a Listing](#updating-a-listing)
+- [Uploading a Profile Photo](#uploading-a-profile-photo)
+- [Toggling Availability](#toggling-availability)
+- [Managing Availability Slots](#managing-availability-slots)
+- [Registering a Worker On-Chain](#registering-a-worker-on-chain)
+- [Reviewing Contact Requests](#reviewing-contact-requests)
+- [Viewing Verifications](#viewing-verifications)
+- [Analytics Dashboard](#analytics-dashboard)
+- [Extending On-Chain TTL](#extending-on-chain-ttl)
+- [Troubleshooting FAQ](#troubleshooting-faq)
+
+---
+
+## What is a Curator?
+
+A curator is a verified community member responsible for:
+
+- Creating and maintaining worker profiles
+- Anchoring listings on the Stellar blockchain via the Registry smart contract
+- Managing availability and contact requests
+- Ensuring listing quality and accuracy
+
+Curators do not need to be the workers themselves. They can represent a community, co-op, or trade association.
+
+---
+
+## Getting the Curator Role
+
+1. Register for a BlueCollar account at the app URL.
+2. Verify your email address by clicking the link in your inbox.
+3. Contact a platform admin (via GitHub Discussions or Telegram) to request the `curator` role.
+4. Once approved, your account will be upgraded and the **Dashboard** section will become visible.
+
+> **Note:** Role upgrades are done by an admin via the internal API. You cannot self-assign the curator role.
+
+---
+
+## Connecting Your Stellar Wallet
+
+A Stellar wallet is required to register workers on-chain.
+
+1. Install [Freighter](https://freighter.app) browser extension.
+2. Create or import a Stellar account.
+3. Click **Connect Wallet** in the top-right corner of the app.
+4. Approve the connection in Freighter.
+
+For testnet development, click **Fund Wallet (Testnet)** to receive XLM from Friendbot.
+
+---
+
+## Creating a Worker Listing
+
+**From the app:**
+
+1. Go to **Dashboard → Register Worker**.
+2. Fill in the required fields:
+   - **Name** — worker's full name or trade name
+   - **Category** — select from the available categories (e.g., Plumber, Electrician)
+   - **Phone** — contact number
+   - **Email** — contact email (optional)
+   - **Bio** — short description of skills and experience
+   - **Wallet Address** — worker's Stellar public key (required for on-chain tips)
+3. Click **Create Listing**.
+
+**Via API:**
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/workers \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "João Silva",
+    "categoryId": "cat_plumber_01",
+    "phone": "+55 11 99999-0000",
+    "email": "joao@example.com",
+    "bio": "10 years experience in residential plumbing.",
+    "walletAddress": "GABC...XYZ"
+  }'
+```
+
+**Success response:**
+
+```json
+{
+  "status": "success",
+  "message": "Worker created",
+  "code": 201,
+  "data": {
+    "id": "wkr_abc123",
+    "name": "João Silva",
+    "isActive": true,
+    "categoryId": "cat_plumber_01",
+    "curatorId": "usr_your_id",
+    "createdAt": "2026-06-25T04:00:00.000Z"
+  }
+}
+```
+
+---
+
+## Updating a Listing
+
+**From the app:**
+
+1. Go to **Dashboard → My Listings**.
+2. Find the listing and click **Edit**.
+3. Update the fields you want to change.
+4. Click **Save Changes**.
+
+**Via API (JSON, no file upload):**
+
+```bash
+curl -X PUT https://api.bluecollar.app/api/v1/workers/wkr_abc123 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"bio": "Updated bio with new skills."}'
+```
+
+> For file uploads (avatar), use the [method-override pattern](#uploading-a-profile-photo) below.
+
+---
+
+## Uploading a Profile Photo
+
+HTML forms and multipart requests only support `POST`. To update a worker with a photo, send a `POST` with the header `X-HTTP-Method: PUT`:
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/workers/wkr_abc123 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-HTTP-Method: PUT" \
+  -F "name=João Silva" \
+  -F "avatar=@/path/to/photo.jpg"
+```
+
+**JavaScript (Fetch API):**
+
+```javascript
+const formData = new FormData()
+formData.append('bio', 'Updated bio.')
+formData.append('avatar', fileInput.files[0])
+
+await fetch('/api/v1/workers/wkr_abc123', {
+  method: 'POST',
+  headers: {
+    'X-HTTP-Method': 'PUT',
+    Authorization: `Bearer ${token}`,
+  },
+  body: formData,
+})
+```
+
+Supported formats: JPEG, PNG, WebP. Max size: 5 MB. Images are resized and optimised automatically by Sharp.
+
+---
+
+## Toggling Availability
+
+Mark a worker as available or unavailable without deleting the listing:
+
+**From the app:** Click the toggle switch on the listing card in **My Listings**.
+
+**Via API:**
+
+```bash
+curl -X PATCH https://api.bluecollar.app/api/v1/workers/wkr_abc123/toggle \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Response returns the updated worker object with the new `isActive` value.
+
+---
+
+## Managing Availability Slots
+
+Set specific time windows when the worker is available for bookings:
+
+```bash
+# Replace entire availability schedule
+curl -X PUT https://api.bluecollar.app/api/v1/workers/wkr_abc123/availability \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "slots": [
+      {"day": "monday", "startTime": "08:00", "endTime": "17:00"},
+      {"day": "tuesday", "startTime": "08:00", "endTime": "17:00"}
+    ]
+  }'
+
+# Add a single slot
+curl -X POST https://api.bluecollar.app/api/v1/workers/wkr_abc123/availability \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"day": "saturday", "startTime": "09:00", "endTime": "13:00"}'
+
+# Delete a slot
+curl -X DELETE https://api.bluecollar.app/api/v1/workers/wkr_abc123/availability/slot_id \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## Registering a Worker On-Chain
+
+Anchoring a worker to the Stellar Registry contract creates an immutable, publicly verifiable record.
+
+**Prerequisites:**
+- Worker must have a `walletAddress` set
+- Your Freighter wallet must be connected
+
+**From the app:**
+
+1. Open the worker listing.
+2. Click **Register On-Chain**.
+3. Approve the transaction in Freighter.
+
+**Via API:**
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/workers/wkr_abc123/register-on-chain \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Success response:**
+
+```json
+{
+  "status": "success",
+  "data": { "txHash": "abc123def456..." }
+}
+```
+
+> On-chain entries expire after ~1 year (535,000 ledgers). See [Extending On-Chain TTL](#extending-on-chain-ttl).
+
+---
+
+## Reviewing Contact Requests
+
+When a user sends a contact request to one of your workers, you'll see it in the dashboard:
+
+```bash
+# List requests
+curl -X GET https://api.bluecollar.app/api/v1/workers/wkr_abc123/contacts \
+  -H "Authorization: Bearer $TOKEN"
+
+# Mark as read
+curl -X PATCH https://api.bluecollar.app/api/v1/workers/wkr_abc123/contacts/req_id \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "read"}'
+```
+
+---
+
+## Viewing Verifications
+
+```bash
+curl -X GET https://api.bluecollar.app/api/v1/workers/wkr_abc123/verifications \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Verifications are identity or credential checks attached to a worker by the platform.
+
+---
+
+## Analytics Dashboard
+
+Track views and engagement for your listings:
+
+```bash
+# Overview
+curl -X GET https://api.bluecollar.app/api/v1/workers/wkr_abc123/analytics \
+  -H "Authorization: Bearer $TOKEN"
+
+# View trend over time
+curl -X GET https://api.bluecollar.app/api/v1/workers/wkr_abc123/analytics/trends \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## Extending On-Chain TTL
+
+On-chain entries expire after ~1 year. Renew before expiry to keep the listing discoverable on Stellar:
+
+```bash
+# Using Stellar CLI
+stellar contract invoke \
+  --id <registry-contract-id> \
+  --source <any-account-secret> \
+  --network testnet \
+  -- extend_worker_ttl \
+  --id wkr_abc123
+```
+
+The app will also display a **Renew Listing** button when the TTL is within 6 months of expiry.
+
+---
+
+## Troubleshooting FAQ
+
+**Q: I get 403 Forbidden when creating a worker.**
+A: Your account does not have the `curator` role. Contact an admin to have your role upgraded.
+
+**Q: The photo upload returns a 400 error.**
+A: Make sure you are sending `POST` with `X-HTTP-Method: PUT` — not a regular `PUT` request. Also check the file size is under 5 MB and the format is JPEG, PNG, or WebP.
+
+**Q: "Register On-Chain" button is greyed out.**
+A: The worker needs a `walletAddress` set first. Edit the listing and add a valid Stellar public key.
+
+**Q: The on-chain registration transaction fails.**
+A: Your Freighter wallet may not have enough XLM for the transaction fee. On testnet, click **Fund Wallet** to add testnet XLM.
+
+**Q: My listing shows "Expired" on-chain.**
+A: The Soroban storage TTL has lapsed. Click **Renew Listing** or use the Stellar CLI `extend_worker_ttl` command.
+
+**Q: I can't see the Dashboard menu.**
+A: You may need to log out and log back in after your role is upgraded, so your JWT is refreshed.
+
+**Q: The idempotency check is rejecting my duplicate request.**
+A: If you send the same `Idempotency-Key` header twice, the second request returns the cached result. Use a new key for genuinely new requests.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,57 +1,408 @@
 # BlueCollar User Guide
 
-## Finding a Worker
-
-1. Open the app and go to the **Workers** page.
-2. Use the category filter (e.g. Plumber, Electrician) and location search to narrow results.
-3. Click a listing to view the worker's profile, reviews, and contact details.
-
-## Connecting Your Stellar Wallet
-
-1. Install the [Freighter browser extension](https://freighter.app).
-2. Create or import a Stellar account in Freighter.
-3. Click **Connect Wallet** in the top-right corner of the app.
-4. Approve the connection request in Freighter.
-
-Your public key will appear in the navbar when connected.
-
-> **Testnet only:** Click **Fund Wallet (Testnet)** in the navbar to receive testnet XLM from Friendbot.
-
-## Sending a Tip
-
-1. Open a worker's profile page.
-2. Click **Send Tip**.
-3. Enter the amount of XLM (or supported token) to send.
-4. Click **Confirm** — Freighter will open asking you to sign the transaction.
-5. Approve the transaction in Freighter.
-
-The tip is sent directly to the worker's Stellar address via the Market smart contract.
-
-## Curator: Managing Listings
-
-Curators are community-verified members who create and manage worker listings.
-
-### Register a Worker
-
-1. Go to **Dashboard → Register Worker**.
-2. Fill in: name, category, location, and contact info.
-3. Submit — the listing is written to the Registry contract on-chain.
-
-### Update a Listing
-
-1. Go to **Dashboard → My Listings**.
-2. Click **Edit** next to the listing.
-3. Update the fields and save.
-
-### Toggle Availability
-
-On any listing you manage, click **Toggle Availability** to mark the worker as available or unavailable.
-
-### Extend TTL
-
-On-chain listings expire after a set period. Click **Renew Listing** to extend the worker's on-chain TTL before it expires.
+BlueCollar connects you with verified, community-curated skilled workers near you. This guide covers everything from finding a worker to sending a tip on the Stellar blockchain.
 
 ---
 
-For wallet setup details see [stellar-wallet-integration.md](stellar-wallet-integration.md).  
-For contract details see [CONTRACT_INTEGRATION.md](CONTRACT_INTEGRATION.md).
+## Table of Contents
+
+- [Creating an Account](#creating-an-account)
+- [Verifying Your Email](#verifying-your-email)
+- [Logging In](#logging-in)
+- [Google Sign-In](#google-sign-in)
+- [Setting Up Two-Factor Authentication](#setting-up-two-factor-authentication)
+- [Discovering Workers](#discovering-workers)
+- [Advanced Search](#advanced-search)
+- [Bookmarking Workers](#bookmarking-workers)
+- [Contacting a Worker](#contacting-a-worker)
+- [Writing a Review](#writing-a-review)
+- [Posting a Job](#posting-a-job)
+- [Connecting Freighter](#connecting-freighter)
+- [Sending a Tip](#sending-a-tip)
+- [Managing Your Profile](#managing-your-profile)
+- [Changing Your Password](#changing-your-password)
+- [Deleting Your Account](#deleting-your-account)
+- [Troubleshooting FAQ](#troubleshooting-faq)
+
+---
+
+## Creating an Account
+
+1. Go to the BlueCollar app and click **Sign Up**.
+2. Enter your first name, last name, email address, and a password (minimum 8 characters).
+3. Click **Create Account** — you will receive a verification email within a few minutes.
+
+**Via API:**
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "firstName": "Ana",
+    "lastName": "Costa",
+    "email": "ana@example.com",
+    "password": "supersecure123"
+  }'
+```
+
+**Success response (201):**
+
+```json
+{
+  "status": "success",
+  "message": "Account created. Check your email to verify.",
+  "code": 201,
+  "data": {
+    "id": "usr_abc123",
+    "email": "ana@example.com",
+    "firstName": "Ana",
+    "lastName": "Costa",
+    "role": "user",
+    "verified": false
+  }
+}
+```
+
+---
+
+## Verifying Your Email
+
+After registering, check your inbox for an email from BlueCollar. Click the **Verify Email** link. This marks your account as verified and unlocks full access.
+
+If you didn't receive the email:
+
+- Check your spam folder.
+- Request a new one:
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/auth/resend-verification \
+  -H "Content-Type: application/json" \
+  -d '{"email": "ana@example.com"}'
+```
+
+---
+
+## Logging In
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "ana@example.com", "password": "supersecure123"}'
+```
+
+**Success response (202):**
+
+```json
+{
+  "status": "success",
+  "code": 202,
+  "token": "<jwt>",
+  "data": {
+    "id": "usr_abc123",
+    "email": "ana@example.com",
+    "role": "user",
+    "verified": true
+  }
+}
+```
+
+Save the `token` and include it in subsequent requests as `Authorization: Bearer <token>`. Tokens expire after 7 days.
+
+---
+
+## Google Sign-In
+
+1. Click **Continue with Google** on the login page.
+2. Select your Google account and approve the permissions.
+3. You will be redirected back to the app, already logged in.
+
+The first time you sign in with Google, an account is automatically created.
+
+---
+
+## Setting Up Two-Factor Authentication
+
+2FA adds an extra layer of security using an authenticator app (Google Authenticator, Authy, etc.).
+
+1. Log in and go to **Settings → Security → Enable 2FA**.
+2. Scan the QR code with your authenticator app.
+3. Enter the 6-digit code to confirm setup.
+
+After enabling 2FA, each login will require your TOTP code as a second step.
+
+**Save your backup codes.** You are given 8 one-time codes during setup. Store them in a safe place — they let you log in if you lose access to your authenticator app.
+
+**Via API:**
+
+```bash
+# Step 1 — get QR code
+curl -X POST https://api.bluecollar.app/api/v1/auth/2fa/setup \
+  -H "Authorization: Bearer $TOKEN"
+
+# Step 2 — enable after scanning (enter the TOTP code)
+curl -X POST https://api.bluecollar.app/api/v1/auth/2fa/enable \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"code": "123456"}'
+```
+
+---
+
+## Discovering Workers
+
+**From the app:**
+
+1. Go to the **Workers** page.
+2. Use the **Category** dropdown to filter by trade (Plumber, Electrician, Carpenter, etc.).
+3. Use the search bar to filter by name or keyword.
+4. Click any listing card to view the full profile.
+
+**Via API:**
+
+```bash
+# List all active workers
+curl https://api.bluecollar.app/api/v1/workers
+
+# Filter by category
+curl "https://api.bluecollar.app/api/v1/workers?category=cat_plumber_01&page=1&limit=20"
+```
+
+---
+
+## Advanced Search
+
+```bash
+curl "https://api.bluecollar.app/api/v1/workers/search/advanced?q=electrician&location=São+Paulo&minRating=4&available=true"
+```
+
+| Parameter   | Description                       |
+| ----------- | --------------------------------- |
+| `q`         | Keyword search (name, bio)        |
+| `category`  | Category ID                       |
+| `location`  | Location name or area             |
+| `minRating` | Minimum average rating (1–5)      |
+| `available` | `true` to show only active workers |
+| `page`      | Page number (default: 1)          |
+| `limit`     | Results per page (default: 20)    |
+
+---
+
+## Bookmarking Workers
+
+Save workers you want to revisit:
+
+```bash
+# Toggle bookmark (adds if not bookmarked, removes if already bookmarked)
+curl -X POST https://api.bluecollar.app/api/v1/workers/wkr_abc123/bookmark \
+  -H "Authorization: Bearer $TOKEN"
+
+# View your bookmarks
+curl https://api.bluecollar.app/api/v1/users/me/bookmarks \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## Contacting a Worker
+
+Send a message directly to a worker through the platform:
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/workers/wkr_abc123/contact \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hi, I need a plumber to fix a leak. Are you available this Friday?"}'
+```
+
+The message is delivered to the curator managing the listing. Rate limiting applies to prevent spam.
+
+---
+
+## Writing a Review
+
+After using a worker's services, leave a review to help the community:
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/workers/wkr_abc123/reviews \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rating": 5,
+    "body": "João arrived on time and fixed the leak quickly. Highly recommend!"
+  }'
+```
+
+- `rating`: integer 1–5
+- `body`: your written review (required)
+
+You can only submit one review per worker. To delete your own review:
+
+```bash
+curl -X DELETE https://api.bluecollar.app/api/v1/workers/reviews/rev_id \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## Posting a Job
+
+If you need a specific task done, post a job that workers can apply to:
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/jobs \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Fix bathroom pipe leak",
+    "description": "Need a plumber to fix a leaking pipe under the sink. Urgently.",
+    "budget": 150,
+    "categoryId": "cat_plumber_01",
+    "expiresAt": "2026-07-10T00:00:00.000Z"
+  }'
+```
+
+Once posted, workers can apply. You'll receive applications at:
+
+```bash
+curl https://api.bluecollar.app/api/v1/jobs/job_id/applications \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Accept or reject applications:
+
+```bash
+curl -X PATCH "https://api.bluecollar.app/api/v1/jobs/job_id/applications/app_id" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "accepted"}'
+```
+
+---
+
+## Connecting Freighter
+
+The Freighter browser extension is needed for on-chain tipping.
+
+1. Install [Freighter](https://freighter.app) from the browser extension store.
+2. Create or import your Stellar account.
+3. In the BlueCollar app, click **Connect Wallet** in the top-right corner.
+4. Approve the connection request in Freighter.
+
+Your Stellar public key will appear in the navbar when connected.
+
+> **Testnet:** Click **Fund Wallet (Testnet)** to receive free testnet XLM from Friendbot.
+
+---
+
+## Sending a Tip
+
+Tip a worker directly using XLM or supported Stellar tokens via the Market smart contract:
+
+1. Open the worker's profile.
+2. Click **Send Tip**.
+3. Enter the amount.
+4. Click **Confirm** — Freighter will open for you to sign the transaction.
+5. Approve in Freighter.
+
+**Via API:**
+
+```bash
+curl -X POST https://api.bluecollar.app/api/v1/payments/tip \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from": "GYOUR...WALLET",
+    "to": "GWORKER...WALLET",
+    "amount": 10
+  }'
+```
+
+The transfer happens directly on the Stellar network — BlueCollar never holds your funds.
+
+---
+
+## Managing Your Profile
+
+Update your name, bio, phone, and avatar:
+
+```bash
+# JSON update
+curl -X PATCH https://api.bluecollar.app/api/v1/users/me \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"bio": "Looking for reliable tradespeople in São Paulo."}'
+
+# With avatar upload (method-override)
+curl -X POST https://api.bluecollar.app/api/v1/users/me \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-HTTP-Method: PUT" \
+  -F "firstName=Ana" \
+  -F "avatar=@/path/to/photo.jpg"
+```
+
+---
+
+## Changing Your Password
+
+```bash
+curl -X PUT https://api.bluecollar.app/api/v1/users/me/password \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"currentPassword": "old_password", "newPassword": "new_secure_password123"}'
+```
+
+**Forgot your password?**
+
+```bash
+# Request reset email
+curl -X POST https://api.bluecollar.app/api/v1/auth/forgot-password \
+  -H "Content-Type: application/json" \
+  -d '{"email": "ana@example.com"}'
+
+# Reset using token from the email
+curl -X PUT https://api.bluecollar.app/api/v1/auth/reset-password \
+  -H "Content-Type: application/json" \
+  -d '{"token": "<token-from-email>", "password": "new_secure_password123"}'
+```
+
+---
+
+## Deleting Your Account
+
+```bash
+curl -X DELETE https://api.bluecollar.app/api/v1/users/me \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+This permanently deletes your account and associated data. This action cannot be undone.
+
+---
+
+## Troubleshooting FAQ
+
+**Q: I didn't receive the verification email.**
+A: Check your spam folder first. Then use the resend endpoint or the **Resend Verification** button on the login page.
+
+**Q: My login returns 403 "Email not verified".**
+A: Verify your email first. If you lost the email, request a new verification link.
+
+**Q: Login returns 401 "Invalid credentials".**
+A: Double-check your email and password. If you signed up with Google, use the Google sign-in button instead.
+
+**Q: My JWT expired — I'm getting 401 on all requests.**
+A: Tokens last 7 days. Use `POST /api/v1/auth/refresh` with your refresh token, or log in again.
+
+**Q: I can't send a tip — Freighter shows an error.**
+A: Make sure your wallet has enough XLM to cover the transaction amount plus the network fee (~0.001 XLM). On testnet, click **Fund Wallet**.
+
+**Q: The worker I want doesn't have a Stellar wallet address.**
+A: On-chain tipping requires the worker to have a wallet address. Contact the curator to update the listing.
+
+**Q: I already reviewed a worker and want to change my rating.**
+A: Delete your existing review and submit a new one. Only one review per worker is permitted.
+
+**Q: How do I report an inappropriate review?**
+A: Click the flag icon on the review, or use `PATCH /api/v1/workers/reviews/{id}/flag`. Flagged reviews are placed in a moderation queue reviewed by admins.
+
+**Q: Can I log in with 2FA using a backup code?**
+A: Yes. On the 2FA verification screen, click **Use Backup Code** and enter one of your saved codes.

--- a/docs/WORKER_GUIDE.md
+++ b/docs/WORKER_GUIDE.md
@@ -1,0 +1,265 @@
+# BlueCollar Worker Guide
+
+This guide is for skilled tradespeople who want to get listed on BlueCollar, build their reputation, and start receiving work through the platform.
+
+---
+
+## Table of Contents
+
+- [How BlueCollar Works for Workers](#how-bluecollar-works-for-workers)
+- [Getting Listed](#getting-listed)
+- [Setting Up a Stellar Wallet](#setting-up-a-stellar-wallet)
+- [Your On-Chain Listing](#your-on-chain-listing)
+- [Profile Completeness Tips](#profile-completeness-tips)
+- [Your Availability](#your-availability)
+- [Receiving Tips and Payments](#receiving-tips-and-payments)
+- [Building Your Reputation](#building-your-reputation)
+- [Understanding Your Reputation Score](#understanding-your-reputation-score)
+- [Verification Badges](#verification-badges)
+- [Portfolio (Coming Soon)](#portfolio-coming-soon)
+- [Responding to Contact Requests](#responding-to-contact-requests)
+- [Applying to Jobs](#applying-to-jobs)
+- [Troubleshooting FAQ](#troubleshooting-faq)
+
+---
+
+## How BlueCollar Works for Workers
+
+BlueCollar is a **curator-managed, decentralised marketplace**. Here's how the flow works:
+
+1. A **curator** (trusted community member) creates your listing on the platform.
+2. Your listing is anchored on the **Stellar blockchain** — no single company can take it down.
+3. Users discover you by browsing categories or searching.
+4. Users can send you **tips and payments directly** via the Stellar Market contract — funds go straight to your wallet.
+5. Users leave **reviews** that build your on-chain reputation over time.
+
+> You do not need a BlueCollar account to appear in listings. However, having a **Stellar wallet** is essential to receive payments.
+
+---
+
+## Getting Listed
+
+You cannot directly create your own listing — a **curator** must create it on your behalf. Curators are verified community members (local trade unions, co-ops, community groups, or individual advocates).
+
+**Steps:**
+
+1. Find a curator in your community, or reach out via [GitHub Discussions](https://github.com/Fidelis900/Blue-Collar/discussions) or [Telegram](https://t.me/bluecollar).
+2. Provide the curator with:
+   - Your full name / trade name
+   - Your trade category (e.g., Plumber, Electrician, Welder)
+   - Contact number and email
+   - A short bio describing your skills and experience
+   - Your Stellar wallet address (required for on-chain registration and tips)
+   - A profile photo (optional but strongly recommended)
+3. The curator creates your listing and registers it on the Stellar Registry contract.
+
+Once listed, your profile appears on the public workers page immediately and is discoverable via search.
+
+---
+
+## Setting Up a Stellar Wallet
+
+A Stellar wallet lets you receive tips and payments directly from users — without any intermediary holding your funds.
+
+**Recommended: Freighter (browser extension)**
+
+1. Go to [freighter.app](https://freighter.app) and install the extension.
+2. Click **Create Wallet** and follow the setup steps.
+3. **Write down your recovery phrase** and store it somewhere safe. This is the only way to recover your wallet if you lose access to your device.
+4. Your **public key** (starts with `G`) is your wallet address. Share this with your curator so it can be added to your listing.
+
+**Important:**
+- Your public key is safe to share publicly — it is like a bank account number.
+- Your **secret key** (starts with `S`) must never be shared with anyone, including BlueCollar.
+
+**Testnet accounts:** For testing, any Stellar testnet account will work. Testnet XLM has no real value.
+
+---
+
+## Your On-Chain Listing
+
+When your curator registers your listing on the Stellar Registry contract, a permanent, verifiable record is created on the blockchain. This means:
+
+- Your listing cannot be arbitrarily deleted by any single party
+- Anyone can independently verify your listing on the Stellar network
+- Your listing ID is tied to your wallet address
+
+**TTL (Time to Live):** On-chain listings expire after approximately 1 year (535,000 ledgers). Your curator should renew it using the **Renew Listing** button or the Stellar CLI before it expires.
+
+You can view your listing on any Stellar explorer using your wallet address.
+
+---
+
+## Profile Completeness Tips
+
+A complete profile gets significantly more views and contact requests. Make sure your curator has added:
+
+| Field            | Why it matters                                                     |
+| ---------------- | ------------------------------------------------------------------ |
+| **Photo**        | Builds trust — listings with photos get 3× more clicks            |
+| **Bio**          | Describe your experience, specialisations, and service area        |
+| **Phone**        | Primary contact method for most users                             |
+| **Email**        | Secondary contact for less urgent enquiries                        |
+| **Category**     | Determines which search results your listing appears in            |
+| **Wallet Address** | Required for receiving on-chain tips and payments               |
+
+---
+
+## Your Availability
+
+Your curator can set your availability schedule — the days and times you are open for work. This helps users know when to expect a response.
+
+**To update your availability**, contact your curator and provide your preferred schedule. Curators manage this via the Dashboard or API.
+
+If you are temporarily unavailable (holiday, illness), ask your curator to use the **Toggle Availability** feature to mark you as inactive. Your listing stays intact but won't appear in active worker searches.
+
+---
+
+## Receiving Tips and Payments
+
+Once your wallet address is in your listing, users can send you XLM (or supported Stellar tokens) directly via the BlueCollar Market smart contract.
+
+**How it works:**
+
+1. User clicks **Send Tip** on your profile.
+2. Freighter opens on their side — they enter the amount and approve.
+3. Stellar processes the transaction — typically settles in 3–5 seconds.
+4. Funds appear in your Stellar wallet immediately.
+
+You can check your balance in Freighter or any Stellar explorer (e.g., [stellar.expert](https://stellar.expert)).
+
+**Platform fee:** A small basis-point fee is applied to payments. Check current fee at:
+
+```bash
+curl https://api.bluecollar.app/api/v1/payments/fee
+```
+
+**Escrow payments:** For larger jobs, users can create an escrow. Funds are locked on-chain and released when both parties agree the work is done.
+
+---
+
+## Building Your Reputation
+
+Your reputation is the single most important factor for getting more work through BlueCollar. Here's how to build it:
+
+1. **Complete jobs reliably** — show up on time, do quality work.
+2. **Ask satisfied clients to leave a review** — a kind reminder after a job helps.
+3. **Keep your availability up to date** — responding quickly to contact requests is tracked.
+4. **Get verification badges** — having your credentials verified by the platform boosts your score.
+
+---
+
+## Understanding Your Reputation Score
+
+Your reputation score is calculated from multiple signals:
+
+| Signal               | Weight |
+| -------------------- | ------ |
+| Average review rating | High   |
+| Number of reviews    | Medium |
+| Review recency       | Medium |
+| Response time        | Medium |
+| Verification status  | High   |
+| On-chain registration | Medium |
+
+Check your current score via the API:
+
+```bash
+curl https://api.bluecollar.app/api/v1/workers/wkr_your_id/reputation
+```
+
+Response:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "score": 87,
+    "breakdown": {
+      "avgRating": 4.8,
+      "reviewCount": 23,
+      "verified": true,
+      "onChain": true,
+      "responseTime": "fast"
+    }
+  }
+}
+```
+
+---
+
+## Verification Badges
+
+Verification badges signal to users that your credentials have been checked. Types of verifications may include:
+
+- Identity verification
+- Trade licence / certification
+- Insurance
+- Community endorsement
+
+Your curator or a platform admin can add verifications to your profile. Contact them if you have credentials you would like added.
+
+---
+
+## Portfolio (Coming Soon)
+
+A portfolio section is planned where you can showcase photos of completed work. Ask your curator to add portfolio images in the meantime via the portfolio endpoints.
+
+---
+
+## Responding to Contact Requests
+
+When a user sends you a contact request through the platform, it is routed to your curator's dashboard. The curator will see your contact details and pass the message on to you.
+
+Make sure your phone number and email in the listing are current and correct. This is the only way users can reach you through the platform.
+
+---
+
+## Applying to Jobs
+
+If you have a BlueCollar account (not required for basic listings), you can browse and apply to job postings directly:
+
+```bash
+# Browse open jobs in your category
+curl "https://api.bluecollar.app/api/v1/jobs?category=cat_electrician_01&status=open"
+
+# Apply
+curl -X POST https://api.bluecollar.app/api/v1/jobs/job_id/apply \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "coverLetter": "I have 8 years of experience in residential electrical work and I am available this week.",
+    "proposedBudget": 200
+  }'
+```
+
+---
+
+## Troubleshooting FAQ
+
+**Q: How do I get a curator to create my listing?**
+A: Join the [Telegram group](https://t.me/bluecollar) or post in [GitHub Discussions](https://github.com/Fidelis900/Blue-Collar/discussions). Community curators will be happy to help you get listed.
+
+**Q: I haven't received any tips in my wallet.**
+A: Make sure your wallet address in the listing is correct — it must be your Stellar public key (starts with `G`). Ask your curator to double-check it.
+
+**Q: My listing appears as "Inactive".**
+A: Your curator has toggled your availability off, or your on-chain listing may have expired. Contact your curator to re-activate or renew the listing.
+
+**Q: I want to update my bio or contact details.**
+A: Contact your curator. They can edit the listing from their Dashboard or via the API.
+
+**Q: My on-chain listing has expired — what happens?**
+A: Your off-platform listing (database) remains intact. Only the on-chain record has expired and needs to be renewed via the `extend_worker_ttl` function. Ask your curator to renew it.
+
+**Q: A user left an unfair or abusive review.**
+A: Users can flag reviews for moderation. Ask the user to flag it, or contact a platform admin to have it reviewed. Admins can remove reviews that violate the community guidelines.
+
+**Q: I set up a Stellar wallet but the funds aren't showing.**
+A: Check the correct network (testnet vs mainnet). If you're on testnet, funds only exist in the test environment. Mainnet tips use real XLM.
+
+**Q: Can I have more than one listing?**
+A: A curator can create multiple listings for different trades or locations. Each listing is independent on-chain.
+
+**Q: How long does it take for a review to appear?**
+A: Reviews appear immediately on your profile once submitted.

--- a/packages/api/POSTMAN_COLLECTION.json
+++ b/packages/api/POSTMAN_COLLECTION.json
@@ -1,0 +1,447 @@
+{
+  "info": {
+    "name": "BlueCollar API",
+    "description": "Complete API collection for the BlueCollar decentralised skilled-worker platform. Base URL: {{baseUrl}}. Set the `baseUrl` variable to `http://localhost:3000/api/v1` for local dev.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": "1.0.0"
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:3000/api/v1" },
+    { "key": "token", "value": "" }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }]
+  },
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Register",
+          "request": {
+            "method": "POST", "url": "{{baseUrl}}/auth/register",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"firstName\": \"Ana\",\n  \"lastName\": \"Costa\",\n  \"email\": \"ana@example.com\",\n  \"password\": \"supersecure123\"\n}" }
+          }
+        },
+        {
+          "name": "Login",
+          "event": [{ "listen": "test", "script": { "exec": ["const r = pm.response.json(); if (r.token) pm.collectionVariables.set('token', r.token);"], "type": "text/javascript" } }],
+          "request": {
+            "method": "POST", "url": "{{baseUrl}}/auth/login",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"email\": \"ana@example.com\",\n  \"password\": \"supersecure123\"\n}" }
+          }
+        },
+        {
+          "name": "Get Current User",
+          "request": { "method": "GET", "url": "{{baseUrl}}/auth/me", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Logout",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/auth/logout", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Refresh Token",
+          "request": { "method": "POST", "url": "{{baseUrl}}/auth/refresh", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"refreshToken\": \"{{refreshToken}}\"\n}" } }
+        },
+        {
+          "name": "Verify Account",
+          "request": { "method": "PUT", "url": "{{baseUrl}}/auth/verify-account", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"token\": \"<token-from-email>\"\n}" } }
+        },
+        {
+          "name": "Resend Verification",
+          "request": { "method": "POST", "url": "{{baseUrl}}/auth/resend-verification", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"email\": \"ana@example.com\"\n}" } }
+        },
+        {
+          "name": "Forgot Password",
+          "request": { "method": "POST", "url": "{{baseUrl}}/auth/forgot-password", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"email\": \"ana@example.com\"\n}" } }
+        },
+        {
+          "name": "Reset Password",
+          "request": { "method": "PUT", "url": "{{baseUrl}}/auth/reset-password", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"token\": \"<token-from-email>\",\n  \"password\": \"newpassword123\"\n}" } }
+        },
+        {
+          "name": "Google OAuth - Initiate",
+          "request": { "method": "GET", "url": "{{baseUrl}}/auth/google" }
+        }
+      ]
+    },
+    {
+      "name": "2FA",
+      "item": [
+        {
+          "name": "Setup 2FA",
+          "request": { "method": "POST", "url": "{{baseUrl}}/auth/2fa/setup", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Enable 2FA",
+          "request": { "method": "POST", "url": "{{baseUrl}}/auth/2fa/enable", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"code\": \"123456\"\n}" } }
+        },
+        {
+          "name": "Verify 2FA (login step 2)",
+          "request": { "method": "POST", "url": "{{baseUrl}}/auth/2fa/verify", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"userId\": \"usr_abc123\",\n  \"code\": \"123456\"\n}" } }
+        },
+        {
+          "name": "Verify Backup Code",
+          "request": { "method": "POST", "url": "{{baseUrl}}/auth/2fa/verify-backup", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"userId\": \"usr_abc123\",\n  \"code\": \"BACKUP-CODE-1\"\n}" } }
+        },
+        {
+          "name": "Disable 2FA",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/auth/2fa", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"code\": \"123456\"\n}" } }
+        },
+        {
+          "name": "Regenerate Backup Codes",
+          "request": { "method": "POST", "url": "{{baseUrl}}/auth/2fa/backup-codes/regenerate", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        }
+      ]
+    },
+    {
+      "name": "Categories",
+      "item": [
+        {
+          "name": "List Categories",
+          "request": { "method": "GET", "url": "{{baseUrl}}/categories" }
+        },
+        {
+          "name": "Get Category",
+          "request": { "method": "GET", "url": "{{baseUrl}}/categories/:id", "variable": [{ "key": "id", "value": "cat_plumber_01" }] }
+        }
+      ]
+    },
+    {
+      "name": "Workers",
+      "item": [
+        {
+          "name": "List Workers",
+          "request": { "method": "GET", "url": { "raw": "{{baseUrl}}/workers?page=1&limit=20", "query": [{ "key": "page", "value": "1" }, { "key": "limit", "value": "20" }, { "key": "category", "value": "", "disabled": true }, { "key": "search", "value": "", "disabled": true }] } }
+        },
+        {
+          "name": "Advanced Search",
+          "request": { "method": "GET", "url": { "raw": "{{baseUrl}}/workers/search/advanced?q=plumber&available=true", "query": [{ "key": "q", "value": "plumber" }, { "key": "category", "value": "", "disabled": true }, { "key": "minRating", "value": "", "disabled": true }, { "key": "available", "value": "true" }, { "key": "page", "value": "1" }, { "key": "limit", "value": "20" }] } }
+        },
+        {
+          "name": "Get Worker",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/:id", "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "List My Workers (curator)",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/mine", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Create Worker (curator)",
+          "request": {
+            "method": "POST", "url": "{{baseUrl}}/workers",
+            "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] },
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"name\": \"João Silva\",\n  \"categoryId\": \"cat_plumber_01\",\n  \"phone\": \"+55 11 99999-0000\",\n  \"email\": \"joao@example.com\",\n  \"bio\": \"10 years experience in residential plumbing.\",\n  \"walletAddress\": \"GABC...XYZ\"\n}" }
+          }
+        },
+        {
+          "name": "Update Worker JSON (curator)",
+          "request": {
+            "method": "PUT", "url": "{{baseUrl}}/workers/:id",
+            "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] },
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"bio\": \"Updated bio.\"\n}" },
+            "variable": [{ "key": "id", "value": "wkr_abc123" }]
+          }
+        },
+        {
+          "name": "Update Worker with Photo (method-override)",
+          "request": {
+            "method": "POST", "url": "{{baseUrl}}/workers/:id",
+            "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] },
+            "header": [{ "key": "X-HTTP-Method", "value": "PUT" }],
+            "body": { "mode": "formdata", "formdata": [{ "key": "name", "value": "João Silva", "type": "text" }, { "key": "bio", "value": "Updated bio.", "type": "text" }, { "key": "avatar", "type": "file", "src": "" }] },
+            "variable": [{ "key": "id", "value": "wkr_abc123" }]
+          }
+        },
+        {
+          "name": "Toggle Worker Active (curator)",
+          "request": { "method": "PATCH", "url": "{{baseUrl}}/workers/:id/toggle", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Delete Worker (curator)",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/workers/:id", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Get Availability",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/:id/availability", "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Set Availability (curator)",
+          "request": { "method": "PUT", "url": "{{baseUrl}}/workers/:id/availability", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"slots\": [\n    { \"day\": \"monday\", \"startTime\": \"08:00\", \"endTime\": \"17:00\" }\n  ]\n}" }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Register On-Chain (curator)",
+          "request": { "method": "POST", "url": "{{baseUrl}}/workers/:id/register-on-chain", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Contact Worker",
+          "request": { "method": "POST", "url": "{{baseUrl}}/workers/:id/contact", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"message\": \"Hi, I need a plumber this Friday.\"\n}" }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "List Contact Requests (curator)",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/:id/contacts", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Toggle Bookmark",
+          "request": { "method": "POST", "url": "{{baseUrl}}/workers/:id/bookmark", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Get Reputation",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/:id/reputation", "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Sync Reputation (admin)",
+          "request": { "method": "POST", "url": "{{baseUrl}}/workers/:id/reputation/sync", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Get Verifications (curator)",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/:id/verifications", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Get Analytics (curator)",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/:id/analytics", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Track Profile View",
+          "request": { "method": "POST", "url": "{{baseUrl}}/workers/:id/analytics/view", "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        }
+      ]
+    },
+    {
+      "name": "Reviews",
+      "item": [
+        {
+          "name": "List Worker Reviews",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/:id/reviews", "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Submit Review",
+          "request": { "method": "POST", "url": "{{baseUrl}}/workers/:id/reviews", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"rating\": 5,\n  \"body\": \"Excellent work!\"\n}" }, "variable": [{ "key": "id", "value": "wkr_abc123" }] }
+        },
+        {
+          "name": "Delete Review",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/workers/reviews/:id", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "rev_abc123" }] }
+        },
+        {
+          "name": "Flag Review",
+          "request": { "method": "PATCH", "url": "{{baseUrl}}/workers/reviews/:id/flag", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "rev_abc123" }] }
+        },
+        {
+          "name": "Moderation Queue (admin)",
+          "request": { "method": "GET", "url": "{{baseUrl}}/workers/reviews/moderation/queue", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Moderate Review (admin)",
+          "request": { "method": "PATCH", "url": "{{baseUrl}}/workers/reviews/:id/moderate", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"action\": \"approve\"\n}" }, "variable": [{ "key": "id", "value": "rev_abc123" }] }
+        }
+      ]
+    },
+    {
+      "name": "Users",
+      "item": [
+        {
+          "name": "Update Profile (PATCH)",
+          "request": { "method": "PATCH", "url": "{{baseUrl}}/users/me", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"bio\": \"Looking for tradespeople in SP.\"\n}" } }
+        },
+        {
+          "name": "Update Profile with Avatar (method-override)",
+          "request": { "method": "POST", "url": "{{baseUrl}}/users/me", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "X-HTTP-Method", "value": "PUT" }], "body": { "mode": "formdata", "formdata": [{ "key": "firstName", "value": "Ana", "type": "text" }, { "key": "avatar", "type": "file", "src": "" }] } }
+        },
+        {
+          "name": "Change Password",
+          "request": { "method": "PUT", "url": "{{baseUrl}}/users/me/password", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"currentPassword\": \"old_password\",\n  \"newPassword\": \"new_password123\"\n}" } }
+        },
+        {
+          "name": "List Bookmarks",
+          "request": { "method": "GET", "url": "{{baseUrl}}/users/me/bookmarks", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Save Push Subscription",
+          "request": { "method": "POST", "url": "{{baseUrl}}/users/me/push-subscription", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"endpoint\": \"https://fcm.googleapis.com/...\",\n  \"keys\": { \"p256dh\": \"...\", \"auth\": \"...\" }\n}" } }
+        },
+        {
+          "name": "Delete Push Subscription",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/users/me/push-subscription", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Complete Onboarding",
+          "request": { "method": "POST", "url": "{{baseUrl}}/users/onboarding/complete", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Delete Account",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/users/me", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        }
+      ]
+    },
+    {
+      "name": "Jobs",
+      "item": [
+        {
+          "name": "List Jobs",
+          "request": { "method": "GET", "url": { "raw": "{{baseUrl}}/jobs?page=1&limit=20&status=open", "query": [{ "key": "page", "value": "1" }, { "key": "limit", "value": "20" }, { "key": "status", "value": "open" }, { "key": "category", "value": "", "disabled": true }] } }
+        },
+        {
+          "name": "Get Job",
+          "request": { "method": "GET", "url": "{{baseUrl}}/jobs/:id", "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "Create Job",
+          "request": { "method": "POST", "url": "{{baseUrl}}/jobs", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"title\": \"Fix bathroom pipe\",\n  \"description\": \"Leaking pipe under sink.\",\n  \"budget\": 150,\n  \"categoryId\": \"cat_plumber_01\"\n}" } }
+        },
+        {
+          "name": "Update Job",
+          "request": { "method": "PUT", "url": "{{baseUrl}}/jobs/:id", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"title\": \"Updated title\",\n  \"status\": \"in_progress\"\n}" }, "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "Delete Job",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/jobs/:id", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "Renew Job",
+          "request": { "method": "POST", "url": "{{baseUrl}}/jobs/:id/renew", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "My Posted Jobs",
+          "request": { "method": "GET", "url": "{{baseUrl}}/jobs/me/posted", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "My Applications",
+          "request": { "method": "GET", "url": "{{baseUrl}}/jobs/me/applications", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Apply to Job",
+          "request": { "method": "POST", "url": "{{baseUrl}}/jobs/:id/apply", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"coverLetter\": \"I am available and experienced.\",\n  \"proposedBudget\": 130\n}" }, "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "List Applications (job owner)",
+          "request": { "method": "GET", "url": "{{baseUrl}}/jobs/:id/applications", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "Update Application Status",
+          "request": { "method": "PATCH", "url": "{{baseUrl}}/jobs/:id/applications/:applicationId", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"status\": \"accepted\"\n}" }, "variable": [{ "key": "id", "value": "job_abc123" }, { "key": "applicationId", "value": "app_abc123" }] }
+        },
+        {
+          "name": "Withdraw Application",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/jobs/:id/apply", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "Send Message",
+          "request": { "method": "POST", "url": "{{baseUrl}}/jobs/:id/messages", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"body\": \"Can you start Monday?\"\n}" }, "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "List Messages",
+          "request": { "method": "GET", "url": "{{baseUrl}}/jobs/:id/messages", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "variable": [{ "key": "id", "value": "job_abc123" }] }
+        },
+        {
+          "name": "Recommended Jobs for Worker",
+          "request": { "method": "GET", "url": "{{baseUrl}}/jobs/recommendations/:workerId", "variable": [{ "key": "workerId", "value": "wkr_abc123" }] }
+        }
+      ]
+    },
+    {
+      "name": "Payments",
+      "item": [
+        {
+          "name": "Get Platform Fee",
+          "request": { "method": "GET", "url": "{{baseUrl}}/payments/fee" }
+        },
+        {
+          "name": "Update Platform Fee (admin)",
+          "request": { "method": "PATCH", "url": "{{baseUrl}}/payments/fee", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"fee_bps\": 50\n}" } }
+        },
+        {
+          "name": "Send Tip",
+          "request": { "method": "POST", "url": "{{baseUrl}}/payments/tip", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"from\": \"GYOUR...WALLET\",\n  \"to\": \"GWORKER...WALLET\",\n  \"amount\": 10\n}" } }
+        },
+        {
+          "name": "Create Escrow",
+          "request": { "method": "POST", "url": "{{baseUrl}}/payments/escrow", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"from\": \"GYOUR...WALLET\",\n  \"to\": \"GWORKER...WALLET\",\n  \"amount\": 500,\n  \"expiryDate\": \"2026-08-01T00:00:00.000Z\"\n}" } }
+        }
+      ]
+    },
+    {
+      "name": "Disputes",
+      "item": [
+        {
+          "name": "Open Dispute",
+          "request": { "method": "POST", "url": "{{baseUrl}}/disputes", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"jobId\": \"job_abc123\",\n  \"reason\": \"Work was not completed as agreed.\"\n}" } }
+        },
+        {
+          "name": "List Disputes (admin)",
+          "request": { "method": "GET", "url": "{{baseUrl}}/disputes", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Resolve Dispute (admin)",
+          "request": { "method": "PATCH", "url": "{{baseUrl}}/disputes/:id", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"resolution\": \"Refund issued to user.\"\n}" }, "variable": [{ "key": "id", "value": "dispute_abc123" }] }
+        }
+      ]
+    },
+    {
+      "name": "Admin",
+      "item": [
+        {
+          "name": "Get Stats",
+          "request": { "method": "GET", "url": "{{baseUrl}}/admin/stats", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "List All Workers",
+          "request": { "method": "GET", "url": "{{baseUrl}}/admin/workers", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "List All Users",
+          "request": { "method": "GET", "url": "{{baseUrl}}/admin/users", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Bulk Toggle Workers",
+          "request": { "method": "POST", "url": "{{baseUrl}}/admin/workers/bulk-toggle", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"ids\": [\"wkr_abc123\", \"wkr_def456\"]\n}" } }
+        },
+        {
+          "name": "Bulk Delete Workers",
+          "request": { "method": "DELETE", "url": "{{baseUrl}}/admin/workers/bulk-delete", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"ids\": [\"wkr_abc123\"]\n}" } }
+        },
+        {
+          "name": "Import Workers CSV",
+          "request": { "method": "POST", "url": "{{baseUrl}}/admin/workers/import", "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] }, "body": { "mode": "formdata", "formdata": [{ "key": "file", "type": "file", "src": "" }] } }
+        },
+        {
+          "name": "Export Workers JSON",
+          "request": { "method": "GET", "url": { "raw": "{{baseUrl}}/admin/export/workers?format=json", "query": [{ "key": "format", "value": "json" }] }, "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Export Workers CSV",
+          "request": { "method": "GET", "url": { "raw": "{{baseUrl}}/admin/export/workers?format=csv", "query": [{ "key": "format", "value": "csv" }] }, "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        },
+        {
+          "name": "Export Users JSON",
+          "request": { "method": "GET", "url": { "raw": "{{baseUrl}}/admin/export/users?format=json", "query": [{ "key": "format", "value": "json" }] }, "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}", "type": "string" }] } }
+        }
+      ]
+    },
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "Liveness",
+          "request": { "method": "GET", "url": "http://localhost:3000/health" }
+        },
+        {
+          "name": "Readiness",
+          "request": { "method": "GET", "url": "http://localhost:3000/ready" }
+        },
+        {
+          "name": "API Version",
+          "request": { "method": "GET", "url": "{{baseUrl}}/version" }
+        },
+        {
+          "name": "All Versions",
+          "request": { "method": "GET", "url": "{{baseUrl}}/versions" }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1,0 +1,4816 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "BlueCollar API",
+    "version": "1.0.0",
+    "description": "Decentralised skilled-worker marketplace built on Stellar."
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "status",
+          "message",
+          "code"
+        ]
+      },
+      "Success": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "status",
+          "message",
+          "code"
+        ]
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "slug"
+        ]
+      },
+      "Worker": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phone": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bio": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "walletAddress": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "avgRating": {
+            "type": "number"
+          },
+          "reviewCount": {
+            "type": "number"
+          },
+          "categoryId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "phone",
+          "email",
+          "bio",
+          "isActive",
+          "walletAddress",
+          "avgRating",
+          "reviewCount",
+          "categoryId",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "curator",
+              "admin"
+            ]
+          },
+          "verified": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "firstName",
+          "lastName",
+          "role",
+          "verified"
+        ]
+      },
+      "TokenResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "required": [
+          "status",
+          "message",
+          "code",
+          "token",
+          "data"
+        ]
+      },
+      "PaginatedWorkers": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Worker"
+            }
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "number"
+              },
+              "page": {
+                "type": "number"
+              },
+              "limit": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "total",
+              "page",
+              "limit"
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "data",
+          "meta"
+        ]
+      },
+      "Job": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "budget": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "in_progress",
+              "completed",
+              "cancelled"
+            ]
+          },
+          "categoryId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "description",
+          "budget",
+          "status",
+          "categoryId",
+          "userId",
+          "expiresAt",
+          "createdAt",
+          "updatedAt"
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/api/v1/auth/register": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Register a new account",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 8
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "email",
+                  "password",
+                  "firstName",
+                  "lastName"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Account created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Email already in use",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Login with email and password",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "email",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Login successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "delete": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Logout (revokes refresh tokens)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Logged out",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Get current user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Refresh access token",
+        "responses": {
+          "200": {
+            "description": "New token pair",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid refresh token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/verify-account": {
+      "put": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Verify email address",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Account verified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/resend-verification": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Resend verification email",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Email sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/forgot-password": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Request password reset email",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Reset email sent (always 200)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/reset-password": {
+      "put": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Reset password with token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 8
+                  }
+                },
+                "required": [
+                  "token",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Password updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or expired token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/google": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Initiate Google OAuth flow",
+        "responses": {
+          "302": {
+            "description": "Redirect to Google consent screen"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/google/callback": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Google OAuth callback",
+        "responses": {
+          "302": {
+            "description": "Redirect to frontend with JWT"
+          }
+        }
+      }
+    },
+    "/api/v1/categories": {
+      "get": {
+        "tags": [
+          "Categories"
+        ],
+        "summary": "List all categories",
+        "responses": {
+          "200": {
+            "description": "Category list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Category"
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/categories/{id}": {
+      "get": {
+        "tags": [
+          "Categories"
+        ],
+        "summary": "Get a single category",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Category",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Category"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "List active workers (paginated)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "category",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "search",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Worker list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedWorkers"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Create a worker listing (curator)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "categoryId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "bio": {
+                    "type": "string"
+                  },
+                  "walletAddress": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "categoryId"
+                ]
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "categoryId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "bio": {
+                    "type": "string"
+                  },
+                  "walletAddress": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "categoryId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Worker created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Worker"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/mine": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "List my worker listings (curator/admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "My workers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedWorkers"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Get a single worker",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Worker",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Worker"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Update a worker (curator). Use POST + X-HTTP-Method: PUT for file uploads.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "categoryId": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "bio": {
+                    "type": "string"
+                  },
+                  "walletAddress": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "categoryId": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "bio": {
+                    "type": "string"
+                  },
+                  "walletAddress": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Worker updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Worker"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Delete a worker (curator)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/toggle": {
+      "patch": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Toggle worker active status (curator)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status toggled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Worker"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/reviews": {
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Submit a review for a worker",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "rating": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5
+                  },
+                  "comment": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "rating"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Review created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Reviews"
+        ],
+        "summary": "List reviews for a worker",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reviews with aggregate rating",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "avgRating": {
+                      "type": "number"
+                    },
+                    "reviewCount": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data",
+                    "avgRating",
+                    "reviewCount"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/bookmark": {
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Toggle bookmark on a worker",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark toggled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/contact": {
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Send a contact request to a worker",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "minLength": 10
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Request sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me": {
+      "patch": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Update own profile",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "firstName": {
+                    "type": "string"
+                  },
+                  "lastName": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "bio": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Profile updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Delete own account",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Full profile update (supports avatar upload via X-HTTP-Method: PUT)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "firstName": {
+                    "type": "string"
+                  },
+                  "lastName": {
+                    "type": "string"
+                  },
+                  "bio": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "avatar": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/password": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Change password",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "currentPassword": {
+                    "type": "string"
+                  },
+                  "newPassword": {
+                    "type": "string",
+                    "minLength": 8
+                  }
+                },
+                "required": [
+                  "currentPassword",
+                  "newPassword"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Password changed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Wrong current password",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/bookmarks": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "List bookmarked workers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmarks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedWorkers"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/payments/fee": {
+      "get": {
+        "tags": [
+          "Payments"
+        ],
+        "summary": "Get current platform fee",
+        "responses": {
+          "200": {
+            "description": "Fee info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "fee_bps": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "fee_bps"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Payments"
+        ],
+        "summary": "Update platform fee (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fee_bps": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "fee_bps"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Fee updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/payments/tip": {
+      "post": {
+        "tags": [
+          "Payments"
+        ],
+        "summary": "Send a tip to a worker via Stellar",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
+                  },
+                  "amount": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  }
+                },
+                "required": [
+                  "from",
+                  "to",
+                  "amount"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tip sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/payments/escrow": {
+      "post": {
+        "tags": [
+          "Payments"
+        ],
+        "summary": "Create an escrow payment",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
+                  },
+                  "amount": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "expiryDate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from",
+                  "to",
+                  "amount",
+                  "expiryDate"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Escrow created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/stats": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Platform statistics (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/workers": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List all workers (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedWorkers"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/users": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List all users (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/User"
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/workers/bulk-toggle": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Bulk toggle worker active status (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Toggled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/workers/bulk-delete": {
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Bulk delete workers (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Liveness check",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Readiness check (DB + Redis)",
+        "responses": {
+          "200": {
+            "description": "Ready",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "checks": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "checks"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Degraded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "checks": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "checks"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/version": {
+      "get": {
+        "tags": [
+          "Versioning"
+        ],
+        "summary": "Get API versioning information",
+        "responses": {
+          "200": {
+            "description": "API versioning info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "apiPackageVersion": {
+                      "type": "string"
+                    },
+                    "apiVersions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "currentVersion": {
+                      "type": "string"
+                    },
+                    "deprecatedVersions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "apiPackageVersion",
+                    "apiVersions",
+                    "currentVersion",
+                    "deprecatedVersions",
+                    "status"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/version": {
+      "get": {
+        "tags": [
+          "Versioning"
+        ],
+        "summary": "Get v1 API version information",
+        "responses": {
+          "200": {
+            "description": "v1 API version info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "apiVersion": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "supported": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deprecated": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "sunset": {
+                      "type": "null"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "apiVersion",
+                    "status",
+                    "supported",
+                    "deprecated",
+                    "sunset"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/versions": {
+      "get": {
+        "tags": [
+          "Versioning"
+        ],
+        "summary": "List all supported API versions with metadata",
+        "responses": {
+          "200": {
+            "description": "List of API versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "versions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "version": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "current",
+                              "deprecated"
+                            ]
+                          },
+                          "sunset": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "rateLimiting": {
+                            "type": "object",
+                            "properties": {
+                              "requests": {
+                                "type": "number"
+                              },
+                              "windowMs": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "requests",
+                              "windowMs"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "version",
+                          "status",
+                          "sunset",
+                          "rateLimiting"
+                        ]
+                      }
+                    },
+                    "current": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "versions",
+                    "current"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/2fa/setup": {
+      "post": {
+        "tags": [
+          "2FA"
+        ],
+        "summary": "Generate TOTP secret and QR code",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "QR code URI and backup codes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "otpauth": {
+                          "type": "string"
+                        },
+                        "qrCode": {
+                          "type": "string"
+                        },
+                        "backupCodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "otpauth",
+                        "qrCode",
+                        "backupCodes"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/2fa/enable": {
+      "post": {
+        "tags": [
+          "2FA"
+        ],
+        "summary": "Enable 2FA after verifying TOTP code",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "minLength": 6,
+                    "maxLength": 6
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "2FA enabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid TOTP code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/2fa/verify": {
+      "post": {
+        "tags": [
+          "2FA"
+        ],
+        "summary": "Verify TOTP code during login (step 2)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string",
+                    "minLength": 6,
+                    "maxLength": 6
+                  }
+                },
+                "required": [
+                  "userId",
+                  "code"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verified — returns JWT",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/2fa/verify-backup": {
+      "post": {
+        "tags": [
+          "2FA"
+        ],
+        "summary": "Verify a backup code (consumes it)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "userId",
+                  "code"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/2fa": {
+      "delete": {
+        "tags": [
+          "2FA"
+        ],
+        "summary": "Disable 2FA",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "2FA disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/2fa/backup-codes/regenerate": {
+      "post": {
+        "tags": [
+          "2FA"
+        ],
+        "summary": "Regenerate backup codes",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "New backup codes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "backupCodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "backupCodes"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "List jobs (paginated)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "category",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "search",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Job"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "number"
+                        },
+                        "page": {
+                          "type": "number"
+                        },
+                        "limit": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "total",
+                        "page",
+                        "limit"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Create a job posting",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "budget": {
+                    "type": "number"
+                  },
+                  "categoryId": {
+                    "type": "string"
+                  },
+                  "expiresAt": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "description",
+                  "categoryId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Job created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Job"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/{id}": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get a single job",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Job"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Update a job posting",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "budget": {
+                    "type": "number"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Job updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Job"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Delete a job posting",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/{id}/renew": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Renew a job posting (extend expiry)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job renewed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Job"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/me/posted": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "List jobs posted by the current user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "My jobs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Job"
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/me/applications": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "List job applications made by the current user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "My applications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/{id}/apply": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Apply to a job",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "coverLetter": {
+                    "type": "string"
+                  },
+                  "proposedBudget": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Application submitted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Already applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Withdraw a job application",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Withdrawn",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/{id}/applications": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "List applications for a job (job owner)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/{id}/applications/{applicationId}": {
+      "patch": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Update application status (accept / reject)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "applicationId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "accepted",
+                      "rejected"
+                    ]
+                  }
+                },
+                "required": [
+                  "status"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Status updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/{id}/messages": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Send a message in a job thread",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Message sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "List messages in a job thread",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/recommendations/{workerId}": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get recommended jobs for a worker",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workerId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recommended jobs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Job"
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/reviews/{id}": {
+      "delete": {
+        "tags": [
+          "Reviews"
+        ],
+        "summary": "Delete a review (owner only)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/reviews/{id}/flag": {
+      "patch": {
+        "tags": [
+          "Reviews"
+        ],
+        "summary": "Flag a review for moderation",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Flagged",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/reviews/moderation/queue": {
+      "get": {
+        "tags": [
+          "Reviews"
+        ],
+        "summary": "Get moderation queue (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Review queue",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/reviews/{id}/moderate": {
+      "patch": {
+        "tags": [
+          "Reviews"
+        ],
+        "summary": "Approve or reject a flagged review (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "approve",
+                      "reject"
+                    ]
+                  }
+                },
+                "required": [
+                  "action"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Review moderated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/disputes": {
+      "post": {
+        "tags": [
+          "Disputes"
+        ],
+        "summary": "Open a dispute",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "jobId": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string",
+                    "minLength": 10
+                  }
+                },
+                "required": [
+                  "jobId",
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Dispute opened",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Disputes"
+        ],
+        "summary": "List disputes (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Disputes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/disputes/{id}": {
+      "patch": {
+        "tags": [
+          "Disputes"
+        ],
+        "summary": "Resolve a dispute (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "resolution": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "resolution"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/search/advanced": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Advanced worker search",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "category",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "location",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "minRating",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "available",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedWorkers"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/availability": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Get worker availability",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Availability",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Set worker availability (curator)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "slots": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  }
+                },
+                "required": [
+                  "slots"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Availability updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/register-on-chain": {
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Register worker on Stellar Registry contract (curator)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered on-chain",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "txHash": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "txHash"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Already registered or invalid wallet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/contacts": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "List contact requests for a worker (curator)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contact requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/contacts/{requestId}": {
+      "patch": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Update contact request status (curator)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "requestId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "read",
+                      "archived"
+                    ]
+                  }
+                },
+                "required": [
+                  "status"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/verifications": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "List verifications for a worker (curator/admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Verifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/analytics": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Worker analytics (curator/admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Analytics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/analytics/view": {
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Track a profile view (public)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tracked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/reputation": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Get worker reputation score",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reputation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "score": {
+                          "type": "number"
+                        },
+                        "breakdown": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "score",
+                        "breakdown"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/{id}/reputation/sync": {
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Sync reputation from on-chain data (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Synced",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/push-subscription": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Save Web Push subscription",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "string"
+                  },
+                  "keys": {
+                    "type": "object",
+                    "properties": {
+                      "p256dh": {
+                        "type": "string"
+                      },
+                      "auth": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "p256dh",
+                      "auth"
+                    ]
+                  }
+                },
+                "required": [
+                  "endpoint",
+                  "keys"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Remove Web Push subscription",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/onboarding/complete": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Mark onboarding as completed",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Onboarding completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/export/workers": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Export workers as CSV or JSON (admin, 1/min rate limit)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "csv",
+                "json"
+              ]
+            },
+            "required": false,
+            "name": "format",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exported data (application/json or text/csv)"
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/export/users": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Export users as CSV or JSON (admin, 1/min rate limit)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "csv",
+                "json"
+              ]
+            },
+            "required": false,
+            "name": "format",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exported data (application/json or text/csv)"
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/workers/import": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Bulk import workers from CSV (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "description": "CSV file (max 5 MB)"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Import results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "imported": {
+                          "type": "number"
+                        },
+                        "failed": {
+                          "type": "number"
+                        },
+                        "errors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "imported",
+                        "failed",
+                        "errors"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid CSV",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "webhooks": {}
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,7 +35,14 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "7.3.4",
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.40.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.45.0",
+    "@opentelemetry/sdk-node": "^0.45.0",
+    "@opentelemetry/semantic-conventions": "^1.21.0",
     "@prisma/client": "^7.2.0",
+    "@types/swagger-ui-express": "4.1.8",
     "argon2": "^0.41.1",
     "cors": "^2.8.5",
     "express": "^4.18.2",
@@ -52,23 +59,21 @@
     "pino": "^10.3.1",
     "pino-http": "^10.4.0",
     "pino-pretty": "^13.1.3",
+    "prom-client": "^15.1.0",
     "qrcode": "^1.5.4",
     "sharp": "^0.34.5",
     "simple-body-validator": "^1.3.9",
+    "swagger-ui-express": "5.0.1",
+    "v8-profiler-next": "^1.9.0",
     "web-push": "^3.6.7",
     "winston": "^3.17.0",
-    "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/sdk-node": "^0.45.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.40.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.45.0",
-    "@opentelemetry/semantic-conventions": "^1.21.0",
-    "prom-client": "^15.1.0",
-    "v8-profiler-next": "^1.9.0",
     "xss": "^1.0.15",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.2.0",
+    "@stryker-mutator/core": "^8.2.6",
+    "@stryker-mutator/vitest-runner": "^8.2.6",
     "@types/cors": "^2.8.17",
     "@types/express": "latest",
     "@types/jsonwebtoken": "^9.0.9",
@@ -88,8 +93,6 @@
     "supertest": "^7.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.4.0",
-    "vitest": "^1.4.0",
-    "@stryker-mutator/core": "^8.2.6",
-    "@stryker-mutator/vitest-runner": "^8.2.6"
+    "vitest": "^1.4.0"
   }
 }

--- a/packages/api/src/openapi/spec.ts
+++ b/packages/api/src/openapi/spec.ts
@@ -1,5 +1,7 @@
-import { OpenApiGeneratorV31, OpenAPIRegistry } from '@asteasolutions/zod-to-openapi'
+import { OpenApiGeneratorV31, OpenAPIRegistry, extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi'
 import { z } from 'zod'
+
+extendZodWithOpenApi(z)
 import {
   registerRules, loginRules, forgotPasswordRules,
   resetPasswordRules, verifyAccountRules, resendVerificationRules,
@@ -497,6 +499,435 @@ registry.registerPath({
         },
       },
     },
+  },
+})
+
+// ── 2FA ───────────────────────────────────────────────────────────────────────
+registry.registerPath({
+  method: 'post', path: '/api/v1/auth/2fa/setup', tags: ['2FA'],
+  summary: 'Generate TOTP secret and QR code',
+  security: [{ [BearerAuth.name]: [] }],
+  responses: {
+    200: { description: 'QR code URI and backup codes', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.object({ otpauth: z.string(), qrCode: z.string(), backupCodes: z.array(z.string()) }) }) } } },
+  },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/auth/2fa/enable', tags: ['2FA'],
+  summary: 'Enable 2FA after verifying TOTP code',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { body: { content: { 'application/json': { schema: z.object({ code: z.string().length(6) }) } } } },
+  responses: {
+    200: { description: '2FA enabled', content: { 'application/json': { schema: SuccessSchema } } },
+    400: { description: 'Invalid TOTP code', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/auth/2fa/verify', tags: ['2FA'],
+  summary: 'Verify TOTP code during login (step 2)',
+  request: { body: { content: { 'application/json': { schema: z.object({ userId: z.string(), code: z.string().length(6) }) } } } },
+  responses: {
+    200: { description: 'Verified — returns JWT', content: { 'application/json': { schema: TokenResponseSchema } } },
+    401: { description: 'Invalid code', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/auth/2fa/verify-backup', tags: ['2FA'],
+  summary: 'Verify a backup code (consumes it)',
+  request: { body: { content: { 'application/json': { schema: z.object({ userId: z.string(), code: z.string() }) } } } },
+  responses: {
+    200: { description: 'Verified', content: { 'application/json': { schema: TokenResponseSchema } } },
+    401: { description: 'Invalid code', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'delete', path: '/api/v1/auth/2fa', tags: ['2FA'],
+  summary: 'Disable 2FA',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { body: { content: { 'application/json': { schema: z.object({ code: z.string() }) } } } },
+  responses: { 200: { description: '2FA disabled', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/auth/2fa/backup-codes/regenerate', tags: ['2FA'],
+  summary: 'Regenerate backup codes',
+  security: [{ [BearerAuth.name]: [] }],
+  responses: { 200: { description: 'New backup codes', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.object({ backupCodes: z.array(z.string()) }) }) } } },
+  },
+})
+
+// ── Jobs ──────────────────────────────────────────────────────────────────────
+const JobSchema = registry.register('Job', z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  budget: z.number().nullable(),
+  status: z.enum(['open', 'in_progress', 'completed', 'cancelled']),
+  categoryId: z.string(),
+  userId: z.string(),
+  expiresAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+}))
+
+const jobQuerySchema = z.object({
+  page: z.string().optional(),
+  limit: z.string().optional(),
+  category: z.string().optional(),
+  status: z.string().optional(),
+  search: z.string().optional(),
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/jobs', tags: ['Jobs'],
+  summary: 'List jobs (paginated)',
+  request: { query: jobQuerySchema },
+  responses: { 200: { description: 'Job list', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(JobSchema), meta: z.object({ total: z.number(), page: z.number(), limit: z.number() }) }) } } },
+  },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/jobs/{id}', tags: ['Jobs'],
+  summary: 'Get a single job',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: 'Job', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: JobSchema }) } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/jobs', tags: ['Jobs'],
+  summary: 'Create a job posting',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { body: { content: { 'application/json': { schema: z.object({ title: z.string(), description: z.string(), budget: z.number().optional(), categoryId: z.string(), expiresAt: z.string().optional() }) } } } },
+  responses: {
+    201: { description: 'Job created', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: JobSchema }) } } },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'put', path: '/api/v1/jobs/{id}', tags: ['Jobs'],
+  summary: 'Update a job posting',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }), body: { content: { 'application/json': { schema: z.object({ title: z.string().optional(), description: z.string().optional(), budget: z.number().optional(), status: z.string().optional() }) } } } },
+  responses: {
+    200: { description: 'Job updated', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: JobSchema }) } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'delete', path: '/api/v1/jobs/{id}', tags: ['Jobs'],
+  summary: 'Delete a job posting',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Deleted', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/jobs/{id}/renew', tags: ['Jobs'],
+  summary: 'Renew a job posting (extend expiry)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Job renewed', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: JobSchema }) } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/jobs/me/posted', tags: ['Jobs'],
+  summary: 'List jobs posted by the current user',
+  security: [{ [BearerAuth.name]: [] }],
+  responses: { 200: { description: 'My jobs', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(JobSchema) }) } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/jobs/me/applications', tags: ['Jobs'],
+  summary: 'List job applications made by the current user',
+  security: [{ [BearerAuth.name]: [] }],
+  responses: { 200: { description: 'My applications', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())) }) } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/jobs/{id}/apply', tags: ['Jobs'],
+  summary: 'Apply to a job',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }), body: { content: { 'application/json': { schema: z.object({ coverLetter: z.string().optional(), proposedBudget: z.number().optional() }) } } } },
+  responses: {
+    201: { description: 'Application submitted', content: { 'application/json': { schema: SuccessSchema } } },
+    409: { description: 'Already applied', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/jobs/{id}/applications', tags: ['Jobs'],
+  summary: 'List applications for a job (job owner)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Applications', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())) }) } } } },
+})
+
+registry.registerPath({
+  method: 'patch', path: '/api/v1/jobs/{id}/applications/{applicationId}', tags: ['Jobs'],
+  summary: 'Update application status (accept / reject)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string(), applicationId: z.string() }), body: { content: { 'application/json': { schema: z.object({ status: z.enum(['accepted', 'rejected']) }) } } } },
+  responses: { 200: { description: 'Status updated', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'delete', path: '/api/v1/jobs/{id}/apply', tags: ['Jobs'],
+  summary: 'Withdraw a job application',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Withdrawn', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/jobs/{id}/messages', tags: ['Jobs'],
+  summary: 'Send a message in a job thread',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }), body: { content: { 'application/json': { schema: z.object({ body: z.string().min(1) }) } } } },
+  responses: { 201: { description: 'Message sent', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/jobs/{id}/messages', tags: ['Jobs'],
+  summary: 'List messages in a job thread',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Messages', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())) }) } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/jobs/recommendations/{workerId}', tags: ['Jobs'],
+  summary: 'Get recommended jobs for a worker',
+  request: { params: z.object({ workerId: z.string() }) },
+  responses: { 200: { description: 'Recommended jobs', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(JobSchema) }) } } } },
+})
+
+// ── Reviews (standalone) ──────────────────────────────────────────────────────
+registry.registerPath({
+  method: 'get', path: '/api/v1/workers/{id}/reviews', tags: ['Reviews'],
+  summary: 'List reviews for a worker',
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Reviews with aggregate rating', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())), avgRating: z.number(), reviewCount: z.number() }) } } } },
+})
+
+registry.registerPath({
+  method: 'delete', path: '/api/v1/workers/reviews/{id}', tags: ['Reviews'],
+  summary: 'Delete a review (owner only)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    204: { description: 'Deleted' },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: ErrorSchema } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'patch', path: '/api/v1/workers/reviews/{id}/flag', tags: ['Reviews'],
+  summary: 'Flag a review for moderation',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Flagged', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/workers/reviews/moderation/queue', tags: ['Reviews'],
+  summary: 'Get moderation queue (admin)',
+  security: [{ [BearerAuth.name]: [] }],
+  responses: { 200: { description: 'Review queue', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())) }) } } } },
+})
+
+registry.registerPath({
+  method: 'patch', path: '/api/v1/workers/reviews/{id}/moderate', tags: ['Reviews'],
+  summary: 'Approve or reject a flagged review (admin)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }), body: { content: { 'application/json': { schema: z.object({ action: z.enum(['approve', 'reject']) }) } } } },
+  responses: { 200: { description: 'Review moderated', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+// ── Disputes ──────────────────────────────────────────────────────────────────
+registry.registerPath({
+  method: 'post', path: '/api/v1/disputes', tags: ['Disputes'],
+  summary: 'Open a dispute',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { body: { content: { 'application/json': { schema: z.object({ jobId: z.string(), reason: z.string().min(10) }) } } } },
+  responses: {
+    201: { description: 'Dispute opened', content: { 'application/json': { schema: SuccessSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/disputes', tags: ['Disputes'],
+  summary: 'List disputes (admin)',
+  security: [{ [BearerAuth.name]: [] }],
+  responses: { 200: { description: 'Disputes', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())) }) } } } },
+})
+
+registry.registerPath({
+  method: 'patch', path: '/api/v1/disputes/{id}', tags: ['Disputes'],
+  summary: 'Resolve a dispute (admin)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }), body: { content: { 'application/json': { schema: z.object({ resolution: z.string() }) } } } },
+  responses: { 200: { description: 'Resolved', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+// ── Worker extended endpoints ─────────────────────────────────────────────────
+registry.registerPath({
+  method: 'get', path: '/api/v1/workers/search/advanced', tags: ['Workers'],
+  summary: 'Advanced worker search',
+  request: { query: z.object({ q: z.string().optional(), category: z.string().optional(), location: z.string().optional(), minRating: z.string().optional(), available: z.string().optional(), page: z.string().optional(), limit: z.string().optional() }) },
+  responses: { 200: { description: 'Search results', content: { 'application/json': { schema: PaginatedWorkersSchema } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/workers/{id}/availability', tags: ['Workers'],
+  summary: 'Get worker availability',
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Availability', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())) }) } } } },
+})
+
+registry.registerPath({
+  method: 'put', path: '/api/v1/workers/{id}/availability', tags: ['Workers'],
+  summary: 'Set worker availability (curator)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }), body: { content: { 'application/json': { schema: z.object({ slots: z.array(z.record(z.unknown())) }) } } } },
+  responses: { 200: { description: 'Availability updated', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/workers/{id}/register-on-chain', tags: ['Workers'],
+  summary: 'Register worker on Stellar Registry contract (curator)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: 'Registered on-chain', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.object({ txHash: z.string() }) }) } } },
+    400: { description: 'Already registered or invalid wallet', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/workers/{id}/contacts', tags: ['Workers'],
+  summary: 'List contact requests for a worker (curator)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Contact requests', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())) }) } } } },
+})
+
+registry.registerPath({
+  method: 'patch', path: '/api/v1/workers/{id}/contacts/{requestId}', tags: ['Workers'],
+  summary: 'Update contact request status (curator)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string(), requestId: z.string() }), body: { content: { 'application/json': { schema: z.object({ status: z.enum(['read', 'archived']) }) } } } },
+  responses: { 200: { description: 'Updated', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/workers/{id}/verifications', tags: ['Workers'],
+  summary: 'List verifications for a worker (curator/admin)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Verifications', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.array(z.record(z.unknown())) }) } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/workers/{id}/analytics', tags: ['Workers'],
+  summary: 'Worker analytics (curator/admin)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Analytics', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.record(z.unknown()) }) } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/workers/{id}/analytics/view', tags: ['Workers'],
+  summary: 'Track a profile view (public)',
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Tracked', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/workers/{id}/reputation', tags: ['Workers'],
+  summary: 'Get worker reputation score',
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Reputation', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.object({ score: z.number(), breakdown: z.record(z.unknown()) }) }) } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/workers/{id}/reputation/sync', tags: ['Workers'],
+  summary: 'Sync reputation from on-chain data (admin)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: { description: 'Synced', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+// ── Users extended ────────────────────────────────────────────────────────────
+registry.registerPath({
+  method: 'put', path: '/api/v1/users/me', tags: ['Users'],
+  summary: 'Full profile update (supports avatar upload via X-HTTP-Method: PUT)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { body: { content: { 'multipart/form-data': { schema: z.object({ firstName: z.string().optional(), lastName: z.string().optional(), bio: z.string().optional(), phone: z.string().optional(), avatar: z.string().optional() }) } } } },
+  responses: { 200: { description: 'Updated', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: UserSchema }) } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/users/me/push-subscription', tags: ['Users'],
+  summary: 'Save Web Push subscription',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { body: { content: { 'application/json': { schema: z.object({ endpoint: z.string(), keys: z.object({ p256dh: z.string(), auth: z.string() }) }) } } } },
+  responses: { 200: { description: 'Saved', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'delete', path: '/api/v1/users/me/push-subscription', tags: ['Users'],
+  summary: 'Remove Web Push subscription',
+  security: [{ [BearerAuth.name]: [] }],
+  responses: { 200: { description: 'Removed', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/users/onboarding/complete', tags: ['Users'],
+  summary: 'Mark onboarding as completed',
+  security: [{ [BearerAuth.name]: [] }],
+  responses: { 200: { description: 'Onboarding completed', content: { 'application/json': { schema: SuccessSchema } } } },
+})
+
+// ── Admin extended ────────────────────────────────────────────────────────────
+registry.registerPath({
+  method: 'get', path: '/api/v1/admin/export/workers', tags: ['Admin'],
+  summary: 'Export workers as CSV or JSON (admin, 1/min rate limit)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { query: z.object({ format: z.enum(['csv', 'json']).optional() }) },
+  responses: {
+    200: { description: 'Exported data (application/json or text/csv)' },
+    429: { description: 'Rate limit exceeded', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'get', path: '/api/v1/admin/export/users', tags: ['Admin'],
+  summary: 'Export users as CSV or JSON (admin, 1/min rate limit)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { query: z.object({ format: z.enum(['csv', 'json']).optional() }) },
+  responses: {
+    200: { description: 'Exported data (application/json or text/csv)' },
+    429: { description: 'Rate limit exceeded', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+})
+
+registry.registerPath({
+  method: 'post', path: '/api/v1/admin/workers/import', tags: ['Admin'],
+  summary: 'Bulk import workers from CSV (admin)',
+  security: [{ [BearerAuth.name]: [] }],
+  request: { body: { content: { 'multipart/form-data': { schema: z.object({ file: z.string().describe('CSV file (max 5 MB)') }) } } } },
+  responses: {
+    200: { description: 'Import results', content: { 'application/json': { schema: z.object({ status: z.literal('success'), data: z.object({ imported: z.number(), failed: z.number(), errors: z.array(z.string()) }) }) } } },
+    400: { description: 'Invalid CSV', content: { 'application/json': { schema: ErrorSchema } } },
   },
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   packages/api:
     dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: 7.3.4
+        version: 7.3.4(zod@3.25.76)
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.9.1
@@ -35,6 +38,9 @@ importers:
       '@prisma/client':
         specifier: ^7.2.0
         version: 7.5.0(prisma@7.5.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@types/swagger-ui-express':
+        specifier: 4.1.8
+        version: 4.1.8
       argon2:
         specifier: ^0.41.1
         version: 0.41.1
@@ -95,6 +101,9 @@ importers:
       simple-body-validator:
         specifier: ^1.3.9
         version: 1.3.9
+      swagger-ui-express:
+        specifier: 5.0.1
+        version: 5.0.1(express@4.22.1)
       v8-profiler-next:
         specifier: ^1.9.0
         version: 1.10.0(encoding@0.1.13)
@@ -356,6 +365,11 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@asteasolutions/zod-to-openapi@7.3.4':
+    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@axe-core/playwright@4.11.3':
     resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
@@ -3317,6 +3331,9 @@ packages:
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
 
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
 
@@ -4054,6 +4071,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/swagger-ui-express@4.1.8':
+    resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -7158,6 +7178,9 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  openapi3-ts@4.6.0:
+    resolution: {integrity: sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -8301,6 +8324,15 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.32.8:
+    resolution: {integrity: sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -8950,6 +8982,11 @@ packages:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -9006,6 +9043,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+    dependencies:
+      openapi3-ts: 4.6.0
+      zod: 3.25.76
 
   '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
     dependencies:
@@ -12163,6 +12205,8 @@ snapshots:
 
   '@rushstack/eslint-patch@1.16.1': {}
 
+  '@scarf/scarf@1.4.0': {}
+
   '@schummar/icu-type-parser@1.21.5': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -13138,6 +13182,11 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/swagger-ui-express@4.1.8':
+    dependencies:
+      '@types/express': 5.0.6
+      '@types/serve-static': 2.2.0
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -14902,7 +14951,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -14932,7 +14981,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14947,7 +14996,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -16777,6 +16826,10 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openapi3-ts@4.6.0:
+    dependencies:
+      yaml: 2.9.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -18098,6 +18151,15 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swagger-ui-dist@5.32.8:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+      swagger-ui-dist: 5.32.8
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.5.0: {}
@@ -18775,6 +18837,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@1.10.3: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
Closes #708, closes #710

## Summary

### #710 — Role-Based Onboarding Guides
- **`docs/CURATOR_GUIDE.md`** — 15 sections covering: getting the curator role, wallet setup, creating/updating/toggling listings, photo uploads (method-override pattern), availability slots, on-chain registration, contact requests, analytics, TTL renewal, troubleshooting FAQ.
- **`docs/WORKER_GUIDE.md`** — 15 sections covering: how the platform works, getting listed, Stellar wallet setup, on-chain listing explained, receiving payments, reputation scoring, verification badges, job applications, troubleshooting FAQ.
- **`docs/USER_GUIDE.md`** — Replaces the previous 52-line stub with a full 18-section guide: account creation, email verification, Google OAuth, 2FA, worker discovery, advanced search, bookmarks, contact requests, reviews, job posting, Freighter wallet, tipping, profile/password management, troubleshooting FAQ.

### #708 — Complete API Reference
- **`packages/api/src/openapi/spec.ts`** — Extended with all previously undocumented endpoints: 2FA (6 routes), Jobs (15 routes), Reviews standalone moderation (5 routes), Disputes (3 routes), Worker sub-resources (availability, on-chain registration, contacts, verifications, analytics, reputation), Users extended (PUT with upload, push subscriptions, onboarding), Admin extended (CSV import, workers/users export). **73 paths total.**
- **`packages/api/openapi.json`** — Regenerated OpenAPI 3.1 spec (116 KB). Swagger UI served at `/api/docs` in development.
- **`packages/api/POSTMAN_COLLECTION.json`** — 87 requests across 11 folders (Auth, 2FA, Categories, Workers, Reviews, Users, Jobs, Payments, Disputes, Admin, Health). Collection variables for `baseUrl` and `token`; Login request auto-saves JWT.
- Added missing dependencies: `@asteasolutions/zod-to-openapi@7.3.4`, `swagger-ui-express@5.0.1`.

## Testing
- `pnpm openapi:generate` runs successfully and produces `openapi.json`
- Swagger UI accessible at `/api/docs` when `NODE_ENV != production`
- Postman collection validated as well-formed JSON (87 requests)