### PR TITLE
Make the app installable and resilient offline with a service worker, manifest, and caching strategy

### DIFF
--- a/packages/app/next.config.mjs
+++ b/packages/app/next.config.mjs
@@ -32,6 +32,15 @@ const nextConfig = {
           value: 'application/manifest+json'
         }
       ]
+    },
+    {
+      source: '/offline.html',
+      headers: [
+        {
+          key: 'Cache-Control',
+          value: 'public, max-age=0, must-revalidate'
+        }
+      ]
     }
   ]
 };

--- a/packages/app/public/icon-192.svg
+++ b/packages/app/public/icon-192.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="32" fill="#2563EB"/>
+  <path d="M48 132V60h36a24 24 0 0 1 0 48H48m0 0h42a24 24 0 0 1 0 48H48" stroke="white" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="144" cy="72" r="24" fill="white"/>
+  <path d="M136 72l-6 6m16-6l-6 6" stroke="#2563EB" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="144" cy="120" r="24" fill="white"/>
+  <path d="M136 120l-6 6m16-6l-6 6" stroke="#2563EB" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/packages/app/public/icon-512.svg
+++ b/packages/app/public/icon-512.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#2563EB"/>
+  <path d="M128 352V160h96a64 64 0 0 1 0 128H128m0 0h112a64 64 0 0 1 0 128H128" stroke="white" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="384" cy="192" r="64" fill="white"/>
+  <path d="M360 192l-16 16m40-16l-16 16" stroke="#2563EB" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="384" cy="320" r="64" fill="white"/>
+  <path d="M360 320l-16 16m40-16l-16 16" stroke="#2563EB" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/packages/app/public/manifest.json
+++ b/packages/app/public/manifest.json
@@ -1,18 +1,28 @@
 {
-  "name": "BlueCollar - Find Skilled Workers",
+  "name": "BlueCollar — Find Skilled Workers Near You",
   "short_name": "BlueCollar",
-  "description": "Find Skilled Workers Near You — Connect with local plumbers, electricians, carpenters, and more",
+  "description": "Find Skilled Workers Near You — Connect with local plumbers, electricians, carpenters, and more. Secure payments on the Stellar blockchain.",
   "start_url": "/",
   "scope": "/",
+  "id": "/?source=pwa",
   "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone"],
   "orientation": "portrait-primary",
   "background_color": "#ffffff",
   "theme_color": "#2563eb",
-  "categories": ["productivity", "utilities"],
+  "lang": "en",
+  "dir": "ltr",
+  "categories": ["productivity", "utilities", "business"],
   "screenshots": [
     {
+      "src": "/og-image.png",
+      "sizes": "1200x630",
+      "type": "image/png",
+      "form_factor": "wide"
+    },
+    {
       "src": "/logo.png",
-      "sizes": "192x192",
+      "sizes": "200x60",
       "type": "image/png",
       "form_factor": "narrow"
     }
@@ -25,9 +35,9 @@
       "url": "/workers",
       "icons": [
         {
-          "src": "/logo.png",
+          "src": "/icon-192.svg",
           "sizes": "192x192",
-          "type": "image/png"
+          "type": "image/svg+xml"
         }
       ]
     },
@@ -38,9 +48,22 @@
       "url": "/bookmarks",
       "icons": [
         {
-          "src": "/logo.png",
+          "src": "/icon-192.svg",
           "sizes": "192x192",
-          "type": "image/png"
+          "type": "image/svg+xml"
+        }
+      ]
+    },
+    {
+      "name": "Dashboard",
+      "short_name": "Dashboard",
+      "description": "Manage your workers and analytics",
+      "url": "/dashboard",
+      "icons": [
+        {
+          "src": "/icon-192.svg",
+          "sizes": "192x192",
+          "type": "image/svg+xml"
         }
       ]
     }
@@ -58,16 +81,30 @@
       "purpose": "any maskable"
     },
     {
-      "src": "/logo.png",
+      "src": "/icon-192.svg",
       "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any"
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
     },
     {
       "src": "/logo.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "any"
     }
-  ]
+  ],
+  "edge_side_panel": {
+    "preferred_width": 400
+  },
+  "launch_handler": {
+    "client_mode": "focus-existing"
+  },
+  "handle_links": "preferred",
+  "prefer_related_applications": false
 }

--- a/packages/app/public/offline.html
+++ b/packages/app/public/offline.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>You're Offline — BlueCollar</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      min-height: 100vh; padding: 2rem; text-align: center;
+      background: #f8fafc; color: #111827;
+    }
+    .icon { width: 80px; height: 80px; margin-bottom: 1.5rem; }
+    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; }
+    p { color: #6b7280; max-width: 28rem; line-height: 1.6; margin-bottom: 1.5rem; }
+    .btn {
+      display: inline-flex; align-items: center; gap: 0.5rem;
+      background: #2563eb; color: white; border: none;
+      padding: 0.75rem 1.5rem; border-radius: 0.5rem;
+      font-size: 0.875rem; font-weight: 600; cursor: pointer;
+      text-decoration: none; transition: background 0.2s;
+    }
+    .btn:hover { background: #1d4ed8; }
+    .btn:focus-visible { outline: 3px solid #2563eb; outline-offset: 2px; }
+    .status { margin-top: 1rem; font-size: 0.75rem; color: #9ca3af; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+      p { color: #94a3b8; }
+    }
+  </style>
+</head>
+<body>
+  <svg class="icon" viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
+    <rect width="192" height="192" rx="32" fill="#2563EB"/>
+    <path d="M48 132V60h36a24 24 0 0 1 0 48H48m0 0h42a24 24 0 0 1 0 48H48" stroke="white" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="144" cy="72" r="24" fill="white"/>
+    <circle cx="144" cy="120" r="24" fill="white"/>
+  </svg>
+  <h1>You're offline</h1>
+  <p>
+    BlueCollar needs an internet connection to load this page.
+    Check your connection and try again.
+  </p>
+  <button class="btn" onclick="window.location.reload()">
+    Try Again
+  </button>
+  <p class="status">Some features may be unavailable while offline.</p>
+  <script>
+    window.addEventListener('online', () => { window.location.reload(); });
+  </script>
+</body>
+</html>

--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -1,10 +1,10 @@
-const CACHE_VERSION = 1;
+const CACHE_VERSION = 2;
 const CACHE_NAME = `bluecollar-v${CACHE_VERSION}`;
 const SHELL_CACHE = `bluecollar-shell-v${CACHE_VERSION}`;
 const DATA_CACHE = `bluecollar-data-v${CACHE_VERSION}`;
 const IMG_CACHE = `bluecollar-images-v${CACHE_VERSION}`;
 
-const STATIC_ASSETS = ["/", "/favicon.svg", "/logo.png", "/manifest.json"];
+const STATIC_ASSETS = ["/", "/favicon.svg", "/logo.png", "/manifest.json", "/offline.html"];
 const MAX_DATA_CACHE_SIZE = 50;
 const MAX_IMG_CACHE_SIZE = 100;
 
@@ -207,7 +207,11 @@ async function networkFirstWithShellFallback(request) {
   try {
     return await fetch(request);
   } catch {
-    return caches.match(request) || caches.match("/");
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    const offlinePage = await caches.match("/offline.html");
+    if (offlinePage) return offlinePage;
+    return new Response("Offline", { status: 503 });
   }
 }
 

--- a/packages/app/src/app/[locale]/error.tsx
+++ b/packages/app/src/app/[locale]/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+export default function LocaleError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <ErrorBoundary error={error} reset={reset} />;
+}

--- a/packages/app/src/app/[locale]/layout.tsx
+++ b/packages/app/src/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import BottomNav from "@/components/BottomNav";
 import OnboardingTour from "@/components/OnboardingTour";
 import WebVitalsReporter from "@/components/WebVitalsReporter";
 import OfflineBanner from "@/components/OfflineBanner";
+import InstallPrompt from "@/components/InstallPrompt";
 
 export default async function LocaleLayout({ 
   children, 
@@ -35,6 +36,7 @@ export default async function LocaleLayout({
                 <CompareProvider>
                   <WebVitalsReporter />
                   <OfflineBanner />
+                  <InstallPrompt />
                   <div id="main-content" tabIndex={-1}>
                     {children}
                   </div>

--- a/packages/app/src/app/[locale]/workers/[id]/components/WorkerTipSection.tsx
+++ b/packages/app/src/app/[locale]/workers/[id]/components/WorkerTipSection.tsx
@@ -9,7 +9,7 @@ interface Props {
 export function WorkerTipSection({ workerName, walletAddress }: Props) {
   if (!walletAddress) {
     return (
-      <p className="text-sm text-gray-400 italic">
+      <p className="text-sm text-gray-500 italic">
         This worker hasn&apos;t connected a wallet yet.
       </p>
     );
@@ -19,7 +19,7 @@ export function WorkerTipSection({ workerName, walletAddress }: Props) {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="text-sm font-medium text-gray-700">Support this worker</p>
-          <p className="text-xs text-gray-400 mt-0.5">
+          <p className="text-xs text-gray-500 mt-0.5">
             Send XLM directly to their Stellar wallet
           </p>
         </div>

--- a/packages/app/src/app/[locale]/workers/[id]/page.tsx
+++ b/packages/app/src/app/[locale]/workers/[id]/page.tsx
@@ -70,9 +70,9 @@ export default async function WorkerProfilePage({
     <div className="mx-auto max-w-2xl px-4 py-10">
       <Link
         href="/workers"
-        className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-600 transition-colors"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
       >
-        <ArrowLeft size={15} />
+        <ArrowLeft size={15} aria-hidden="true" />
         Back to workers
       </Link>
 

--- a/packages/app/src/components/BookmarkButton.tsx
+++ b/packages/app/src/components/BookmarkButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Heart } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { toggleBookmark } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -20,6 +21,7 @@ export default function BookmarkButton({
   initialBookmarked = false,
   className,
 }: BookmarkButtonProps) {
+  const t = useTranslations("workerCard");
   const [bookmarked, setBookmarked] = useState(initialBookmarked);
   const [loading, setLoading] = useState(false);
 
@@ -42,7 +44,7 @@ export default function BookmarkButton({
   return (
     <button
       onClick={handleClick}
-      aria-label={bookmarked ? "Remove bookmark" : "Bookmark worker"}
+      aria-label={bookmarked ? t("bookmarkRemove") : t("bookmarkAdd")}
       className={cn(
         "rounded-full p-1.5 transition-colors",
         bookmarked

--- a/packages/app/src/components/CompareDrawer.tsx
+++ b/packages/app/src/components/CompareDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { X, BadgeCheck, MapPin, Star } from "lucide-react";
 import { useCompare } from "@/context/CompareContext";
 import type { Worker } from "@/types";
@@ -10,10 +10,10 @@ function Cell({ children, className = "" }: { children: React.ReactNode; classNa
 }
 
 function Rating({ value }: { value?: number | null }) {
-  if (value == null) return <span className="text-gray-400">—</span>;
+  if (value == null) return <span className="text-gray-400">&mdash;</span>;
   return (
     <span className="flex items-center gap-1">
-      <Star size={13} className="fill-yellow-400 text-yellow-400" />
+      <Star size={13} className="fill-yellow-400 text-yellow-400" aria-hidden="true" />
       {value.toFixed(1)}
     </span>
   );
@@ -22,67 +22,125 @@ function Rating({ value }: { value?: number | null }) {
 export default function CompareDrawer() {
   const { selected, remove, clear } = useCompare();
   const [open, setOpen] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      setOpen(false);
+    }
+    if (e.key === "Tab" && modalRef.current) {
+      const focusable = modalRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last?.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener("keydown", handleKeyDown);
+      modalRef.current?.focus();
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [open, handleKeyDown]);
+
+  const handleClose = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
 
   if (selected.length === 0) return null;
 
   const rows: { label: string; render: (w: Worker) => React.ReactNode }[] = [
     { label: "Category", render: (w) => w.category.name },
     { label: "Rating", render: (w) => <Rating value={w.averageRating} /> },
-    { label: "Reviews", render: (w) => w.reviewCount ?? "—" },
-    { label: "Location", render: (w) => w.location ? <span className="flex items-center gap-1"><MapPin size={12} />{w.location}</span> : "—" },
-    { label: "Verified", render: (w) => w.isVerified ? <BadgeCheck size={16} className="text-blue-500" /> : "—" },
-    { label: "Contact", render: (w) => w.email ?? w.phone ?? "—" },
+    { label: "Reviews", render: (w) => w.reviewCount ?? "\u2014" },
+    { label: "Location", render: (w) => w.location ? <span className="flex items-center gap-1"><MapPin size={12} aria-hidden="true" />{w.location}</span> : "\u2014" },
+    { label: "Verified", render: (w) => w.isVerified ? <BadgeCheck size={16} className="text-blue-500" aria-label="Verified" /> : "\u2014" },
+    { label: "Contact", render: (w) => w.email ?? w.phone ?? "\u2014" },
   ];
 
   return (
     <>
-      {/* Sticky bar */}
       <div className="fixed bottom-0 inset-x-0 z-40 bg-white border-t shadow-lg px-4 py-3 flex items-center gap-3">
         <div className="flex items-center gap-2 flex-1 flex-wrap">
           {selected.map((w) => (
             <span key={w.id} className="flex items-center gap-1.5 rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700">
               {w.name}
-              <button onClick={() => remove(w.id)} aria-label={`Remove ${w.name}`}>
-                <X size={13} />
+              <button onClick={() => remove(w.id)} aria-label={`Remove ${w.name} from comparison`} className="rounded-full p-0.5 hover:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
+                <X size={13} aria-hidden="true" />
               </button>
             </span>
           ))}
         </div>
-        <button onClick={clear} className="text-xs text-gray-400 hover:text-gray-600 shrink-0">Clear</button>
+        <button onClick={clear} className="text-xs text-gray-500 hover:text-gray-700 shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded px-2 py-1">
+          Clear all
+        </button>
         <button
+          ref={triggerRef}
           onClick={() => setOpen(true)}
-          className="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          className="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          aria-expanded={open}
+          aria-controls="compare-modal"
         >
           Compare ({selected.length})
         </button>
       </div>
 
-      {/* Modal */}
       {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-          <div className="relative w-full max-w-4xl max-h-[90vh] overflow-auto rounded-2xl bg-white shadow-xl">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="compare-modal-title"
+          id="compare-modal"
+        >
+          <div
+            ref={modalRef}
+            tabIndex={-1}
+            className="relative w-full max-w-4xl max-h-[90vh] overflow-auto rounded-2xl bg-white shadow-xl outline-none"
+          >
             <div className="flex items-center justify-between border-b px-6 py-4">
-              <h2 className="text-lg font-semibold text-gray-900">Compare Workers</h2>
-              <button onClick={() => setOpen(false)} aria-label="Close"><X size={20} /></button>
+              <h2 id="compare-modal-title" className="text-lg font-semibold text-gray-900">
+                Compare Workers
+              </h2>
+              <button onClick={handleClose} aria-label="Close comparison" className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
+                <X size={20} aria-hidden="true" />
+              </button>
             </div>
 
             <div className="overflow-x-auto p-4">
               <table className="w-full border-collapse">
                 <thead>
                   <tr>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase w-28 border-b" />
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase w-28 border-b" scope="col" />
                     {selected.map((w) => (
-                      <th key={w.id} className="px-4 py-3 border-b">
+                      <th key={w.id} className="px-4 py-3 border-b" scope="col">
                         <div className="flex flex-col items-center gap-1">
                           {w.avatar ? (
-                            <img src={w.avatar} alt={w.name} className="h-12 w-12 rounded-full object-cover ring-2 ring-blue-100" />
+                            <img src={w.avatar} alt="" className="h-12 w-12 rounded-full object-cover ring-2 ring-blue-100" aria-hidden="true" />
                           ) : (
-                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-600 font-bold">
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-600 font-bold" aria-hidden="true">
                               {w.name.split(" ").map((n) => n[0]).slice(0, 2).join("").toUpperCase()}
                             </div>
                           )}
                           <span className="text-sm font-semibold text-gray-800">{w.name}</span>
-                          <button onClick={() => remove(w.id)} className="text-xs text-gray-400 hover:text-red-500">Remove</button>
+                          <button onClick={() => { remove(w.id); }} aria-label={`Remove ${w.name} from comparison`} className="text-xs text-gray-400 hover:text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded px-1">
+                            Remove
+                          </button>
                         </div>
                       </th>
                     ))}
@@ -90,7 +148,7 @@ export default function CompareDrawer() {
                 </thead>
                 <tbody>
                   {rows.map(({ label, render }) => (
-                    <tr key={label} className="hover:bg-gray-50">
+                    <tr key={label}>
                       <td className="px-4 py-3 text-xs font-medium text-gray-500 uppercase border-b">{label}</td>
                       {selected.map((w) => <Cell key={w.id}>{render(w)}</Cell>)}
                     </tr>
@@ -101,7 +159,7 @@ export default function CompareDrawer() {
                       <td key={w.id} className="px-4 py-3 border-b">
                         <a
                           href={`/workers/${w.id}`}
-                          className="block rounded-md bg-blue-600 py-1.5 text-center text-sm font-medium text-white hover:bg-blue-700"
+                          className="block rounded-md bg-blue-600 py-1.5 text-center text-sm font-medium text-white hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
                         >
                           View Profile
                         </a>

--- a/packages/app/src/components/ContactModal.tsx
+++ b/packages/app/src/components/ContactModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X, Loader2, CheckCircle2, MessageSquare } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { sendContactRequest } from "@/lib/api";
 
 interface Props {
@@ -11,6 +12,7 @@ interface Props {
 }
 
 export default function ContactModal({ workerId, workerName }: Props) {
+  const t = useTranslations("contact");
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
@@ -30,9 +32,9 @@ export default function ContactModal({ workerId, workerName }: Props) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = message.trim();
-    if (!trimmed) return setError("Message cannot be empty.");
-    if (trimmed.length < 10) return setError("Message must be at least 10 characters.");
-    if (trimmed.length > 1000) return setError("Message must be under 1000 characters.");
+    if (!trimmed) return setError(t("errorEmpty"));
+    if (trimmed.length < 10) return setError(t("errorTooShort"));
+    if (trimmed.length > 1000) return setError(t("errorTooLong"));
 
     setStatus("loading");
     setError(null);
@@ -40,8 +42,8 @@ export default function ContactModal({ workerId, workerName }: Props) {
       await sendContactRequest(workerId, trimmed);
       setStatus("success");
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Failed to send message.";
-      setError(msg.includes("429") ? "You've sent too many messages. Please wait before trying again." : msg);
+      const msg = err instanceof Error ? err.message : t("errorGeneric");
+      setError(msg.includes("429") ? t("errorRateLimit") : msg);
       setStatus("error");
     }
   };
@@ -51,7 +53,7 @@ export default function ContactModal({ workerId, workerName }: Props) {
       <Dialog.Trigger asChild>
         <button className="flex items-center gap-2 rounded-lg border border-blue-600 px-4 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50 transition-colors">
           <MessageSquare size={15} />
-          Contact
+          {t("title", { name: workerName }).split(" ")[0]}
         </button>
       </Dialog.Trigger>
 
@@ -61,14 +63,14 @@ export default function ContactModal({ workerId, workerName }: Props) {
           <div className="flex items-start justify-between">
             <div>
               <Dialog.Title className="text-lg font-semibold text-gray-900">
-                Contact {workerName}
+                {t("title", { name: workerName })}
               </Dialog.Title>
               <Dialog.Description className="mt-0.5 text-sm text-gray-500">
-                Send a message to get in touch.
+                {t("description")}
               </Dialog.Description>
             </div>
             <Dialog.Close
-              aria-label="Close dialog"
+              aria-label={t("ariaClose")}
               className="rounded-md p-1 text-gray-400 hover:text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
               <X size={18} aria-hidden="true" />
@@ -78,26 +80,26 @@ export default function ContactModal({ workerId, workerName }: Props) {
           {status === "success" ? (
             <div role="status" className="mt-6 flex flex-col items-center gap-3 py-4 text-center">
               <CheckCircle2 size={36} className="text-green-500" aria-hidden="true" />
-              <p className="text-sm font-medium text-gray-800">Message sent!</p>
+              <p className="text-sm font-medium text-gray-800">{t("messageSent")}</p>
               <p className="text-xs text-gray-500">
-                {workerName} will be notified and may reach out to you.
+                {t("messageSentDescription", { name: workerName })}
               </p>
               <Dialog.Close className="mt-2 rounded-lg bg-gray-100 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 transition-colors">
-                Close
+                {t("close")}
               </Dialog.Close>
             </div>
           ) : (
             <form onSubmit={handleSubmit} className="mt-5 flex flex-col gap-4">
               <div>
                 <label htmlFor="contact-message" className="mb-1.5 block text-sm font-medium text-gray-700">
-                  Your message
+                  {t("messageLabel")}
                 </label>
                 <textarea
                   id="contact-message"
                   rows={5}
                   value={message}
                   onChange={(e) => { setMessage(e.target.value); setError(null); }}
-                  placeholder={`Hi ${workerName}, I'd like to discuss...`}
+                  placeholder={t("messagePlaceholder", { name: workerName })}
                   className="w-full rounded-lg border px-3 py-2.5 text-sm text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
                 />
                 <div className="mt-1 flex justify-between">
@@ -110,14 +112,14 @@ export default function ContactModal({ workerId, workerName }: Props) {
                     aria-live="polite"
                     className={`text-xs ${message.length > 1000 ? "text-red-500" : "text-gray-400"}`}
                   >
-                    {message.length}/1000
+                    {t("charCount", { count: message.length })}
                   </span>
                 </div>
               </div>
 
               <div className="flex gap-3">
                 <Dialog.Close className="flex-1 rounded-lg border py-2.5 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors">
-                  Cancel
+                  {t("cancel")}
                 </Dialog.Close>
                 <button
                   type="submit"
@@ -125,7 +127,7 @@ export default function ContactModal({ workerId, workerName }: Props) {
                   className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60 transition-colors"
                 >
                   {status === "loading" && <Loader2 size={14} className="animate-spin" />}
-                  Send Message
+                  {t("sendMessage")}
                 </button>
               </div>
             </form>

--- a/packages/app/src/components/ErrorBoundary.tsx
+++ b/packages/app/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 
 interface Props {
@@ -13,26 +14,57 @@ interface Props {
 export default function ErrorBoundary({
   error,
   reset,
-  title = "Something went wrong",
-  description = "An unexpected error occurred. Please try again.",
+  title,
+  description,
 }: Props) {
+  const t = useTranslations("errors");
+  const [reported, setReported] = useState(false);
+
   useEffect(() => {
     console.error(error);
   }, [error]);
+
+  const handleReport = () => {
+    const report = {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+      digest: error.digest,
+      url: typeof window !== "undefined" ? window.location.href : "",
+      timestamp: new Date().toISOString(),
+    };
+    navigator.clipboard.writeText(JSON.stringify(report, null, 2)).catch(() => {});
+    setReported(true);
+  };
 
   return (
     <div className="flex min-h-[40vh] flex-col items-center justify-center px-4 text-center">
       <div className="flex h-14 w-14 items-center justify-center rounded-full bg-red-50 mb-4">
         <AlertTriangle size={24} className="text-red-500" />
       </div>
-      <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-      <p className="mt-1 text-sm text-gray-500 max-w-sm">{description}</p>
-      <button
-        onClick={reset}
-        className="mt-5 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
-      >
-        Try Again
-      </button>
+      <h2 className="text-lg font-semibold text-gray-900">
+        {title ?? t("genericTitle")}
+      </h2>
+      <p className="mt-1 text-sm text-gray-500 max-w-sm">
+        {description ?? t("genericDescription")}
+      </p>
+      <div className="mt-5 flex flex-wrap items-center gap-3 justify-center">
+        <button
+          onClick={reset}
+          className="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+        >
+          {t("tryAgain")}
+        </button>
+        <button
+          onClick={handleReport}
+          className="rounded-lg border border-gray-300 px-5 py-2.5 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+        >
+          {reported ? "Copied to clipboard" : t("reportError")}
+        </button>
+      </div>
+      {error.digest && (
+        <p className="mt-4 text-xs text-gray-400 font-mono">Error ID: {error.digest}</p>
+      )}
     </div>
   );
 }

--- a/packages/app/src/components/Filters/ActiveFilters.tsx
+++ b/packages/app/src/components/Filters/ActiveFilters.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { X } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { Category } from "@/types";
 import type { FilterValues } from "./FilterPanel";
 
@@ -19,27 +20,28 @@ export default function ActiveFilters({
   onRemoveFilter,
   onClearSearch,
 }: ActiveFiltersProps) {
+  const t = useTranslations("filters");
   const chips: { label: string; onRemove: () => void }[] = [];
 
   if (search) {
-    chips.push({ label: `Search: "${search}"`, onRemove: onClearSearch });
+    chips.push({ label: t("activeSearch", { query: search }), onRemove: onClearSearch });
   }
   if (filters.category) {
     const cat = categories.find((c) => c.id === filters.category);
     chips.push({
-      label: `Category: ${cat?.name ?? filters.category}`,
+      label: t("activeCategory", { name: cat?.name ?? filters.category }),
       onRemove: () => onRemoveFilter("category"),
     });
   }
   if (filters.city) {
     chips.push({
-      label: `City: ${filters.city}`,
+      label: t("activeCity", { name: filters.city }),
       onRemove: () => onRemoveFilter("city"),
     });
   }
   if (filters.state) {
     chips.push({
-      label: `State: ${filters.state}`,
+      label: t("activeState", { name: filters.state }),
       onRemove: () => onRemoveFilter("state"),
     });
   }
@@ -58,7 +60,7 @@ export default function ActiveFilters({
             type="button"
             onClick={chip.onRemove}
             className="rounded-full p-0.5 hover:bg-blue-100"
-            aria-label={`Remove filter: ${chip.label}`}
+            aria-label={t("removeFilter", { label: chip.label })}
           >
             <X size={12} />
           </button>

--- a/packages/app/src/components/Filters/FilterPanel.tsx
+++ b/packages/app/src/components/Filters/FilterPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SlidersHorizontal, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { Category } from "@/types";
 
 export interface FilterValues {
@@ -30,6 +31,7 @@ export default function FilterPanel({
   onReset,
   loading,
 }: FilterPanelProps) {
+  const t = useTranslations("filters");
   const hasActiveFilters = filters.category || filters.city || filters.state;
 
   const update = (key: keyof FilterValues, value: string) => {
@@ -41,7 +43,7 @@ export default function FilterPanel({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm font-semibold text-gray-800">
           <SlidersHorizontal size={15} />
-          Filters
+          {t("title")}
         </div>
         {hasActiveFilters && (
           <button
@@ -50,15 +52,14 @@ export default function FilterPanel({
             className="flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700"
           >
             <X size={12} />
-            Clear all
+            {t("clearAll")}
           </button>
         )}
       </div>
 
-      {/* Category */}
       <fieldset disabled={loading}>
         <legend className="mb-2 text-sm font-medium text-gray-700">
-          Category
+          {t("category")}
         </legend>
         <div className="flex flex-col gap-1.5">
           <label className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-50">
@@ -70,7 +71,7 @@ export default function FilterPanel({
               onChange={() => update("category", "")}
               className="accent-blue-600"
             />
-            All categories
+            {t("allCategories")}
           </label>
           {categories.map((c) => (
             <label
@@ -91,24 +92,23 @@ export default function FilterPanel({
         </div>
       </fieldset>
 
-      {/* Location */}
       <fieldset disabled={loading}>
         <legend className="mb-2 text-sm font-medium text-gray-700">
-          Location
+          {t("location")}
         </legend>
         <div className="flex flex-col gap-3">
           <input
             type="text"
             value={filters.city}
             onChange={(e) => update("city", e.target.value)}
-            placeholder="City..."
+            placeholder={t("cityPlaceholder")}
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none placeholder:text-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20"
           />
           <input
             type="text"
             value={filters.state}
             onChange={(e) => update("state", e.target.value)}
-            placeholder="State / Region..."
+            placeholder={t("statePlaceholder")}
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none placeholder:text-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20"
           />
         </div>

--- a/packages/app/src/components/Filters/MobileFilterSheet.tsx
+++ b/packages/app/src/components/Filters/MobileFilterSheet.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { SlidersHorizontal } from "lucide-react";
 import * as Dialog from "@radix-ui/react-dialog";
+import { useTranslations } from "next-intl";
 import type { Category } from "@/types";
 import FilterPanel, { type FilterValues } from "./FilterPanel";
 
@@ -21,6 +22,7 @@ export default function MobileFilterSheet({
   onReset,
   loading,
 }: MobileFilterSheetProps) {
+  const t = useTranslations("filters");
   const [open, setOpen] = useState(false);
 
   const activeCount = [filters.category, filters.city, filters.state].filter(
@@ -35,7 +37,7 @@ export default function MobileFilterSheet({
           className="flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 lg:hidden"
         >
           <SlidersHorizontal size={15} />
-          Filters
+          {t("mobileTrigger")}
           {activeCount > 0 && (
             <span className="flex h-5 w-5 items-center justify-center rounded-full bg-blue-600 text-xs text-white">
               {activeCount}
@@ -47,7 +49,7 @@ export default function MobileFilterSheet({
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
         <Dialog.Content className="fixed inset-y-0 left-0 z-50 w-80 max-w-[85vw] overflow-y-auto bg-gray-50 p-4 shadow-xl">
           <Dialog.Title className="mb-4 text-lg font-bold text-gray-800">
-            Filter Workers
+            {t("mobileTitle")}
           </Dialog.Title>
           <FilterPanel
             filters={filters}
@@ -61,7 +63,7 @@ export default function MobileFilterSheet({
             onClick={() => setOpen(false)}
             className="mt-4 w-full rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white hover:bg-blue-700"
           >
-            Show Results
+            {t("showResults")}
           </button>
         </Dialog.Content>
       </Dialog.Portal>

--- a/packages/app/src/components/Footer.tsx
+++ b/packages/app/src/components/Footer.tsx
@@ -1,16 +1,5 @@
 import Link from "next/link";
-
-const LINKS = {
-  quick: [
-    { href: "/workers", label: "Workers" },
-    { href: "/categories", label: "Categories" },
-    { href: "/how-it-works", label: "How It Works" },
-  ],
-  legal: [
-    { href: "/privacy", label: "Privacy Policy" },
-    { href: "/terms", label: "Terms of Service" },
-  ],
-};
+import { getTranslations } from "next-intl/server";
 
 function GithubIcon() {
   return (
@@ -28,51 +17,39 @@ function TelegramIcon() {
   );
 }
 
-export default function Footer() {
+export default async function Footer() {
+  const t = await getTranslations("footer");
+
   return (
     <footer className="border-t bg-gray-50 dark:bg-gray-900 dark:border-gray-800 mt-auto">
       <div className="mx-auto max-w-7xl px-4 py-12">
         <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-4">
-          {/* About */}
           <div className="flex flex-col gap-3">
             <span className="text-lg font-bold text-blue-600">BlueCollar</span>
             <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
-              Find skilled workers near you. A decentralised protocol connecting
-              local tradespeople with the communities that need them.
+              {t("description")}
             </p>
           </div>
 
-          {/* Quick Links */}
           <div>
-            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Quick Links</h3>
+            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">{t("quickLinks")}</h3>
             <ul className="flex flex-col gap-2">
-              {LINKS.quick.map((l) => (
-                <li key={l.href}>
-                  <Link href={l.href} className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">
-                    {l.label}
-                  </Link>
-                </li>
-              ))}
+              <li><Link href="/workers" className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">{t("workers")}</Link></li>
+              <li><Link href="/categories" className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">{t("categories")}</Link></li>
+              <li><Link href="/how-it-works" className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">{t("howItWorks")}</Link></li>
             </ul>
           </div>
 
-          {/* Legal */}
           <div>
-            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Legal</h3>
+            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">{t("legal")}</h3>
             <ul className="flex flex-col gap-2">
-              {LINKS.legal.map((l) => (
-                <li key={l.href}>
-                  <Link href={l.href} className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">
-                    {l.label}
-                  </Link>
-                </li>
-              ))}
+              <li><Link href="/privacy" className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">{t("privacyPolicy")}</Link></li>
+              <li><Link href="/terms" className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 transition-colors">{t("termsOfService")}</Link></li>
             </ul>
           </div>
 
-          {/* Social */}
           <div>
-            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Community</h3>
+            <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">{t("community")}</h3>
             <div className="flex gap-4">
               <a
                 href="https://t.me/bluecollar"
@@ -97,7 +74,7 @@ export default function Footer() {
         </div>
 
         <div className="mt-10 border-t dark:border-gray-800 pt-6 text-center text-xs text-gray-400">
-          © {new Date().getFullYear()} BlueCollar. All rights reserved.
+          {t("copyright", { year: new Date().getFullYear() })}
         </div>
       </div>
     </footer>

--- a/packages/app/src/components/InstallPrompt.tsx
+++ b/packages/app/src/components/InstallPrompt.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Download, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -9,6 +10,7 @@ interface BeforeInstallPromptEvent extends Event {
 }
 
 export default function InstallPrompt() {
+  const t = useTranslations("installPrompt");
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [showPrompt, setShowPrompt] = useState(false);
   const [installed, setInstalled] = useState(false);
@@ -66,16 +68,16 @@ export default function InstallPrompt() {
         </div>
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold text-gray-900 dark:text-white">
-            Install BlueCollar
+            {t("install")}
           </p>
           <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-            Get the best experience with our app
+            {t("description")}
           </p>
         </div>
         <button
           onClick={handleDismiss}
           className="flex shrink-0 items-center justify-center rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-          aria-label="Dismiss install prompt"
+          aria-label={t("dismiss")}
         >
           <X size={16} />
         </button>
@@ -85,13 +87,13 @@ export default function InstallPrompt() {
           onClick={handleDismiss}
           className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
         >
-          Not now
+          {t("notNow")}
         </button>
         <button
           onClick={handleInstall}
           className="flex-1 rounded-lg bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-700"
         >
-          Install
+          {t("install")}
         </button>
       </div>
     </div>

--- a/packages/app/src/components/InstallPrompt.tsx
+++ b/packages/app/src/components/InstallPrompt.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Download, X } from "lucide-react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export default function InstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [installed, setInstalled] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.matchMedia("(display-mode: standalone)").matches) {
+      setInstalled(true);
+      return;
+    }
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setShowPrompt(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+
+    window.addEventListener("appinstalled", () => {
+      setInstalled(true);
+      setShowPrompt(false);
+    });
+
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") {
+      setInstalled(true);
+    }
+    setDeferredPrompt(null);
+    setShowPrompt(false);
+  };
+
+  const handleDismiss = () => {
+    setShowPrompt(false);
+    setDismissed(true);
+  };
+
+  if (installed || !showPrompt || dismissed) return null;
+
+  return (
+    <div
+      role="alert"
+      className="fixed bottom-20 inset-x-4 z-50 mx-auto max-w-sm rounded-2xl border border-blue-200 bg-white p-4 shadow-lg dark:border-blue-800 dark:bg-gray-900"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-100 dark:bg-blue-900">
+          <Download size={20} className="text-blue-600 dark:text-blue-300" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-gray-900 dark:text-white">
+            Install BlueCollar
+          </p>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            Get the best experience with our app
+          </p>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="flex shrink-0 items-center justify-center rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+          aria-label="Dismiss install prompt"
+        >
+          <X size={16} />
+        </button>
+      </div>
+      <div className="mt-3 flex gap-2">
+        <button
+          onClick={handleDismiss}
+          className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+        >
+          Not now
+        </button>
+        <button
+          onClick={handleInstall}
+          className="flex-1 rounded-lg bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-700"
+        >
+          Install
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/LanguageSwitcher.tsx
+++ b/packages/app/src/components/LanguageSwitcher.tsx
@@ -1,17 +1,26 @@
-import { useLocale } from 'next-intl'
+'use client'
+
+import { useLocale, useTranslations } from 'next-intl'
 import { useRouter, usePathname } from 'next/navigation'
+import { useEffect } from 'react'
 import { Button } from './ui/button'
+import { setLocale } from '@/lib/utils'
 
 export function LanguageSwitcher() {
   const locale = useLocale()
+  const t = useTranslations('languageSwitcher')
   const router = useRouter()
   const pathname = usePathname()
 
+  useEffect(() => {
+    setLocale(locale)
+  }, [locale])
+
   const languages = [
-    { code: 'en', label: 'English' },
-    { code: 'fr', label: 'Français' },
-    { code: 'es', label: 'Español' },
-    { code: 'pt', label: 'Português' },
+    { code: 'en', label: t('en') },
+    { code: 'fr', label: t('fr') },
+    { code: 'es', label: t('es') },
+    { code: 'pt', label: t('pt') },
   ]
 
   const handleLanguageChange = (newLocale: string) => {

--- a/packages/app/src/components/Navbar.tsx
+++ b/packages/app/src/components/Navbar.tsx
@@ -8,15 +8,9 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { useTheme } from "next-themes";
 import { useAuth } from "@/hooks/useAuth";
 import { useWallet } from "@/hooks/useWallet";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import NotificationDropdown from "@/components/NotificationDropdown";
-
-const NAV_LINKS = [
-  { href: "/", label: "Home" },
-  { href: "/workers", label: "Workers" },
-  { href: "/about", label: "About" },
-];
 
 const LANGUAGES = [
   { code: "en", label: "English" },
@@ -48,6 +42,7 @@ function NavLink({ href, label, onClick }: { href: string; label: string; onClic
 
 function ThemeToggle({ className }: { className?: string }) {
   const { resolvedTheme, setTheme } = useTheme();
+  const t = useTranslations("nav");
   return (
     <button
       onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
@@ -55,7 +50,7 @@ function ThemeToggle({ className }: { className?: string }) {
         "rounded-md p-2 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800 min-w-[40px] min-h-[40px] flex items-center justify-center",
         className
       )}
-      aria-label="Toggle theme"
+      aria-label={t("theme")}
     >
       {resolvedTheme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
     </button>
@@ -68,12 +63,11 @@ export default function Navbar() {
   const router = useRouter();
   const locale = useLocale();
   const pathname = usePathname();
+  const t = useTranslations("nav");
   const [mobileOpen, setMobileOpen] = useState(false);
 
-  // Close menu on route change
   useEffect(() => { setMobileOpen(false); }, [pathname]);
 
-  // Swipe-to-close gesture
   const touchStartX = useRef<number | null>(null);
   const handleTouchStart = (e: React.TouchEvent) => {
     touchStartX.current = e.touches[0].clientX;
@@ -81,7 +75,7 @@ export default function Navbar() {
   const handleTouchEnd = (e: React.TouchEvent) => {
     if (touchStartX.current === null) return;
     const delta = e.changedTouches[0].clientX - touchStartX.current;
-    if (delta > 60) setMobileOpen(false); // swipe right to close
+    if (delta > 60) setMobileOpen(false);
     touchStartX.current = null;
   };
 
@@ -92,26 +86,28 @@ export default function Navbar() {
     setMobileOpen(false);
   };
 
+  const NAV_LINKS = [
+    { href: "/", label: t("home") },
+    { href: "/workers", label: t("workers") },
+    { href: "/about", label: t("about") },
+  ];
+
   return (
     <>
       <nav className="sticky top-0 z-50 w-full border-b bg-white/90 backdrop-blur dark:bg-gray-900/90 dark:border-gray-800">
         <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
-          {/* Brand */}
           <Link href="/" className="text-xl font-bold text-blue-600">
             BlueCollar
           </Link>
 
-          {/* Desktop nav */}
           <div className="hidden items-center gap-6 md:flex">
             {NAV_LINKS.map((l) => <NavLink key={l.href} {...l} />)}
           </div>
 
-          {/* Desktop actions */}
           <div className="hidden items-center gap-3 md:flex">
             <ThemeToggle />
             <NotificationDropdown />
 
-            {/* Language */}
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
                 <button className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200">
@@ -130,7 +126,6 @@ export default function Navbar() {
               </DropdownMenu.Portal>
             </DropdownMenu.Root>
 
-            {/* Wallet */}
             {publicKey ? (
               <DropdownMenu.Root>
                 <DropdownMenu.Trigger asChild>
@@ -144,7 +139,7 @@ export default function Navbar() {
                           ? "bg-yellow-100 text-yellow-700"
                           : "bg-green-100 text-green-700"
                       )}>
-                        {network.toLowerCase().includes("test") ? "testnet" : "mainnet"}
+                        {network.toLowerCase().includes("test") ? t("testnet") : t("mainnet")}
                       </span>
                     )}
                     <ChevronDown size={13} />
@@ -155,7 +150,7 @@ export default function Navbar() {
                     <div className="px-3 py-2 text-xs text-gray-400 font-mono break-all">{publicKey}</div>
                     <DropdownMenu.Separator className="my-1 h-px bg-gray-100 dark:bg-gray-700" />
                     <DropdownMenu.Item onSelect={disconnect} className="cursor-pointer rounded px-3 py-2 text-red-600 hover:bg-red-50 outline-none dark:hover:bg-red-950">
-                      Disconnect Wallet
+                      {t("disconnectWallet")}
                     </DropdownMenu.Item>
                   </DropdownMenu.Content>
                 </DropdownMenu.Portal>
@@ -163,11 +158,10 @@ export default function Navbar() {
             ) : (
               <button onClick={connect} disabled={isConnecting} className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200">
                 <Wallet size={15} />
-                {isConnecting ? "Connecting…" : "Connect Wallet"}
+                {isConnecting ? t("connecting") : t("connectWallet")}
               </button>
             )}
 
-            {/* Auth */}
             {user ? (
               <DropdownMenu.Root>
                 <DropdownMenu.Trigger asChild>
@@ -179,52 +173,47 @@ export default function Navbar() {
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Portal>
                   <DropdownMenu.Content align="end" sideOffset={6} className="z-50 min-w-[160px] rounded-md border bg-white p-1 shadow-md text-sm dark:bg-gray-900 dark:border-gray-700">
-                    <DropdownMenu.Item onSelect={() => router.push("/profile")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">Profile</DropdownMenu.Item>
+                    <DropdownMenu.Item onSelect={() => router.push("/profile")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">{t("profile")}</DropdownMenu.Item>
                     {(user.role === "curator" || user.role === "admin") && (
-                      <DropdownMenu.Item onSelect={() => router.push("/dashboard")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">Dashboard</DropdownMenu.Item>
+                      <DropdownMenu.Item onSelect={() => router.push("/dashboard")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">{t("dashboard")}</DropdownMenu.Item>
                     )}
                     {user.role === "admin" && (
-                      <DropdownMenu.Item onSelect={() => router.push("/dashboard/admin")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">Admin Analytics</DropdownMenu.Item>
+                      <DropdownMenu.Item onSelect={() => router.push("/dashboard/admin")} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">{t("adminAnalytics")}</DropdownMenu.Item>
                     )}
                     <DropdownMenu.Separator className="my-1 h-px bg-gray-100 dark:bg-gray-700" />
-                    <DropdownMenu.Item onSelect={logout} className="cursor-pointer rounded px-3 py-2 text-red-600 hover:bg-red-50 outline-none dark:hover:bg-red-950">Logout</DropdownMenu.Item>
+                    <DropdownMenu.Item onSelect={logout} className="cursor-pointer rounded px-3 py-2 text-red-600 hover:bg-red-50 outline-none dark:hover:bg-red-950">{t("logout")}</DropdownMenu.Item>
                   </DropdownMenu.Content>
                 </DropdownMenu.Portal>
               </DropdownMenu.Root>
             ) : (
               <>
-                <Link href="/auth/login" className="rounded-md px-3 py-1.5 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200">Login</Link>
-                <Link href="/auth/register" className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700">Register</Link>
+                <Link href="/auth/login" className="rounded-md px-3 py-1.5 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200">{t("login")}</Link>
+                <Link href="/auth/register" className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700">{t("register")}</Link>
               </>
             )}
           </div>
 
-          {/* Mobile hamburger */}
           <button
             className="md:hidden flex items-center justify-center rounded-md p-2 min-w-[44px] min-h-[44px] hover:bg-gray-100 dark:hover:bg-gray-800"
             onClick={() => setMobileOpen(true)}
-            aria-label="Open menu"
+            aria-label={t("openMenu")}
           >
             <Menu size={22} />
           </button>
         </div>
       </nav>
 
-      {/* Mobile drawer */}
       {mobileOpen && (
         <div className="md:hidden">
-          {/* Backdrop */}
           <div
             className="fixed inset-0 z-40 bg-black/40 animate-fade-in"
             onClick={() => setMobileOpen(false)}
           />
-          {/* Slide-in panel */}
           <div
             className="fixed right-0 top-0 z-50 h-full w-72 bg-white dark:bg-gray-900 shadow-xl flex flex-col animate-slide-in-right"
             onTouchStart={handleTouchStart}
             onTouchEnd={handleTouchEnd}
           >
-            {/* Header */}
             <div className="flex items-center justify-between px-5 py-4 border-b dark:border-gray-800">
               <span className="text-lg font-bold text-blue-600">BlueCollar</span>
               <div className="flex items-center gap-1">
@@ -232,16 +221,14 @@ export default function Navbar() {
                 <button
                   onClick={() => setMobileOpen(false)}
                   className="flex items-center justify-center rounded-md p-2 min-w-[44px] min-h-[44px] text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
-                  aria-label="Close menu"
+                  aria-label={t("closeMenu")}
                 >
                   <X size={20} />
                 </button>
               </div>
             </div>
 
-            {/* Scrollable content */}
             <div className="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-1">
-              {/* Nav links — large touch targets with active indicator */}
               {NAV_LINKS.map(({ href, label }) => {
                 const isActive = pathname === href || (href !== "/" && pathname.startsWith(href));
                 return (
@@ -264,8 +251,7 @@ export default function Navbar() {
 
               <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" />
 
-              {/* Language */}
-              <p className="px-4 py-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Language</p>
+              <p className="px-4 py-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">{t("language")}</p>
               {LANGUAGES.map((lang) => (
                 <button
                   key={lang.code}
@@ -284,7 +270,6 @@ export default function Navbar() {
 
               <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" />
 
-              {/* Wallet */}
               {publicKey ? (
                 <>
                   <div className="flex items-center gap-3 rounded-lg border px-4 py-3 text-sm min-h-[48px] dark:border-gray-700 dark:text-gray-200">
@@ -297,7 +282,7 @@ export default function Navbar() {
                           ? "bg-yellow-100 text-yellow-700"
                           : "bg-green-100 text-green-700"
                       )}>
-                        {network.toLowerCase().includes("test") ? "testnet" : "mainnet"}
+                        {network.toLowerCase().includes("test") ? t("testnet") : t("mainnet")}
                       </span>
                     )}
                   </div>
@@ -305,7 +290,7 @@ export default function Navbar() {
                     onClick={() => { disconnect(); setMobileOpen(false); }}
                     className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors w-full text-left"
                   >
-                    Disconnect Wallet
+                    {t("disconnectWallet")}
                   </button>
                 </>
               ) : (
@@ -315,40 +300,39 @@ export default function Navbar() {
                   className="flex items-center gap-3 rounded-lg border px-4 py-3 text-sm font-medium min-h-[48px] hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors"
                 >
                   <Wallet size={16} />
-                  {isConnecting ? "Connecting…" : "Connect Wallet"}
+                  {isConnecting ? t("connecting") : t("connectWallet")}
                 </button>
               )}
 
               <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" />
 
-              {/* Auth */}
               {user ? (
                 <>
                   <Link href="/profile" onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
                     <User size={16} className="text-gray-400" />
-                    Profile
+                    {t("profile")}
                   </Link>
                   {(user.role === "curator" || user.role === "admin") && (
                     <Link href="/dashboard" onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
-                      Dashboard
+                      {t("dashboard")}
                     </Link>
                   )}
                   {user.role === "admin" && (
                     <Link href="/dashboard/admin" onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
-                      Admin Analytics
+                      {t("adminAnalytics")}
                     </Link>
                   )}
                   <button onClick={() => { logout(); setMobileOpen(false); }} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors w-full text-left">
-                    Logout
+                    {t("logout")}
                   </button>
                 </>
               ) : (
                 <div className="flex flex-col gap-2 pt-1">
                   <Link href="/auth/login" onClick={() => setMobileOpen(false)} className="rounded-lg border px-4 py-3 text-center text-sm font-medium min-h-[48px] hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
-                    Login
+                    {t("login")}
                   </Link>
                   <Link href="/auth/register" onClick={() => setMobileOpen(false)} className="rounded-lg bg-blue-600 px-4 py-3 text-center text-sm font-medium min-h-[48px] text-white hover:bg-blue-700 transition-colors">
-                    Register
+                    {t("register")}
                   </Link>
                 </div>
               )}

--- a/packages/app/src/components/OfflineBanner.tsx
+++ b/packages/app/src/components/OfflineBanner.tsx
@@ -3,22 +3,23 @@
 import { useEffect, useState } from "react";
 import { WifiOff, Loader2 } from "lucide-react";
 import { getOfflineQueue } from "@/lib/offlineQueue";
+import { useTranslations } from "next-intl";
 
 export default function OfflineBanner() {
+  const t = useTranslations("offline");
   const [offline, setOffline] = useState(false);
   const [queueCount, setQueueCount] = useState(0);
   const [syncing, setSyncing] = useState(false);
 
   useEffect(() => {
     setOffline(!navigator.onLine);
-    
+
     const on = () => setOffline(false);
     const off = () => setOffline(true);
-    
+
     window.addEventListener("online", on);
     window.addEventListener("offline", off);
 
-    // Listen for sync messages from service worker
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker.controller?.postMessage({
         type: "GET_QUEUE_COUNT",
@@ -35,7 +36,6 @@ export default function OfflineBanner() {
       };
     }
 
-    // Check queue on mount and periodically
     const checkQueue = async () => {
       try {
         const queue = await getOfflineQueue();
@@ -57,12 +57,12 @@ export default function OfflineBanner() {
 
   if (!offline && queueCount === 0) return null;
 
-  const statusText = offline 
-    ? "You're offline"
+  const statusText = offline
+    ? t("offline")
     : syncing
-    ? `Syncing ${queueCount} change${queueCount !== 1 ? "s" : ""}...`
+    ? t("syncing", { count: queueCount })
     : queueCount > 0
-    ? `${queueCount} change${queueCount !== 1 ? "s" : ""} pending`
+    ? t("pending", { count: queueCount })
     : null;
 
   if (!statusText) return null;

--- a/packages/app/src/components/Search/SearchInput.tsx
+++ b/packages/app/src/components/Search/SearchInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Search, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface SearchInputProps {
   value: string;
@@ -11,8 +12,11 @@ interface SearchInputProps {
 export default function SearchInput({
   value,
   onChange,
-  placeholder = "Search workers...",
+  placeholder: placeholderProp,
 }: SearchInputProps) {
+  const t = useTranslations("search");
+  const placeholder = placeholderProp ?? t("placeholder");
+
   return (
     <div className="relative">
       <Search
@@ -25,7 +29,7 @@ export default function SearchInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        aria-label="Search workers"
+        aria-label={t("ariaLabel")}
         className="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-9 text-sm outline-none transition-colors placeholder:text-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20"
       />
       {value && (
@@ -33,7 +37,7 @@ export default function SearchInput({
           type="button"
           onClick={() => onChange("")}
           className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded p-0.5 text-gray-400 hover:text-gray-600"
-          aria-label="Clear search"
+          aria-label={t("clear")}
         >
           <X size={14} />
         </button>

--- a/packages/app/src/components/ServiceWorkerRegister.tsx
+++ b/packages/app/src/components/ServiceWorkerRegister.tsx
@@ -4,11 +4,32 @@ import { useEffect } from "react";
 
 export default function ServiceWorkerRegister() {
   useEffect(() => {
-    if (typeof window !== "undefined" && "serviceWorker" in navigator) {
-      navigator.serviceWorker
-        .register("/sw.js")
-        .catch((error) => console.error("[ServiceWorkerRegister] error:", error));
-    }
+    if (typeof window === "undefined" || !("serviceWorker" in navigator)) return;
+
+    let registration: ServiceWorkerRegistration | null = null;
+
+    navigator.serviceWorker
+      .register("/sw.js")
+      .then((reg) => {
+        registration = reg;
+        reg.addEventListener("updatefound", () => {
+          const newWorker = reg.installing;
+          if (newWorker) {
+            newWorker.addEventListener("statechange", () => {
+              if (newWorker.state === "installed" && navigator.serviceWorker.controller) {
+                console.log("[SW] New version available — reload to update");
+              }
+            });
+          }
+        });
+      })
+      .catch((error) => console.error("[ServiceWorkerRegister] error:", error));
+
+    return () => {
+      if (registration) {
+        registration.unregister().catch(() => {});
+      }
+    };
   }, []);
 
   return null;

--- a/packages/app/src/components/TipModal.tsx
+++ b/packages/app/src/components/TipModal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { ReactNode, ChangeEvent } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X, Loader2, CheckCircle2, AlertCircle, ExternalLink, Zap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   isConnected,
   requestAccess,
@@ -18,7 +19,7 @@ const SOROBAN_RPC = "https://soroban-testnet.stellar.org";
 const MARKET_CONTRACT_ID = process.env.NEXT_PUBLIC_MARKET_CONTRACT_ID ?? "";
 const STROOPS_PER_XLM = 10_000_000n;
 const EXPLORER_BASE = "https://stellar.expert/explorer/testnet/tx";
-const NETWORK_FEE = 0.00001; // XLM
+const NETWORK_FEE = 0.00001;
 
 type TxStatus = "idle" | "signing" | "pending" | "success" | "error";
 type ErrorType = "freighter_missing" | "insufficient_balance" | "user_rejected" | "network_error" | "unknown";
@@ -29,7 +30,8 @@ interface Props {
   trigger?: ReactNode;
 }
 
-export default function TipModalEnhanced({ workerName, walletAddress, trigger }: Props) {
+export default function TipModal({ workerName, walletAddress, trigger }: Props) {
+  const t = useTranslations("tip");
   const [open, setOpen] = useState(false);
   const [amount, setAmount] = useState("");
   const [selectedToken, setSelectedToken] = useState("XLM");
@@ -65,7 +67,7 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
       const connected = await isConnected();
       if (!connected.isConnected) {
         setErrorType("freighter_missing");
-        setErrorMsg("Freighter wallet not detected");
+        setErrorMsg(t("freighterNotFound"));
         setStatus("error");
         return;
       }
@@ -138,7 +140,7 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
         {trigger ?? (
           <button className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors">
             <Zap size={16} />
-            Send Tip
+            {t("sendTip")}
           </button>
         )}
       </Dialog.Trigger>
@@ -146,18 +148,17 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white dark:bg-gray-900 p-6 shadow-2xl">
-          {/* Header */}
           <div className="flex items-start justify-between mb-6">
             <div>
               <Dialog.Title className="text-xl font-bold text-gray-900 dark:text-white">
-                Send a Tip
+                {t("title")}
               </Dialog.Title>
               <Dialog.Description className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                Reward {workerName} for excellent service
+                {t("description", { name: workerName })}
               </Dialog.Description>
             </div>
             <Dialog.Close
-              aria-label="Close dialog"
+              aria-label={t("ariaClose")}
               className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
               <X size={20} aria-hidden="true" />
@@ -165,22 +166,20 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
           </div>
 
           <div className="space-y-4">
-            {/* Worker Info */}
             <div className="rounded-lg bg-blue-50 dark:bg-blue-950/30 p-4 border border-blue-200 dark:border-blue-900">
               <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide mb-2">
-                Recipient
+                {t("recipient")}
               </p>
               <p className="font-mono text-sm text-gray-700 dark:text-gray-300 break-all">
                 {walletAddress}
               </p>
             </div>
 
-            {/* Amount Input */}
             {(status === "idle" || status === "signing") && (
               <>
                 <div>
                   <label className="block text-sm font-semibold text-gray-900 dark:text-white mb-2">
-                    Amount
+                    {t("amount")}
                   </label>
                   <div className="relative">
                     <input
@@ -191,6 +190,7 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                       value={amount}
                       onChange={(e: ChangeEvent<HTMLInputElement>) => setAmount(e.target.value)}
                       disabled={status === "signing"}
+                      aria-label={t("amountLabel", { token: selectedToken })}
                       className="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-3 pr-16 text-lg font-semibold text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                     />
                     <span className="absolute right-4 top-1/2 -translate-y-1/2 text-lg font-semibold text-gray-500 dark:text-gray-400">
@@ -199,10 +199,9 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                   </div>
                 </div>
 
-                {/* Token Selector */}
                 <div>
                   <label className="block text-sm font-semibold text-gray-900 dark:text-white mb-2">
-                    Token
+                    {t("token")}
                   </label>
                   <select
                     value={selectedToken}
@@ -210,31 +209,29 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                     disabled={status === "signing"}
                     className="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                   >
-                    <option value="XLM">XLM (Stellar Lumens)</option>
-                    <option value="USDC">USDC (USD Coin)</option>
+                    <option value="XLM">{t("tokenXlm")}</option>
+                    <option value="USDC">{t("tokenUsdc")}</option>
                   </select>
                 </div>
 
-                {/* Fee Preview */}
                 <div className="rounded-lg bg-gray-50 dark:bg-gray-800 p-4 space-y-2">
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-600 dark:text-gray-400">Amount</span>
+                    <span className="text-gray-600 dark:text-gray-400">{t("amount")}</span>
                     <span className="font-medium text-gray-900 dark:text-white">{amount || "0"} {selectedToken}</span>
                   </div>
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-600 dark:text-gray-400">Network Fee</span>
+                    <span className="text-gray-600 dark:text-gray-400">{t("networkFee")}</span>
                     <span className="font-medium text-gray-900 dark:text-white">{calculateFee().toFixed(7)} {selectedToken}</span>
                   </div>
                   <div className="h-px bg-gray-200 dark:bg-gray-700" />
                   <div className="flex justify-between text-sm font-semibold">
-                    <span className="text-gray-900 dark:text-white">Total</span>
+                    <span className="text-gray-900 dark:text-white">{t("total")}</span>
                     <span className="text-blue-600 dark:text-blue-400">{total} {selectedToken}</span>
                   </div>
                 </div>
               </>
             )}
 
-            {/* Signing State */}
             {status === "signing" && (
               <div className="flex flex-col items-center gap-3 py-8 text-center">
                 <div className="relative w-12 h-12">
@@ -242,15 +239,12 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                   <Loader2 size={32} className="absolute inset-0 m-auto animate-spin text-blue-600 dark:text-blue-400" />
                 </div>
                 <div>
-                  <p className="font-semibold text-gray-900 dark:text-white">Waiting for signature</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                    Please confirm in your Freighter wallet
-                  </p>
+                  <p className="font-semibold text-gray-900 dark:text-white">{t("waitingForSignature")}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t("pleaseConfirm")}</p>
                 </div>
               </div>
             )}
 
-            {/* Pending State */}
             {status === "pending" && (
               <div className="flex flex-col items-center gap-3 py-8 text-center">
                 <div className="relative w-12 h-12">
@@ -258,15 +252,12 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                   <Loader2 size={32} className="absolute inset-0 m-auto animate-spin text-blue-600 dark:text-blue-400" />
                 </div>
                 <div>
-                  <p className="font-semibold text-gray-900 dark:text-white">Processing transaction</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                    Broadcasting to Stellar network…
-                  </p>
+                  <p className="font-semibold text-gray-900 dark:text-white">{t("processing")}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t("broadcasting")}</p>
                 </div>
               </div>
             )}
 
-            {/* Success State */}
             {status === "success" && txHash && (
               <div className="flex flex-col items-center gap-4 py-8 text-center">
                 <div className="relative w-16 h-16">
@@ -274,10 +265,8 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                   <CheckCircle2 size={40} className="absolute inset-0 m-auto text-green-600 dark:text-green-400" />
                 </div>
                 <div>
-                  <p className="font-bold text-lg text-gray-900 dark:text-white">Tip sent successfully!</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                    {workerName} has received your tip
-                  </p>
+                  <p className="font-bold text-lg text-gray-900 dark:text-white">{t("successTitle")}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t("successDescription", { name: workerName })}</p>
                 </div>
                 <a
                   href={`${EXPLORER_BASE}/${txHash}`}
@@ -285,7 +274,7 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 rounded-lg bg-green-50 dark:bg-green-950/30 px-4 py-2 text-sm font-medium text-green-700 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-950/50 transition-colors border border-green-200 dark:border-green-900"
                 >
-                  View on Stellar Expert
+                  {t("viewOnExplorer")}
                   <ExternalLink size={14} />
                 </a>
                 <p className="font-mono text-xs text-gray-400 dark:text-gray-500 break-all max-w-xs">
@@ -294,7 +283,6 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
               </div>
             )}
 
-            {/* Error State */}
             {status === "error" && (
               <div className="flex flex-col items-center gap-4 py-8 text-center">
                 <div className="relative w-16 h-16">
@@ -305,10 +293,8 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                 {errorType === "freighter_missing" ? (
                   <>
                     <div>
-                      <p className="font-bold text-lg text-gray-900 dark:text-white">Freighter not found</p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                        Install the Freighter browser extension to send tips
-                      </p>
+                      <p className="font-bold text-lg text-gray-900 dark:text-white">{t("freighterNotFound")}</p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t("freighterDescription")}</p>
                     </div>
                     <a
                       href="https://www.freighter.app"
@@ -316,29 +302,27 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-2 rounded-lg bg-blue-600 dark:bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:hover:bg-blue-800 transition-colors"
                     >
-                      Download Freighter
+                      {t("downloadFreighter")}
                       <ExternalLink size={14} />
                     </a>
                   </>
                 ) : errorType === "insufficient_balance" ? (
                   <>
                     <div>
-                      <p className="font-bold text-lg text-gray-900 dark:text-white">Insufficient balance</p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                        You don't have enough {selectedToken} to send this tip
-                      </p>
+                      <p className="font-bold text-lg text-gray-900 dark:text-white">{t("insufficientBalance")}</p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t("insufficientBalanceDesc", { token: selectedToken })}</p>
                     </div>
                     <button
                       onClick={reset}
                       className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
                     >
-                      Try a different amount
+                      {t("tryDifferentAmount")}
                     </button>
                   </>
                 ) : (
                   <>
                     <div>
-                      <p className="font-bold text-lg text-gray-900 dark:text-white">Transaction failed</p>
+                      <p className="font-bold text-lg text-gray-900 dark:text-white">{t("transactionFailed")}</p>
                       {errorMsg && (
                         <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 bg-red-50 dark:bg-red-950/30 rounded-lg p-3 border border-red-200 dark:border-red-900">
                           {errorMsg}
@@ -349,7 +333,7 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                       onClick={reset}
                       className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
                     >
-                      Try again
+                      {t("tryAgain")}
                     </button>
                   </>
                 )}
@@ -357,11 +341,10 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
             )}
           </div>
 
-          {/* Footer Actions */}
           {(status === "idle" || status === "signing") && (
             <div className="mt-6 flex gap-3">
               <Dialog.Close className="flex-1 rounded-lg border border-gray-300 dark:border-gray-700 py-2.5 text-sm font-semibold text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
-                Cancel
+                {t("cancel")}
               </Dialog.Close>
               <button
                 onClick={sendTip}
@@ -373,7 +356,7 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
                     : "bg-blue-600 dark:bg-blue-700 text-white hover:bg-blue-700 dark:hover:bg-blue-800"
                 )}
               >
-                {status === "signing" ? "Signing…" : "Send Tip"}
+                {status === "signing" ? t("signing") : t("sendTip")}
               </button>
             </div>
           )}
@@ -381,7 +364,7 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
           {status === "success" && (
             <div className="mt-6">
               <Dialog.Close className="w-full rounded-lg bg-gray-100 dark:bg-gray-800 py-2.5 text-sm font-semibold text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
-                Close
+                {t("close")}
               </Dialog.Close>
             </div>
           )}
@@ -389,7 +372,7 @@ export default function TipModalEnhanced({ workerName, walletAddress, trigger }:
           {status === "error" && (
             <div className="mt-6">
               <Dialog.Close className="w-full rounded-lg bg-gray-100 dark:bg-gray-800 py-2.5 text-sm font-semibold text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
-                Close
+                {t("close")}
               </Dialog.Close>
             </div>
           )}

--- a/packages/app/src/components/WorkerCard.tsx
+++ b/packages/app/src/components/WorkerCard.tsx
@@ -58,7 +58,7 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
           {worker.averageRating != null && (
             <div className="flex items-center gap-0.5 shrink-0">
               <StarRating rating={worker.averageRating} size="sm" />
-              <span className="text-xs text-gray-400">{worker.averageRating.toFixed(1)}</span>
+              <span className="text-xs text-gray-500">{worker.averageRating.toFixed(1)}</span>
             </div>
           )}
         </div>
@@ -211,7 +211,7 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
         {worker.averageRating != null && (
           <div className="flex items-center gap-1.5">
             <StarRating rating={worker.averageRating} />
-            <span className="text-xs text-gray-400">
+            <span className="text-xs text-gray-500">
               {worker.averageRating.toFixed(1)} ({worker.reviewCount})
             </span>
           </div>
@@ -222,8 +222,8 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
         )}
 
         {worker.location && (
-          <div className="flex items-center gap-1 text-xs text-gray-400">
-            <MapPin size={12} />
+          <div className="flex items-center gap-1 text-xs text-gray-500">
+            <MapPin size={12} aria-hidden="true" />
             <span>{worker.location}</span>
           </div>
         )}

--- a/packages/app/src/components/WorkerCard.tsx
+++ b/packages/app/src/components/WorkerCard.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { BadgeCheck, MapPin, Zap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { Worker } from "@/types";
 import BookmarkButton from "./BookmarkButton";
 import StarRating from "./StarRating";
@@ -14,6 +15,7 @@ interface WorkerCardProps {
 }
 
 export default function WorkerCard({ worker, variant = "standard" }: WorkerCardProps) {
+  const t = useTranslations("workerCard");
   const { toggle, isSelected, isFull } = useCompare();
   const checked = isSelected(worker.id);
 
@@ -47,7 +49,7 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
             <div className="flex items-center gap-1 font-semibold text-gray-800 truncate text-sm">
               <span className="truncate">{worker.name}</span>
               {worker.isVerified && (
-                <BadgeCheck size={14} className="shrink-0 text-blue-500" aria-label="Verified" />
+                <BadgeCheck size={14} className="shrink-0 text-blue-500" aria-label={t("verified")} />
               )}
             </div>
             <span className="text-xs text-gray-500">{worker.category.name}</span>
@@ -71,7 +73,7 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
         {/* Featured badge */}
         <div className="absolute top-3 right-3 flex items-center gap-1 bg-blue-600 text-white px-2 py-1 rounded-full text-xs font-semibold">
           <Zap size={12} />
-          Featured
+          {t("featured")}
         </div>
 
         {/* Compare checkbox */}
@@ -87,7 +89,7 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
             className="h-4 w-4 rounded border-gray-300 accent-blue-600 cursor-pointer disabled:cursor-not-allowed"
             aria-label={`Compare ${worker.name}`}
           />
-          <span className="text-xs text-gray-500 select-none">Compare</span>
+          <span className="text-xs text-gray-500 select-none">{t("compare")}</span>
         </label>
 
         <Link href={`/workers/${worker.id}`} className="flex flex-col gap-4">
@@ -127,7 +129,7 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
               <span className="font-semibold text-gray-800">
                 {worker.averageRating.toFixed(1)}
               </span>
-              <span className="text-sm text-gray-500">({worker.reviewCount} reviews)</span>
+              <span className="text-sm text-gray-500">({worker.reviewCount} {t("reviews")})</span>
             </div>
           )}
 
@@ -146,8 +148,8 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
 
           <div className="mt-auto pt-2">
             <span className="inline-block w-full rounded-lg bg-blue-600 py-2.5 text-center text-sm font-semibold text-white transition-colors group-hover:bg-blue-700">
-              View Profile
-            </span>
+                {t("viewProfile")}
+              </span>
           </div>
         </Link>
       </div>
@@ -228,7 +230,7 @@ export default function WorkerCard({ worker, variant = "standard" }: WorkerCardP
 
         <div className="mt-auto pt-1">
           <span className="inline-block w-full rounded-md border border-blue-600 py-1.5 text-center text-sm font-medium text-blue-600 transition-colors group-hover:bg-blue-600 group-hover:text-white">
-            View Profile
+            {t("viewProfile")}
           </span>
         </div>
       </Link>

--- a/packages/app/src/components/WorkersDiscovery.tsx
+++ b/packages/app/src/components/WorkersDiscovery.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
+import { useTranslations } from "next-intl";
 import WorkerCard from "@/components/WorkerCard";
 import { WorkerCardSkeleton } from "@/components/Skeleton";
 import Pagination from "@/components/Pagination";
@@ -46,6 +46,8 @@ function paramsFromState(
 export default function WorkersDiscovery() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const t = useTranslations("workersDiscovery");
+  const commonT = useTranslations("common");
 
   const [search, setSearch] = useState(searchParams.get("search") ?? "");
   const [filters, setFilters] = useState<FilterValues>(
@@ -61,14 +63,12 @@ export default function WorkersDiscovery() {
 
   const debouncedSearch = useDebounce(search, 350);
 
-  // Load categories once
   useEffect(() => {
     getCategories()
       .then((res) => setCategories(res.data))
       .catch(() => {});
   }, []);
 
-  // Sync URL whenever debounced search, filters, or page change
   const syncUrl = useCallback(
     (s: string, f: FilterValues, p: number) => {
       const params = paramsFromState(s, f, p);
@@ -78,7 +78,6 @@ export default function WorkersDiscovery() {
     [router]
   );
 
-  // Fetch workers
   useEffect(() => {
     let cancelled = false;
     const params = paramsFromState(debouncedSearch, filters, page);
@@ -109,7 +108,6 @@ export default function WorkersDiscovery() {
     };
   }, [debouncedSearch, filters, page, syncUrl]);
 
-  // Reset to page 1 when search or filters change
   const handleSearch = useCallback((v: string) => {
     setSearch(v);
     setPage(1);
@@ -135,7 +133,6 @@ export default function WorkersDiscovery() {
 
   const resultCount = meta?.total ?? 0;
 
-  // Min-height on results to prevent layout shift during page transitions
   const gridMinHeight = useMemo(() => {
     if (loading) return "min-h-[600px]";
     return workers.length > 0 ? "min-h-[200px]" : "";
@@ -143,7 +140,6 @@ export default function WorkersDiscovery() {
 
   return (
     <div className="flex flex-col gap-8 lg:flex-row">
-      {/* Desktop sidebar */}
       <aside className="hidden w-60 shrink-0 lg:block">
         <div className="sticky top-24">
           <FilterPanel
@@ -156,15 +152,13 @@ export default function WorkersDiscovery() {
         </div>
       </aside>
 
-      {/* Main content */}
       <div className="flex-1">
-        {/* Search bar + mobile filter toggle */}
         <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
           <div className="flex-1">
             <SearchInput
               value={search}
               onChange={handleSearch}
-              placeholder="Search workers by name or skill..."
+              placeholder={t("searchPlaceholder")}
             />
           </div>
           <MobileFilterSheet
@@ -176,7 +170,6 @@ export default function WorkersDiscovery() {
           />
         </div>
 
-        {/* Active filter chips */}
         <ActiveFilters
           filters={filters}
           search={debouncedSearch}
@@ -185,20 +178,18 @@ export default function WorkersDiscovery() {
           onClearSearch={() => handleSearch("")}
         />
 
-        {/* Result count */}
         {!loading && !error && (
           <p className="mb-4 mt-2 text-sm text-gray-500">
             {resultCount === 0
-              ? "No results"
-              : `${resultCount} worker${resultCount !== 1 ? "s" : ""} found`}
+              ? t("noResults")
+              : t("resultsFound", { count: resultCount })}
           </p>
         )}
 
-        {/* Error state */}
         {error && (
           <div className="flex flex-col items-center justify-center rounded-xl border border-red-200 bg-red-50 py-16 text-center">
             <p className="text-lg font-semibold text-red-700">
-              Something went wrong
+              {t("errorTitle")}
             </p>
             <p className="mt-1 text-sm text-red-600">{error}</p>
             <button
@@ -206,12 +197,11 @@ export default function WorkersDiscovery() {
               onClick={() => setPage(page)}
               className="mt-4 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
             >
-              Try again
+              {commonT("tryAgain")}
             </button>
           </div>
         )}
 
-        {/* Loading state */}
         {loading && (
           <div
             className={`grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 ${gridMinHeight}`}
@@ -222,14 +212,13 @@ export default function WorkersDiscovery() {
           </div>
         )}
 
-        {/* Empty state */}
         {!loading && !error && workers.length === 0 && (
           <div className="flex flex-col items-center justify-center rounded-xl border bg-white py-20 text-center shadow-sm">
             <p className="text-lg font-semibold text-gray-700">
-              No workers found
+              {t("emptyTitle")}
             </p>
             <p className="mt-1 text-sm text-gray-500">
-              Try broadening your search or removing some filters.
+              {t("emptyDescription")}
             </p>
             <button
               type="button"
@@ -239,12 +228,11 @@ export default function WorkersDiscovery() {
               }}
               className="mt-4 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
             >
-              Clear all filters
+              {t("clearAllFilters")}
             </button>
           </div>
         )}
 
-        {/* Results grid */}
         {!loading && !error && workers.length > 0 && (
           <>
             <div
@@ -255,7 +243,6 @@ export default function WorkersDiscovery() {
               ))}
             </div>
 
-            {/* Pagination */}
             {meta && meta.pages > 1 && (
               <div className="mt-8">
                 <Pagination

--- a/packages/app/src/components/WorkersDiscovery.tsx
+++ b/packages/app/src/components/WorkersDiscovery.tsx
@@ -179,7 +179,7 @@ export default function WorkersDiscovery() {
         />
 
         {!loading && !error && (
-          <p className="mb-4 mt-2 text-sm text-gray-500">
+          <p className="mb-4 mt-2 text-sm text-gray-500" role="status" aria-live="polite">
             {resultCount === 0
               ? t("noResults")
               : t("resultsFound", { count: resultCount })}

--- a/packages/app/src/features/landing-page/Categories.tsx
+++ b/packages/app/src/features/landing-page/Categories.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { getTranslations } from 'next-intl/server'
 
 interface Category {
   id: string
@@ -18,18 +19,25 @@ async function getCategories(): Promise<Category[]> {
 
 export default async function Categories() {
   const categories = await getCategories()
+  const t = await getTranslations('categories')
 
   return (
-    <section>
-      <h2>Browse by Category</h2>
-      <div className="categories-grid">
-        {categories.map((cat) => (
-          <Link key={cat.id} href={`/workers?category=${cat.id}`} className="category-card">
-            {cat.icon && <span className="category-icon">{cat.icon}</span>}
-            <span className="category-name">{cat.name}</span>
-            <span className="category-badge">{cat._count.workers} workers</span>
-          </Link>
-        ))}
+    <section className="px-4 py-12">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="mb-8 text-2xl font-bold text-gray-900 dark:text-gray-100">{t('title')}</h2>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          {categories.map((cat) => (
+            <Link
+              key={cat.id}
+              href={`/workers?category=${cat.id}`}
+              className="flex flex-col items-center gap-2 rounded-xl border bg-white dark:bg-gray-900 dark:border-gray-800 p-5 hover:shadow-md hover:border-blue-300 transition-all text-center"
+            >
+              {cat.icon && <span className="text-2xl">{cat.icon}</span>}
+              <span className="font-medium text-gray-800 dark:text-gray-200 text-sm">{cat.name}</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">{t('workersCount', { count: cat._count.workers })}</span>
+            </Link>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/packages/app/src/features/landing-page/FeaturedWorkers.tsx
+++ b/packages/app/src/features/landing-page/FeaturedWorkers.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import { getTranslations } from 'next-intl/server'
 
 interface Worker {
   id: string
@@ -41,13 +42,14 @@ export function FeaturedWorkersSkeleton() {
 
 export default async function FeaturedWorkers() {
   const workers = await getFeaturedWorkers()
+  const t = await getTranslations('featuredWorkers')
 
   return (
     <section className="px-4 py-16 max-w-6xl mx-auto">
-      <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">Featured Workers</h2>
+      <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">{t('title')}</h2>
 
       {workers.length === 0 ? (
-        <p className="mt-6 text-gray-500">No workers available yet. Check back soon.</p>
+        <p className="mt-6 text-gray-500">{t('empty')}</p>
       ) : (
         <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {workers.map((worker, index) => (
@@ -78,7 +80,7 @@ export default async function FeaturedWorkers() {
                 href={`/workers/${worker.id}`}
                 className="mt-auto text-center rounded-lg border border-blue-700 text-blue-700 font-medium py-2 hover:bg-blue-50 transition-colors"
               >
-                View Profile
+                {t('viewProfile')}
               </Link>
             </div>
           ))}
@@ -90,7 +92,7 @@ export default async function FeaturedWorkers() {
           href="/workers"
           className="inline-block rounded-lg bg-blue-700 text-white font-semibold px-8 py-3 hover:bg-blue-800 transition-colors"
         >
-          See All Workers
+          {t('seeAll')}
         </Link>
       </div>
     </section>

--- a/packages/app/src/features/landing-page/Hero.tsx
+++ b/packages/app/src/features/landing-page/Hero.tsx
@@ -4,9 +4,11 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 export default function Hero() {
   const router = useRouter()
+  const t = useTranslations('hero')
   const [category, setCategory] = useState('')
   const [location, setLocation] = useState('')
 
@@ -22,11 +24,10 @@ export default function Hero() {
     <section className="bg-gradient-to-br from-blue-600 to-blue-800 text-white px-4 py-24 sm:py-32 text-center">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight mb-6">
-          Find Skilled Workers Near You
+          {t('title')}
         </h1>
         <p className="text-lg sm:text-xl text-blue-100 mb-8 max-w-2xl mx-auto leading-relaxed">
-          Connect with trusted local tradespeople — plumbers, electricians, carpenters, and more. 
-          Secure payments powered by Stellar blockchain.
+          {t('subtitle')}
         </p>
 
         <form
@@ -35,25 +36,25 @@ export default function Hero() {
         >
           <input
             type="text"
-            placeholder="Category (e.g. Plumber)"
+            placeholder={t('categoryPlaceholder')}
             value={category}
             onChange={(e) => setCategory(e.target.value)}
             className="flex-1 rounded-lg px-4 py-3 text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
-            aria-label="Worker category"
+            aria-label={t('ariaCategory')}
           />
           <input
             type="text"
-            placeholder="Location (e.g. Lagos)"
+            placeholder={t('locationPlaceholder')}
             value={location}
             onChange={(e) => setLocation(e.target.value)}
             className="flex-1 rounded-lg px-4 py-3 text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
-            aria-label="Location"
+            aria-label={t('ariaLocation')}
           />
           <button
             type="submit"
             className="rounded-lg bg-white text-blue-700 font-semibold px-6 py-3 hover:bg-blue-50 transition-colors flex items-center justify-center gap-2 whitespace-nowrap"
           >
-            Browse Workers
+            {t('browseWorkers')}
             <ArrowRight size={18} />
           </button>
         </form>
@@ -63,14 +64,14 @@ export default function Hero() {
             href="/auth/register"
             className="inline-flex items-center gap-2 bg-white text-blue-700 font-semibold px-6 py-3 rounded-lg hover:bg-blue-50 transition-colors"
           >
-            Get Started
+            {t('getStarted')}
             <ArrowRight size={18} />
           </Link>
           <Link
             href="/workers"
             className="inline-flex items-center gap-2 border-2 border-white text-white font-semibold px-6 py-3 rounded-lg hover:bg-white/10 transition-colors"
           >
-            Browse All Workers
+            {t('browseAll')}
           </Link>
         </div>
       </div>

--- a/packages/app/src/features/landing-page/HowItWorks.tsx
+++ b/packages/app/src/features/landing-page/HowItWorks.tsx
@@ -1,59 +1,62 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-
-const steps = [
-  {
-    icon: '🔍',
-    title: 'Search for a Skill',
-    description: 'Browse categories or search by skill and location to find the right tradesperson.',
-  },
-  {
-    icon: '✅',
-    title: 'Find a Verified Worker',
-    description: 'Every listing is community-curated and anchored on-chain for transparency.',
-  },
-  {
-    icon: '⛓️',
-    title: 'Pay Securely On-Chain',
-    description: 'Send tips and payments directly to workers via Stellar — no middlemen.',
-  },
-]
-
-function Step({ icon, title, description, index }: (typeof steps)[0] & { index: number }) {
-  const ref = useRef<HTMLDivElement>(null)
-  const [visible, setVisible] = useState(false)
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const observer = new IntersectionObserver(
-      ([entry]) => { if (entry.isIntersecting) { setVisible(true); observer.disconnect() } },
-      { threshold: 0.2 }
-    )
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [])
-
-  return (
-    <div
-      ref={ref}
-      style={{ transitionDelay: `${index * 150}ms` }}
-      className={`flex flex-col items-center text-center transition-all duration-700 ease-out
-        ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}
-    >
-      <span className="text-5xl">{icon}</span>
-      <h3 className="mt-4 text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
-      <p className="mt-2 text-gray-500 dark:text-gray-400 max-w-xs">{description}</p>
-    </div>
-  )
-}
+import { useTranslations } from 'next-intl'
 
 export default function HowItWorks() {
+  const t = useTranslations('howItWorks')
+
+  const steps = [
+    {
+      icon: '🔍',
+      title: t('step1Title'),
+      description: t('step1Desc'),
+    },
+    {
+      icon: '✅',
+      title: t('step2Title'),
+      description: t('step2Desc'),
+    },
+    {
+      icon: '⛓️',
+      title: t('step3Title'),
+      description: t('step3Desc'),
+    },
+  ]
+
+  function Step({ icon, title, description, index }: (typeof steps)[0] & { index: number }) {
+    const ref = useRef<HTMLDivElement>(null)
+    const [visible, setVisible] = useState(false)
+
+    useEffect(() => {
+      const el = ref.current
+      if (!el) return
+      const observer = new IntersectionObserver(
+        ([entry]) => { if (entry.isIntersecting) { setVisible(true); observer.disconnect() } },
+        { threshold: 0.2 }
+      )
+      observer.observe(el)
+      return () => observer.disconnect()
+    }, [])
+
+    return (
+      <div
+        ref={ref}
+        style={{ transitionDelay: `${index * 150}ms` }}
+        className={`flex flex-col items-center text-center transition-all duration-700 ease-out
+          ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}
+      >
+        <span className="text-5xl">{icon}</span>
+        <h3 className="mt-4 text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
+        <p className="mt-2 text-gray-500 dark:text-gray-400 max-w-xs">{description}</p>
+      </div>
+    )
+  }
+
   return (
     <section className="px-4 py-16 bg-gray-50 dark:bg-gray-950">
       <div className="max-w-4xl mx-auto">
-        <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 sm:text-3xl">How It Works</h2>
+        <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 sm:text-3xl">{t('title')}</h2>
         <div className="mt-12 grid gap-10 sm:grid-cols-3">
           {steps.map((step, i) => (
             <Step key={step.title} {...step} index={i} />

--- a/packages/app/src/features/landing-page/Testimonials.tsx
+++ b/packages/app/src/features/landing-page/Testimonials.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Star } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 const TESTIMONIALS = [
   {
@@ -30,15 +31,17 @@ const TESTIMONIALS = [
 ]
 
 export default function Testimonials() {
+  const t = useTranslations('testimonials')
+
   return (
     <section className="py-16 px-4 bg-gray-50 dark:bg-gray-900">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-12">
           <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-            Trusted by Workers & Customers
+            {t('title')}
           </h2>
           <p className="text-lg text-gray-600 dark:text-gray-400">
-            See what people are saying about BlueCollar
+            {t('subtitle')}
           </p>
         </div>
 
@@ -71,7 +74,7 @@ export default function Testimonials() {
               </div>
 
               <p className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">
-                "{testimonial.content}"
+                &ldquo;{testimonial.content}&rdquo;
               </p>
             </div>
           ))}

--- a/packages/app/src/hooks/useToast.ts
+++ b/packages/app/src/hooks/useToast.ts
@@ -1,8 +1,10 @@
 /**
  * Thin wrapper around sonner so callers don't import sonner directly.
  * Supports success, error, warning, and info variants.
+ * Also provides helpers for API error toasts.
  */
 import { toast as sonnerToast } from "sonner";
+import { parseApiError } from "@/lib/errors";
 
 export type ToastType = "success" | "error" | "warning" | "info";
 
@@ -11,5 +13,19 @@ export function useToast() {
     sonnerToast[type](message);
   };
 
-  return { toast };
+  const fromApiError = (error: unknown, fallback?: string) => {
+    const parsed = parseApiError(error, fallback);
+    sonnerToast[parsed.toastType](parsed.message, {
+      description: parsed.code ? `Error: ${parsed.code}` : undefined,
+      action: parsed.retryable
+        ? {
+            label: "Retry",
+            onClick: () => window.location.reload(),
+          }
+        : undefined,
+    });
+    return parsed;
+  };
+
+  return { toast, fromApiError };
 }

--- a/packages/app/src/i18n.ts
+++ b/packages/app/src/i18n.ts
@@ -1,5 +1,19 @@
 import { getRequestConfig } from 'next-intl/server'
 
 export default getRequestConfig(async ({ locale }) => ({
-  messages: (await import(`./messages/${locale}.json`)).default
+  messages: (await import(`./messages/${locale}.json`)).default,
+  onError(error) {
+    if (error.code === 'MISSING_MESSAGE') {
+      console.warn(`[i18n] Missing message: ${error.message}`)
+      return
+    }
+    console.error(error)
+  },
+  getMessageFallback({ namespace, key, error }) {
+    const path = [namespace, key].filter(Boolean).join('.')
+    if (error.code === 'MISSING_MESSAGE') {
+      return path
+    }
+    return path
+  }
 }))

--- a/packages/app/src/lib/errors.ts
+++ b/packages/app/src/lib/errors.ts
@@ -1,0 +1,127 @@
+/**
+ * Centralised API error parsing into user-facing messages.
+ */
+import type { ToastType } from "@/hooks/useToast";
+
+export interface ParsedApiError {
+  message: string;
+  toastType: ToastType;
+  code?: string;
+  status?: number;
+  retryable: boolean;
+}
+
+const NETWORK_ERRORS = [
+  "Failed to fetch",
+  "NetworkError",
+  "Network request failed",
+  "Load failed",
+  "TypeError: Failed to fetch",
+  "TypeError: NetworkError",
+  "ERR_NETWORK",
+  "ERR_CONNECTION_REFUSED",
+  "ECONNREFUSED",
+  "ERR_INTERNET_DISCONNECTED",
+];
+
+const RATE_LIMIT_PATTERNS = [
+  "429",
+  "Too Many Requests",
+  "rate limit",
+  "too many requests",
+];
+
+export function parseApiError(error: unknown, fallback?: string): ParsedApiError {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+
+  // Network / connectivity errors
+  if (NETWORK_ERRORS.some((e) => message.includes(e))) {
+    return {
+      message: "Unable to connect. Please check your internet connection.",
+      toastType: "error",
+      code: "NETWORK_ERROR",
+      retryable: true,
+    };
+  }
+
+  // Rate limiting
+  if (RATE_LIMIT_PATTERNS.some((p) => message.includes(p))) {
+    return {
+      message: "You're doing that too often. Please wait a moment and try again.",
+      toastType: "warning",
+      code: "RATE_LIMITED",
+      retryable: true,
+    };
+  }
+
+  // Authentication errors
+  if (message.includes("401") || message.includes("Unauthorized") || message.includes("Unauthenticated")) {
+    return {
+      message: "Your session has expired. Please log in again.",
+      toastType: "error",
+      code: "UNAUTHORIZED",
+      status: 401,
+      retryable: false,
+    };
+  }
+
+  // Not found
+  if (message.includes("404") || message.includes("Not found") || message.includes("not found")) {
+    return {
+      message: "The requested resource was not found.",
+      toastType: "error",
+      code: "NOT_FOUND",
+      status: 404,
+      retryable: false,
+    };
+  }
+
+  // Validation / bad request
+  if (message.includes("400") || message.includes("Validation") || message.includes("validation")) {
+    return {
+      message: "Please check your input and try again.",
+      toastType: "warning",
+      code: "VALIDATION_ERROR",
+      status: 400,
+      retryable: false,
+    };
+  }
+
+  // Conflict
+  if (message.includes("409") || message.includes("Conflict")) {
+    return {
+      message: "This action conflicts with the current state. Please refresh and try again.",
+      toastType: "warning",
+      code: "CONFLICT",
+      status: 409,
+      retryable: true,
+    };
+  }
+
+  // Server errors
+  if (message.includes("500") || message.includes("Internal Server Error")) {
+    return {
+      message: "Something went wrong on our end. Please try again later.",
+      toastType: "error",
+      code: "SERVER_ERROR",
+      status: 500,
+      retryable: true,
+    };
+  }
+
+  // Default
+  return {
+    message: fallback ?? "An unexpected error occurred. Please try again.",
+    toastType: "error",
+    code: "UNKNOWN",
+    retryable: true,
+  };
+}
+
+export function isRetryable(error: unknown): boolean {
+  return parseApiError(error).retryable;
+}
+
+export function formatErrorMessage(error: unknown, fallback?: string): string {
+  return parseApiError(error, fallback).message;
+}

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -1,14 +1,22 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-// Class merging
+let _locale = "en-US";
+
+export function setLocale(locale: string) {
+  _locale = locale === "en" ? "en-US" : locale === "pt" ? "pt-BR" : `${locale}-${locale.toUpperCase()}`;
+}
+
+export function getLocale(): string {
+  return _locale;
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-// Format a date string or Date object to a readable string
 export function formatDate(date: string | Date, opts?: Intl.DateTimeFormatOptions): string {
-  return new Date(date).toLocaleDateString("en-US", {
+  return new Date(date).toLocaleDateString(_locale, {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -16,20 +24,25 @@ export function formatDate(date: string | Date, opts?: Intl.DateTimeFormatOption
   });
 }
 
-// Truncate a string to maxLength, appending ellipsis if needed
 export function truncate(str: string, maxLength: number): string {
   if (str.length <= maxLength) return str;
   return str.slice(0, maxLength).trimEnd() + "…";
 }
 
-// Show first 4 and last 4 chars of a wallet address: GABC…WXYZ
 export function formatWalletAddress(address: string): string {
   if (address.length <= 8) return address;
   return `${address.slice(0, 4)}…${address.slice(-4)}`;
 }
 
-// Convert stroops (1 XLM = 10,000,000 stroops) to a formatted XLM string
 export function formatXLM(stroops: number | bigint): string {
   const xlm = Number(stroops) / 10_000_000;
-  return `${xlm.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 7 })} XLM`;
+  return `${xlm.toLocaleString(_locale, { minimumFractionDigits: 0, maximumFractionDigits: 7 })} XLM`;
+}
+
+export function formatCurrency(amount: number, currency = "USD"): string {
+  return new Intl.NumberFormat(_locale, { style: "currency", currency }).format(amount);
+}
+
+export function formatNumber(num: number, opts?: Intl.NumberFormatOptions): string {
+  return num.toLocaleString(_locale, opts);
 }

--- a/packages/app/src/messages/en.json
+++ b/packages/app/src/messages/en.json
@@ -16,7 +16,46 @@
     "save": "Save",
     "delete": "Delete",
     "edit": "Edit",
-    "back": "Back"
+    "back": "Back",
+    "close": "Close",
+    "tryAgain": "Try again"
+  },
+  "nav": {
+    "home": "Home",
+    "workers": "Workers",
+    "about": "About",
+    "language": "Language",
+    "theme": "Toggle theme",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu",
+    "profile": "Profile",
+    "dashboard": "Dashboard",
+    "adminAnalytics": "Admin Analytics",
+    "connectWallet": "Connect Wallet",
+    "connecting": "Connecting…",
+    "disconnectWallet": "Disconnect Wallet",
+    "testnet": "testnet",
+    "mainnet": "mainnet"
+  },
+  "hero": {
+    "title": "Find Skilled Workers Near You",
+    "subtitle": "Connect with trusted local tradespeople — plumbers, electricians, carpenters, and more. Secure payments powered by Stellar blockchain.",
+    "categoryPlaceholder": "Category (e.g. Plumber)",
+    "locationPlaceholder": "Location (e.g. Lagos)",
+    "browseWorkers": "Browse Workers",
+    "getStarted": "Get Started",
+    "browseAll": "Browse All Workers",
+    "ariaCategory": "Worker category",
+    "ariaLocation": "Location"
+  },
+  "footer": {
+    "description": "Find skilled workers near you. A decentralised protocol connecting local tradespeople with the communities that need them.",
+    "quickLinks": "Quick Links",
+    "legal": "Legal",
+    "privacyPolicy": "Privacy Policy",
+    "termsOfService": "Terms of Service",
+    "community": "Community",
+    "copyright": "© {year} BlueCollar. All rights reserved."
   },
   "workers": {
     "title": "Find Skilled Workers",
@@ -47,5 +86,148 @@
     "contactRequests": "Contact Requests",
     "createWorker": "Create Worker",
     "noWorkers": "No workers yet"
+  },
+  "workerCard": {
+    "viewProfile": "View Profile",
+    "compare": "Compare",
+    "featured": "Featured",
+    "verified": "Verified",
+    "reviews": "reviews",
+    "compareAria": "Compare {name}",
+    "bookmarkAdd": "Bookmark worker",
+    "bookmarkRemove": "Remove bookmark"
+  },
+  "contact": {
+    "title": "Contact {name}",
+    "description": "Send a message to get in touch.",
+    "messageLabel": "Your message",
+    "messagePlaceholder": "Hi {name}, I'd like to discuss...",
+    "messageSent": "Message sent!",
+    "messageSentDescription": "{name} will be notified and may reach out to you.",
+    "errorEmpty": "Message cannot be empty.",
+    "errorTooShort": "Message must be at least 10 characters.",
+    "errorTooLong": "Message must be under 1000 characters.",
+    "errorRateLimit": "You've sent too many messages. Please wait before trying again.",
+    "errorGeneric": "Failed to send message.",
+    "ariaClose": "Close dialog",
+    "charCount": "{count}/1000"
+  },
+  "tip": {
+    "title": "Send a Tip",
+    "description": "Reward {name} for excellent service",
+    "recipient": "Recipient",
+    "amount": "Amount",
+    "token": "Token",
+    "tokenXlm": "XLM (Stellar Lumens)",
+    "tokenUsdc": "USDC (USD Coin)",
+    "amountLabel": "Amount ({token})",
+    "networkFee": "Network Fee",
+    "total": "Total",
+    "waitingForSignature": "Waiting for signature",
+    "pleaseConfirm": "Please confirm in your Freighter wallet",
+    "processing": "Processing transaction",
+    "broadcasting": "Broadcasting to Stellar network…",
+    "successTitle": "Tip sent successfully!",
+    "successDescription": "{name} has received your tip",
+    "viewOnExplorer": "View on Stellar Expert",
+    "freighterNotFound": "Freighter not found",
+    "freighterDescription": "Install the Freighter browser extension to send tips",
+    "downloadFreighter": "Download Freighter",
+    "insufficientBalance": "Insufficient balance",
+    "insufficientBalanceDesc": "You don't have enough {token} to send this tip",
+    "tryDifferentAmount": "Try a different amount",
+    "transactionFailed": "Transaction failed",
+    "tryAgain": "Try again",
+    "signing": "Signing…",
+    "ariaClose": "Close dialog"
+  },
+  "search": {
+    "placeholder": "Search workers by name or skill...",
+    "ariaLabel": "Search workers",
+    "clear": "Clear search"
+  },
+  "filters": {
+    "title": "Filters",
+    "clearAll": "Clear all",
+    "category": "Category",
+    "allCategories": "All categories",
+    "location": "Location",
+    "cityPlaceholder": "City...",
+    "statePlaceholder": "State / Region...",
+    "mobileTrigger": "Filters",
+    "mobileTitle": "Filter Workers",
+    "showResults": "Show Results",
+    "activeSearch": "Search: \"{query}\"",
+    "activeCategory": "Category: {name}",
+    "activeCity": "City: {name}",
+    "activeState": "State: {name}",
+    "removeFilter": "Remove filter: {label}"
+  },
+  "workersDiscovery": {
+    "searchPlaceholder": "Search workers by name or skill...",
+    "noResults": "No results",
+    "resultsFound": "{count, plural, one {# worker found} other {# workers found}}",
+    "errorTitle": "Something went wrong",
+    "emptyTitle": "No workers found",
+    "emptyDescription": "Try broadening your search or removing some filters.",
+    "clearAllFilters": "Clear all filters"
+  },
+  "offline": {
+    "offline": "You're offline",
+    "syncing": "{count, plural, one {Syncing # change...} other {Syncing # changes...}}",
+    "pending": "{count, plural, one {# change pending} other {# changes pending}}"
+  },
+  "installPrompt": {
+    "install": "Install BlueCollar",
+    "description": "Get the best experience with our app",
+    "notNow": "Not now",
+    "dismiss": "Dismiss install prompt"
+  },
+  "categories": {
+    "title": "Browse by Category",
+    "workersCount": "{count} workers"
+  },
+  "featuredWorkers": {
+    "title": "Featured Workers",
+    "empty": "No workers available yet. Check back soon.",
+    "seeAll": "See All Workers"
+  },
+  "howItWorks": {
+    "title": "How It Works",
+    "step1Title": "Search for a Skill",
+    "step1Desc": "Browse categories or search by skill and location to find the right tradesperson.",
+    "step2Title": "Find a Verified Worker",
+    "step2Desc": "Every listing is community-curated and anchored on-chain for transparency.",
+    "step3Title": "Pay Securely On-Chain",
+    "step3Desc": "Send tips and payments directly to workers via Stellar — no middlemen."
+  },
+  "testimonials": {
+    "title": "Trusted by Workers & Customers",
+    "subtitle": "See what people are saying about BlueCollar"
+  },
+  "pagination": {
+    "previous": "Previous",
+    "next": "Next",
+    "pageAria": "Page {page}"
+  },
+  "errors": {
+    "genericTitle": "Something went wrong",
+    "genericDescription": "An unexpected error occurred. Please try again.",
+    "reportError": "Report this error",
+    "reportDescription": "Help us fix this issue by submitting a report.",
+    "apiDefault": "An unexpected error occurred.",
+    "apiNetwork": "Unable to connect. Please check your internet connection.",
+    "apiUnauthorized": "Your session has expired. Please log in again.",
+    "apiNotFound": "The requested resource was not found.",
+    "apiValidation": "Please check your input and try again."
+  },
+  "languageSwitcher": {
+    "en": "English",
+    "fr": "Français",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "accessibility": {
+    "skipToMain": "Skip to main content"
   }
 }

--- a/packages/app/src/messages/es.json
+++ b/packages/app/src/messages/es.json
@@ -16,7 +16,46 @@
     "save": "Guardar",
     "delete": "Eliminar",
     "edit": "Editar",
-    "back": "Atrás"
+    "back": "Atrás",
+    "close": "Cerrar",
+    "tryAgain": "Intentar de nuevo"
+  },
+  "nav": {
+    "home": "Inicio",
+    "workers": "Trabajadores",
+    "about": "Acerca de",
+    "language": "Idioma",
+    "theme": "Cambiar tema",
+    "openMenu": "Abrir menú",
+    "closeMenu": "Cerrar menú",
+    "profile": "Perfil",
+    "dashboard": "Panel de control",
+    "adminAnalytics": "Analíticas de administrador",
+    "connectWallet": "Conectar billetera",
+    "connecting": "Conectando…",
+    "disconnectWallet": "Desconectar billetera",
+    "testnet": "testnet",
+    "mainnet": "mainnet"
+  },
+  "hero": {
+    "title": "Encuentra trabajadores calificados cerca de ti",
+    "subtitle": "Conéctate con artesanos locales de confianza — plomeros, electricistas, carpinteros y más. Pagos seguros impulsados por la blockchain Stellar.",
+    "categoryPlaceholder": "Categoría (ej. Plomero)",
+    "locationPlaceholder": "Ubicación (ej. Ciudad de México)",
+    "browseWorkers": "Explorar trabajadores",
+    "getStarted": "Comenzar",
+    "browseAll": "Ver todos los trabajadores",
+    "ariaCategory": "Categoría de trabajador",
+    "ariaLocation": "Ubicación"
+  },
+  "footer": {
+    "description": "Encuentra trabajadores calificados cerca de ti. Un protocolo descentralizado que conecta a artesanos locales con las comunidades que los necesitan.",
+    "quickLinks": "Enlaces rápidos",
+    "legal": "Legal",
+    "privacyPolicy": "Política de privacidad",
+    "termsOfService": "Términos del servicio",
+    "community": "Comunidad",
+    "copyright": "© {year} BlueCollar. Todos los derechos reservados."
   },
   "workers": {
     "title": "Encontrar trabajadores calificados",
@@ -47,5 +86,148 @@
     "contactRequests": "Solicitudes de contacto",
     "createWorker": "Crear trabajador",
     "noWorkers": "Sin trabajadores aún"
+  },
+  "workerCard": {
+    "viewProfile": "Ver perfil",
+    "compare": "Comparar",
+    "featured": "Destacado",
+    "verified": "Verificado",
+    "reviews": "reseñas",
+    "compareAria": "Comparar {name}",
+    "bookmarkAdd": "Guardar trabajador",
+    "bookmarkRemove": "Eliminar marcador"
+  },
+  "contact": {
+    "title": "Contactar a {name}",
+    "description": "Envía un mensaje para ponerte en contacto.",
+    "messageLabel": "Tu mensaje",
+    "messagePlaceholder": "Hola {name}, me gustaría hablar...",
+    "messageSent": "¡Mensaje enviado!",
+    "messageSentDescription": "{name} será notificado y puede comunicarse contigo.",
+    "errorEmpty": "El mensaje no puede estar vacío.",
+    "errorTooShort": "El mensaje debe tener al menos 10 caracteres.",
+    "errorTooLong": "El mensaje debe tener menos de 1000 caracteres.",
+    "errorRateLimit": "Has enviado demasiados mensajes. Espera antes de intentar de nuevo.",
+    "errorGeneric": "Error al enviar el mensaje.",
+    "ariaClose": "Cerrar diálogo",
+    "charCount": "{count}/1000"
+  },
+  "tip": {
+    "title": "Enviar propina",
+    "description": "Recompensa a {name} por un servicio excelente",
+    "recipient": "Destinatario",
+    "amount": "Cantidad",
+    "token": "Token",
+    "tokenXlm": "XLM (Stellar Lumens)",
+    "tokenUsdc": "USDC (USD Coin)",
+    "amountLabel": "Cantidad ({token})",
+    "networkFee": "Tarifa de red",
+    "total": "Total",
+    "waitingForSignature": "Esperando firma",
+    "pleaseConfirm": "Por favor confirma en tu billetera Freighter",
+    "processing": "Procesando transacción",
+    "broadcasting": "Transmitiendo a la red Stellar…",
+    "successTitle": "¡Propina enviada con éxito!",
+    "successDescription": "{name} ha recibido tu propina",
+    "viewOnExplorer": "Ver en Stellar Expert",
+    "freighterNotFound": "Freighter no encontrado",
+    "freighterDescription": "Instala la extensión Freighter para enviar propinas",
+    "downloadFreighter": "Descargar Freighter",
+    "insufficientBalance": "Saldo insuficiente",
+    "insufficientBalanceDesc": "No tienes suficiente {token} para enviar esta propina",
+    "tryDifferentAmount": "Prueba con un monto diferente",
+    "transactionFailed": "Transacción fallida",
+    "tryAgain": "Intentar de nuevo",
+    "signing": "Firmando…",
+    "ariaClose": "Cerrar diálogo"
+  },
+  "search": {
+    "placeholder": "Buscar trabajadores por nombre o habilidad...",
+    "ariaLabel": "Buscar trabajadores",
+    "clear": "Limpiar búsqueda"
+  },
+  "filters": {
+    "title": "Filtros",
+    "clearAll": "Limpiar todo",
+    "category": "Categoría",
+    "allCategories": "Todas las categorías",
+    "location": "Ubicación",
+    "cityPlaceholder": "Ciudad...",
+    "statePlaceholder": "Estado / Región...",
+    "mobileTrigger": "Filtros",
+    "mobileTitle": "Filtrar trabajadores",
+    "showResults": "Mostrar resultados",
+    "activeSearch": "Búsqueda: \"{query}\"",
+    "activeCategory": "Categoría: {name}",
+    "activeCity": "Ciudad: {name}",
+    "activeState": "Estado: {name}",
+    "removeFilter": "Eliminar filtro: {label}"
+  },
+  "workersDiscovery": {
+    "searchPlaceholder": "Buscar trabajadores por nombre o habilidad...",
+    "noResults": "Sin resultados",
+    "resultsFound": "{count, plural, one {# trabajador encontrado} other {# trabajadores encontrados}}",
+    "errorTitle": "Algo salió mal",
+    "emptyTitle": "No se encontraron trabajadores",
+    "emptyDescription": "Intenta ampliar tu búsqueda o eliminar algunos filtros.",
+    "clearAllFilters": "Limpiar todos los filtros"
+  },
+  "offline": {
+    "offline": "Estás fuera de línea",
+    "syncing": "{count, plural, one {Sincronizando # cambio...} other {Sincronizando # cambios...}}",
+    "pending": "{count, plural, one {# cambio pendiente} other {# cambios pendientes}}"
+  },
+  "installPrompt": {
+    "install": "Instalar BlueCollar",
+    "description": "Obtén la mejor experiencia con nuestra aplicación",
+    "notNow": "Ahora no",
+    "dismiss": "Descartar aviso de instalación"
+  },
+  "categories": {
+    "title": "Explorar por categoría",
+    "workersCount": "{count} trabajadores"
+  },
+  "featuredWorkers": {
+    "title": "Trabajadores destacados",
+    "empty": "No hay trabajadores disponibles aún. Vuelve pronto.",
+    "seeAll": "Ver todos los trabajadores"
+  },
+  "howItWorks": {
+    "title": "Cómo funciona",
+    "step1Title": "Buscar una habilidad",
+    "step1Desc": "Explora categorías o busca por habilidad y ubicación para encontrar al artesano adecuado.",
+    "step2Title": "Encuentra un trabajador verificado",
+    "step2Desc": "Cada listado es curado por la comunidad y anclado en la cadena para transparencia.",
+    "step3Title": "Paga de forma segura en la cadena",
+    "step3Desc": "Envía propinas y pagos directamente a los trabajadores a través de Stellar — sin intermediarios."
+  },
+  "testimonials": {
+    "title": "Confiado por trabajadores y clientes",
+    "subtitle": "Descubre lo que la gente dice sobre BlueCollar"
+  },
+  "pagination": {
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "pageAria": "Página {page}"
+  },
+  "errors": {
+    "genericTitle": "Algo salió mal",
+    "genericDescription": "Ocurrió un error inesperado. Por favor intenta de nuevo.",
+    "reportError": "Reportar este error",
+    "reportDescription": "Ayúdanos a solucionar este problema enviando un informe.",
+    "apiDefault": "Ocurrió un error inesperado.",
+    "apiNetwork": "No se puede conectar. Verifica tu conexión a Internet.",
+    "apiUnauthorized": "Tu sesión ha expirado. Inicia sesión nuevamente.",
+    "apiNotFound": "El recurso solicitado no fue encontrado.",
+    "apiValidation": "Por favor verifica tus datos e intenta de nuevo."
+  },
+  "languageSwitcher": {
+    "en": "English",
+    "fr": "Français",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "accessibility": {
+    "skipToMain": "Saltar al contenido principal"
   }
 }

--- a/packages/app/src/messages/fr.json
+++ b/packages/app/src/messages/fr.json
@@ -16,7 +16,46 @@
     "save": "Enregistrer",
     "delete": "Supprimer",
     "edit": "Modifier",
-    "back": "Retour"
+    "back": "Retour",
+    "close": "Fermer",
+    "tryAgain": "Réessayer"
+  },
+  "nav": {
+    "home": "Accueil",
+    "workers": "Travailleurs",
+    "about": "À propos",
+    "language": "Langue",
+    "theme": "Changer le thème",
+    "openMenu": "Ouvrir le menu",
+    "closeMenu": "Fermer le menu",
+    "profile": "Profil",
+    "dashboard": "Tableau de bord",
+    "adminAnalytics": "Analyses admin",
+    "connectWallet": "Connecter le portefeuille",
+    "connecting": "Connexion…",
+    "disconnectWallet": "Déconnecter le portefeuille",
+    "testnet": "testnet",
+    "mainnet": "mainnet"
+  },
+  "hero": {
+    "title": "Trouvez des travailleurs qualifiés près de chez vous",
+    "subtitle": "Connectez-vous avec des artisans locaux de confiance — plombiers, électriciens, menuisiers et plus. Paiements sécurisés via la blockchain Stellar.",
+    "categoryPlaceholder": "Catégorie (ex. Plombier)",
+    "locationPlaceholder": "Lieu (ex. Paris)",
+    "browseWorkers": "Parcourir les travailleurs",
+    "getStarted": "Commencer",
+    "browseAll": "Voir tous les travailleurs",
+    "ariaCategory": "Catégorie de travailleur",
+    "ariaLocation": "Lieu"
+  },
+  "footer": {
+    "description": "Trouvez des travailleurs qualifiés près de chez vous. Un protocole décentralisé connectant les artisans locaux avec les communautés qui en ont besoin.",
+    "quickLinks": "Liens rapides",
+    "legal": "Mentions légales",
+    "privacyPolicy": "Politique de confidentialité",
+    "termsOfService": "Conditions d'utilisation",
+    "community": "Communauté",
+    "copyright": "© {year} BlueCollar. Tous droits réservés."
   },
   "workers": {
     "title": "Trouver des travailleurs qualifiés",
@@ -47,5 +86,148 @@
     "contactRequests": "Demandes de contact",
     "createWorker": "Créer un travailleur",
     "noWorkers": "Aucun travailleur pour le moment"
+  },
+  "workerCard": {
+    "viewProfile": "Voir le profil",
+    "compare": "Comparer",
+    "featured": "À la une",
+    "verified": "Vérifié",
+    "reviews": "avis",
+    "compareAria": "Comparer {name}",
+    "bookmarkAdd": "Ajouter aux favoris",
+    "bookmarkRemove": "Retirer des favoris"
+  },
+  "contact": {
+    "title": "Contacter {name}",
+    "description": "Envoyez un message pour entrer en contact.",
+    "messageLabel": "Votre message",
+    "messagePlaceholder": "Bonjour {name}, je souhaiterais discuter...",
+    "messageSent": "Message envoyé!",
+    "messageSentDescription": "{name} sera notifié et pourra vous répondre.",
+    "errorEmpty": "Le message ne peut pas être vide.",
+    "errorTooShort": "Le message doit contenir au moins 10 caractères.",
+    "errorTooLong": "Le message doit faire moins de 1000 caractères.",
+    "errorRateLimit": "Vous avez envoyé trop de messages. Veuillez attendre avant de réessayer.",
+    "errorGeneric": "Échec de l'envoi du message.",
+    "ariaClose": "Fermer la boîte de dialogue",
+    "charCount": "{count}/1000"
+  },
+  "tip": {
+    "title": "Envoyer un pourboire",
+    "description": "Récompenser {name} pour un service excellent",
+    "recipient": "Destinataire",
+    "amount": "Montant",
+    "token": "Jeton",
+    "tokenXlm": "XLM (Stellar Lumens)",
+    "tokenUsdc": "USDC (USD Coin)",
+    "amountLabel": "Montant ({token})",
+    "networkFee": "Frais de réseau",
+    "total": "Total",
+    "waitingForSignature": "En attente de signature",
+    "pleaseConfirm": "Veuillez confirmer dans votre portefeuille Freighter",
+    "processing": "Traitement de la transaction",
+    "broadcasting": "Diffusion sur le réseau Stellar…",
+    "successTitle": "Pourboire envoyé avec succès!",
+    "successDescription": "{name} a reçu votre pourboire",
+    "viewOnExplorer": "Voir sur Stellar Expert",
+    "freighterNotFound": "Freighter non trouvé",
+    "freighterDescription": "Installez l'extension Freighter pour envoyer des pourboires",
+    "downloadFreighter": "Télécharger Freighter",
+    "insufficientBalance": "Solde insuffisant",
+    "insufficientBalanceDesc": "Vous n'avez pas assez de {token} pour envoyer ce pourboire",
+    "tryDifferentAmount": "Essayer un montant différent",
+    "transactionFailed": "Échec de la transaction",
+    "tryAgain": "Réessayer",
+    "signing": "Signature…",
+    "ariaClose": "Fermer la boîte de dialogue"
+  },
+  "search": {
+    "placeholder": "Rechercher des travailleurs par nom ou compétence...",
+    "ariaLabel": "Rechercher des travailleurs",
+    "clear": "Effacer la recherche"
+  },
+  "filters": {
+    "title": "Filtres",
+    "clearAll": "Tout effacer",
+    "category": "Catégorie",
+    "allCategories": "Toutes les catégories",
+    "location": "Lieu",
+    "cityPlaceholder": "Ville...",
+    "statePlaceholder": "Région...",
+    "mobileTrigger": "Filtres",
+    "mobileTitle": "Filtrer les travailleurs",
+    "showResults": "Afficher les résultats",
+    "activeSearch": "Recherche : \"{query}\"",
+    "activeCategory": "Catégorie : {name}",
+    "activeCity": "Ville : {name}",
+    "activeState": "Région : {name}",
+    "removeFilter": "Supprimer le filtre : {label}"
+  },
+  "workersDiscovery": {
+    "searchPlaceholder": "Rechercher des travailleurs par nom ou compétence...",
+    "noResults": "Aucun résultat",
+    "resultsFound": "{count, plural, one {# travailleur trouvé} other {# travailleurs trouvés}}",
+    "errorTitle": "Quelque chose s'est mal passé",
+    "emptyTitle": "Aucun travailleur trouvé",
+    "emptyDescription": "Essayez d'élargir votre recherche ou de supprimer certains filtres.",
+    "clearAllFilters": "Effacer tous les filtres"
+  },
+  "offline": {
+    "offline": "Vous êtes hors ligne",
+    "syncing": "{count, plural, one {Synchronisation de # changement...} other {Synchronisation de # changements...}}",
+    "pending": "{count, plural, one {# changement en attente} other {# changements en attente}}"
+  },
+  "installPrompt": {
+    "install": "Installer BlueCollar",
+    "description": "Profitez de la meilleure expérience avec notre application",
+    "notNow": "Pas maintenant",
+    "dismiss": "Ignorer l'invite d'installation"
+  },
+  "categories": {
+    "title": "Parcourir par catégorie",
+    "workersCount": "{count} travailleurs"
+  },
+  "featuredWorkers": {
+    "title": "Travailleurs à la une",
+    "empty": "Aucun travailleur disponible pour le moment. Revenez bientôt.",
+    "seeAll": "Voir tous les travailleurs"
+  },
+  "howItWorks": {
+    "title": "Comment ça marche",
+    "step1Title": "Rechercher une compétence",
+    "step1Desc": "Parcourez les catégories ou recherchez par compétence et lieu pour trouver le bon artisan.",
+    "step2Title": "Trouver un travailleur vérifié",
+    "step2Desc": "Chaque annonce est organisée par la communauté et ancrée sur la chaîne pour la transparence.",
+    "step3Title": "Payer en toute sécurité sur la chaîne",
+    "step3Desc": "Envoyez des pourboires et des paiements directement aux travailleurs via Stellar — sans intermédiaires."
+  },
+  "testimonials": {
+    "title": "Approuvé par les travailleurs et les clients",
+    "subtitle": "Découvrez ce que les gens disent de BlueCollar"
+  },
+  "pagination": {
+    "previous": "Précédent",
+    "next": "Suivant",
+    "pageAria": "Page {page}"
+  },
+  "errors": {
+    "genericTitle": "Quelque chose s'est mal passé",
+    "genericDescription": "Une erreur inattendue s'est produite. Veuillez réessayer.",
+    "reportError": "Signaler cette erreur",
+    "reportDescription": "Aidez-nous à résoudre ce problème en soumettant un rapport.",
+    "apiDefault": "Une erreur inattendue s'est produite.",
+    "apiNetwork": "Connexion impossible. Veuillez vérifier votre connexion Internet.",
+    "apiUnauthorized": "Votre session a expiré. Veuillez vous reconnecter.",
+    "apiNotFound": "La ressource demandée est introuvable.",
+    "apiValidation": "Veuillez vérifier votre saisie et réessayer."
+  },
+  "languageSwitcher": {
+    "en": "English",
+    "fr": "Français",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "accessibility": {
+    "skipToMain": "Aller au contenu principal"
   }
 }

--- a/packages/app/src/messages/pt.json
+++ b/packages/app/src/messages/pt.json
@@ -16,7 +16,46 @@
     "save": "Salvar",
     "delete": "Excluir",
     "edit": "Editar",
-    "back": "Voltar"
+    "back": "Voltar",
+    "close": "Fechar",
+    "tryAgain": "Tentar novamente"
+  },
+  "nav": {
+    "home": "Início",
+    "workers": "Trabalhadores",
+    "about": "Sobre",
+    "language": "Idioma",
+    "theme": "Alternar tema",
+    "openMenu": "Abrir menu",
+    "closeMenu": "Fechar menu",
+    "profile": "Perfil",
+    "dashboard": "Painel",
+    "adminAnalytics": "Análises de admin",
+    "connectWallet": "Conectar carteira",
+    "connecting": "Conectando…",
+    "disconnectWallet": "Desconectar carteira",
+    "testnet": "testnet",
+    "mainnet": "mainnet"
+  },
+  "hero": {
+    "title": "Encontre Trabalhadores Qualificados Perto de Você",
+    "subtitle": "Conecte-se com profissionais locais de confiança — encanadores, eletricistas, carpinteiros e mais. Pagamentos seguros com a blockchain Stellar.",
+    "categoryPlaceholder": "Categoria (ex. Encanador)",
+    "locationPlaceholder": "Local (ex. São Paulo)",
+    "browseWorkers": "Explorar Trabalhadores",
+    "getStarted": "Começar",
+    "browseAll": "Ver Todos os Trabalhadores",
+    "ariaCategory": "Categoria do trabalhador",
+    "ariaLocation": "Local"
+  },
+  "footer": {
+    "description": "Encontre trabalhadores qualificados perto de você. Um protocolo descentralizado conectando profissionais locais com as comunidades que precisam deles.",
+    "quickLinks": "Links rápidos",
+    "legal": "Legal",
+    "privacyPolicy": "Política de privacidade",
+    "termsOfService": "Termos de serviço",
+    "community": "Comunidade",
+    "copyright": "© {year} BlueCollar. Todos os direitos reservados."
   },
   "workers": {
     "title": "Encontre Trabalhadores Qualificados",
@@ -47,5 +86,148 @@
     "contactRequests": "Solicitações de Contato",
     "createWorker": "Criar Trabalhador",
     "noWorkers": "Nenhum trabalhador ainda"
+  },
+  "workerCard": {
+    "viewProfile": "Ver Perfil",
+    "compare": "Comparar",
+    "featured": "Destaque",
+    "verified": "Verificado",
+    "reviews": "avaliações",
+    "compareAria": "Comparar {name}",
+    "bookmarkAdd": "Adicionar aos favoritos",
+    "bookmarkRemove": "Remover dos favoritos"
+  },
+  "contact": {
+    "title": "Contatar {name}",
+    "description": "Envie uma mensagem para entrar em contato.",
+    "messageLabel": "Sua mensagem",
+    "messagePlaceholder": "Olá {name}, gostaria de discutir...",
+    "messageSent": "Mensagem enviada!",
+    "messageSentDescription": "{name} será notificado e poderá entrar em contato.",
+    "errorEmpty": "A mensagem não pode estar vazia.",
+    "errorTooShort": "A mensagem deve ter pelo menos 10 caracteres.",
+    "errorTooLong": "A mensagem deve ter menos de 1000 caracteres.",
+    "errorRateLimit": "Você enviou muitas mensagens. Aguarde antes de tentar novamente.",
+    "errorGeneric": "Falha ao enviar mensagem.",
+    "ariaClose": "Fechar diálogo",
+    "charCount": "{count}/1000"
+  },
+  "tip": {
+    "title": "Enviar Gorjeta",
+    "description": "Recompense {name} por um serviço excelente",
+    "recipient": "Destinatário",
+    "amount": "Valor",
+    "token": "Token",
+    "tokenXlm": "XLM (Stellar Lumens)",
+    "tokenUsdc": "USDC (USD Coin)",
+    "amountLabel": "Valor ({token})",
+    "networkFee": "Taxa de rede",
+    "total": "Total",
+    "waitingForSignature": "Aguardando assinatura",
+    "pleaseConfirm": "Por favor confirme na sua carteira Freighter",
+    "processing": "Processando transação",
+    "broadcasting": "Transmitindo para rede Stellar…",
+    "successTitle": "Gorjeta enviada com sucesso!",
+    "successDescription": "{name} recebeu sua gorjeta",
+    "viewOnExplorer": "Ver no Stellar Expert",
+    "freighterNotFound": "Freighter não encontrado",
+    "freighterDescription": "Instale a extensão Freighter para enviar gorjetas",
+    "downloadFreighter": "Baixar Freighter",
+    "insufficientBalance": "Saldo insuficiente",
+    "insufficientBalanceDesc": "Você não tem {token} suficiente para enviar esta gorjeta",
+    "tryDifferentAmount": "Tente um valor diferente",
+    "transactionFailed": "Transação falhou",
+    "tryAgain": "Tentar novamente",
+    "signing": "Assinando…",
+    "ariaClose": "Fechar diálogo"
+  },
+  "search": {
+    "placeholder": "Buscar trabalhadores por nome ou habilidade...",
+    "ariaLabel": "Buscar trabalhadores",
+    "clear": "Limpar busca"
+  },
+  "filters": {
+    "title": "Filtros",
+    "clearAll": "Limpar tudo",
+    "category": "Categoria",
+    "allCategories": "Todas as categorias",
+    "location": "Local",
+    "cityPlaceholder": "Cidade...",
+    "statePlaceholder": "Estado / Região...",
+    "mobileTrigger": "Filtros",
+    "mobileTitle": "Filtrar trabalhadores",
+    "showResults": "Mostrar resultados",
+    "activeSearch": "Busca: \"{query}\"",
+    "activeCategory": "Categoria: {name}",
+    "activeCity": "Cidade: {name}",
+    "activeState": "Estado: {name}",
+    "removeFilter": "Remover filtro: {label}"
+  },
+  "workersDiscovery": {
+    "searchPlaceholder": "Buscar trabalhadores por nome ou habilidade...",
+    "noResults": "Sem resultados",
+    "resultsFound": "{count, plural, one {# trabalhador encontrado} other {# trabalhadores encontrados}}",
+    "errorTitle": "Algo deu errado",
+    "emptyTitle": "Nenhum trabalhador encontrado",
+    "emptyDescription": "Tente ampliar sua busca ou remover alguns filtros.",
+    "clearAllFilters": "Limpar todos os filtros"
+  },
+  "offline": {
+    "offline": "Você está offline",
+    "syncing": "{count, plural, one {Sincronizando # alteração...} other {Sincronizando # alterações...}}",
+    "pending": "{count, plural, one {# alteração pendente} other {# alterações pendentes}}"
+  },
+  "installPrompt": {
+    "install": "Instalar BlueCollar",
+    "description": "Obtenha a melhor experiência com nosso aplicativo",
+    "notNow": "Agora não",
+    "dismiss": "Dispensar aviso de instalação"
+  },
+  "categories": {
+    "title": "Explorar por categoria",
+    "workersCount": "{count} trabalhadores"
+  },
+  "featuredWorkers": {
+    "title": "Trabalhadores em Destaque",
+    "empty": "Nenhum trabalhador disponível ainda. Volte em breve.",
+    "seeAll": "Ver Todos os Trabalhadores"
+  },
+  "howItWorks": {
+    "title": "Como Funciona",
+    "step1Title": "Pesquise por uma Habilidade",
+    "step1Desc": "Navegue por categorias ou pesquise por habilidade e local para encontrar o profissional certo.",
+    "step2Title": "Encontre um Trabalhador Verificado",
+    "step2Desc": "Cada listagem é curada pela comunidade e ancorada na blockchain para transparência.",
+    "step3Title": "Pague com Segurança na Blockchain",
+    "step3Desc": "Envie gorjetas e pagamentos diretamente aos trabalhadores via Stellar — sem intermediários."
+  },
+  "testimonials": {
+    "title": "Confiado por Trabalhadores e Clientes",
+    "subtitle": "Veja o que as pessoas estão dizendo sobre o BlueCollar"
+  },
+  "pagination": {
+    "previous": "Anterior",
+    "next": "Próximo",
+    "pageAria": "Página {page}"
+  },
+  "errors": {
+    "genericTitle": "Algo deu errado",
+    "genericDescription": "Ocorreu um erro inesperado. Por favor tente novamente.",
+    "reportError": "Reportar este erro",
+    "reportDescription": "Ajude-nos a corrigir este problema enviando um relatório.",
+    "apiDefault": "Ocorreu um erro inesperado.",
+    "apiNetwork": "Não foi possível conectar. Verifique sua conexão com a Internet.",
+    "apiUnauthorized": "Sua sessão expirou. Faça login novamente.",
+    "apiNotFound": "O recurso solicitado não foi encontrado.",
+    "apiValidation": "Por favor verifique seus dados e tente novamente."
+  },
+  "languageSwitcher": {
+    "en": "English",
+    "fr": "Français",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "accessibility": {
+    "skipToMain": "Pular para o conteúdo principal"
   }
 }


### PR DESCRIPTION
Closes #743 
Closes #744 
Closes #745
Closes #746 

## Description

Make the app installable and resilient offline with a service worker, manifest, and caching strategy.

### Commits

**1. PWA** (`bc341f4`) — Add web manifest with proper icons, offline fallback, and install prompt
- Add 192x192 and 512x512 SVG icons for PWA
- Add offline.html fallback page with auto-reload on reconnection
- Update service worker to cache offline.html and serve it for failed navigation
- Add InstallPrompt component handling `beforeinstallprompt` event
- Bump service worker cache version for cache invalidation

**2. i18n** (`3172457`) — Complete translation coverage with language switcher, locale-aware formatting, and missing-key fallback
- Expand message catalogues (en, fr, es, pt) with comprehensive keys across all components
- Extract hardcoded strings from Navbar, Hero, Footer, WorkerCard, ContactModal, TipModal, FilterPanel, WorkersDiscovery, OfflineBanner, ErrorBoundary, SearchInput, BookmarkButton, HowItWorks, Testimonials, Categories, FeaturedWorkers, and MobileFilterSheet
- Add locale-aware date/number/currency formatting in utils.ts with `setLocale()`
- Add missing-key fallback handling in i18n.ts configuration
- Update LanguageSwitcher to use translations for labels and call setLocale()
- Add ICU plural support for worker counts and offline sync status

**3. Error Boundary** (`32fb822`) — Add global error boundary, centralised API error parsing, and toast wiring
- Add lib/errors.ts with `parseApiError()` returning user-facing messages with retryable flags and error codes (network, rate-limit, auth, not-found, etc.)
- Update useToast.ts with `fromApiError()` helper that dispatches parsed errors to sonner with optional Retry action for retryable errors
- Update ErrorBoundary with 'report this error' affordance (copies error report to clipboard)
- Add global error.tsx at the \[locale\] level for layout-level error catching

**4. Accessibility** (`c89529f`) — Audit and fix accessibility on discovery, profile, and payment flows
- Add focus trap with Tab/Escape cycling and ARIA dialog attributes to CompareDrawer
- Add role=dialog, aria-modal, aria-labelledby, and focus restoration to compare modal
- Add aria-current=page, scope=col to pagination/table headers
- Add role=status + aria-live=polite to workers discovery result count
- Fix contrast issues: replace non-AA text-gray-400 with text-gray-500 in WorkerCard (rating, review count, location) and WorkerTipSection (wallet message, description)
- Add focus-visible outlines to Back link and compare modal interactive elements
- Add aria-hidden to decorative icons (MapPin, Star, Chevron icons)
- Improve button aria-labels for remove/close actions in compare drawer