### PR TITLE
feat: add Form primitives, Table, User Dashboard, and Curator Console

### DIFF
--- a/packages/app/src/app/[locale]/curator/[id]/edit/page.tsx
+++ b/packages/app/src/app/[locale]/curator/[id]/edit/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
+import { ListingForm } from "@/components/Curator/ListingForm";
+import { getWorker } from "@/lib/api";
+import type { Worker } from "@/types";
+
+export default function EditListingPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const { token } = useAuth();
+  const [worker, setWorker] = useState<Worker | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getWorker(params.id)
+      .then((r) => setWorker(r.data))
+      .catch(() => setError("Failed to load listing"))
+      .finally(() => setLoading(false));
+  }, [params.id]);
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <Link
+        href="/curator"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-brand-600 transition-colors"
+      >
+        <ArrowLeft size={15} />
+        Back to console
+      </Link>
+
+      <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-8 shadow-sm">
+        <h1 className="mb-6 text-xl font-bold text-gray-900 dark:text-gray-100">
+          Edit Listing
+        </h1>
+
+        {loading && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 size={24} className="animate-spin text-gray-400" />
+          </div>
+        )}
+
+        {error && (
+          <p className="text-sm text-red-600">{error}</p>
+        )}
+
+        {!loading && !error && worker && token && (
+          <ListingForm
+            workerId={worker.id}
+            token={token}
+            defaultValues={{
+              name: worker.name,
+              bio: worker.bio ?? "",
+              categoryId: worker.category.id,
+              phone: worker.phone ?? "",
+              email: worker.email ?? "",
+              walletAddress: worker.walletAddress ?? "",
+            }}
+            onSuccess={() => router.push("/curator")}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/app/[locale]/curator/new/page.tsx
+++ b/packages/app/src/app/[locale]/curator/new/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
+import { ListingForm } from "@/components/Curator/ListingForm";
+
+export default function NewListingPage() {
+  const router = useRouter();
+  const { token } = useAuth();
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <Link
+        href="/curator"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-brand-600 transition-colors"
+      >
+        <ArrowLeft size={15} />
+        Back to console
+      </Link>
+      <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-8 shadow-sm">
+        <h1 className="mb-6 text-xl font-bold text-gray-900 dark:text-gray-100">New Listing</h1>
+        {token && (
+          <ListingForm
+            token={token}
+            onSuccess={() => router.push("/curator")}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/app/[locale]/curator/page.tsx
+++ b/packages/app/src/app/[locale]/curator/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Plus, X, AlertTriangle, Loader2 } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
+import { ListingsTable } from "@/components/Curator/ListingsTable";
+import type { CuratorWorker } from "@/components/Curator/ListingsTable";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
+
+export default function CuratorConsolePage() {
+  const { user, token, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+
+  const [workers, setWorkers] = useState<CuratorWorker[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState<Set<string>>(new Set());
+  const [deleteTarget, setDeleteTarget] = useState<CuratorWorker | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && (!user || (user.role !== "curator" && user.role !== "admin"))) {
+      router.replace("/auth/login");
+    }
+  }, [user, authLoading, router]);
+
+  const fetchWorkers = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API}/workers/mine`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Failed to load listings");
+      const j = await res.json();
+      setWorkers(j.data ?? []);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (!authLoading && token) fetchWorkers();
+  }, [authLoading, token, fetchWorkers]);
+
+  const handleToggle = async (worker: CuratorWorker) => {
+    setToggling((s) => new Set(s).add(worker.id));
+    setWorkers((prev) => prev.map((w) => w.id === worker.id ? { ...w, isActive: !w.isActive } : w));
+    try {
+      const res = await fetch(`${API}/workers/${worker.id}/toggle`, {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Toggle failed");
+    } catch {
+      setWorkers((prev) => prev.map((w) => w.id === worker.id ? { ...w, isActive: worker.isActive } : w));
+    } finally {
+      setToggling((s) => { const n = new Set(s); n.delete(worker.id); return n; });
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    const target = deleteTarget;
+    setDeleting(true);
+    setWorkers((prev) => prev.filter((w) => w.id !== target.id));
+    setDeleteTarget(null);
+    try {
+      const res = await fetch(`${API}/workers/${target.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Delete failed");
+    } catch {
+      setWorkers((prev) => [target, ...prev]);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (authLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 size={28} className="animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Curator Console</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Manage your worker listings and monitor on-chain status.
+          </p>
+        </div>
+        <Link
+          href="/curator/new"
+          className="flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 transition-colors"
+        >
+          <Plus size={16} />
+          New Listing
+        </Link>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* Listings */}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
+        <ListingsTable
+          workers={workers}
+          loading={loading}
+          onToggle={handleToggle}
+          onDelete={setDeleteTarget}
+          toggling={toggling}
+        />
+      </div>
+
+      {/* Delete confirmation dialog */}
+      <Dialog.Root open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white dark:bg-gray-900 p-6 shadow-xl">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-50 dark:bg-red-900/30">
+                <AlertTriangle size={18} className="text-red-500" />
+              </div>
+              <div className="flex-1">
+                <Dialog.Title className="font-semibold text-gray-900 dark:text-gray-100">
+                  Delete listing?
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  This will permanently remove{" "}
+                  <strong className="text-gray-700 dark:text-gray-300">{deleteTarget?.name}</strong>. This cannot be undone.
+                </Dialog.Description>
+              </div>
+              <Dialog.Close className="rounded p-1 text-gray-400 hover:text-gray-600">
+                <X size={16} />
+              </Dialog.Close>
+            </div>
+            <div className="mt-5 flex gap-3">
+              <Dialog.Close className="flex-1 rounded-lg border dark:border-gray-700 py-2.5 text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                Cancel
+              </Dialog.Close>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-600 py-2.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-60 transition-colors"
+              >
+                {deleting && <Loader2 size={14} className="animate-spin" />}
+                Delete
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}

--- a/packages/app/src/app/[locale]/dashboard/user/page.tsx
+++ b/packages/app/src/app/[locale]/dashboard/user/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Activity, Heart, MessageSquare, User } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
+import { cn } from "@/lib/utils";
+import { ActivityTimeline } from "@/components/Dashboard/ActivityTimeline";
+import { SavedWorkers } from "@/components/Dashboard/SavedWorkers";
+import { MessagesPreview } from "@/components/Dashboard/MessagesPreview";
+import { QuickProfileEdit } from "@/components/Dashboard/QuickProfileEdit";
+import type { ActivityItem } from "@/components/Dashboard/ActivityTimeline";
+import type { Worker, Conversation, AppNotification } from "@/types";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
+
+type Tab = "activity" | "saved" | "messages" | "profile";
+
+const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+  { id: "activity", label: "Activity", icon: <Activity size={15} /> },
+  { id: "saved", label: "Saved Workers", icon: <Heart size={15} /> },
+  { id: "messages", label: "Messages", icon: <MessageSquare size={15} /> },
+  { id: "profile", label: "Profile", icon: <User size={15} /> },
+];
+
+function notificationsToActivity(items: AppNotification[]): ActivityItem[] {
+  return items.map((n) => ({
+    id: n.id,
+    type: (n.type === "tip" ? "tip" : n.type === "review" ? "review" : n.type === "message" ? "message" : "bookmark") as ActivityItem["type"],
+    title: n.title,
+    description: n.message ?? undefined,
+    createdAt: n.createdAt,
+    href: n.href ?? undefined,
+  }));
+}
+
+export default function UserDashboardPage() {
+  const { user, token, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("activity");
+  const [activity, setActivity] = useState<ActivityItem[]>([]);
+  const [savedWorkers, setSavedWorkers] = useState<Worker[]>([]);
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!authLoading && !user) router.replace("/auth/login");
+  }, [user, authLoading, router]);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const [notifRes, bookmarkRes, convRes] = await Promise.allSettled([
+        fetch(`${API}/notifications?limit=20`, { headers: { Authorization: `Bearer ${token}` } }),
+        fetch(`${API}/users/me/bookmarks`, { headers: { Authorization: `Bearer ${token}` } }),
+        fetch(`${API}/conversations?limit=5`, { headers: { Authorization: `Bearer ${token}` } }),
+      ]);
+
+      if (notifRes.status === "fulfilled" && notifRes.value.ok) {
+        const j = await notifRes.value.json();
+        setActivity(notificationsToActivity(j.data ?? []));
+      }
+      if (bookmarkRes.status === "fulfilled" && bookmarkRes.value.ok) {
+        const j = await bookmarkRes.value.json();
+        setSavedWorkers(j.data ?? []);
+      }
+      if (convRes.status === "fulfilled" && convRes.value.ok) {
+        const j = await convRes.value.json();
+        setConversations(j.data ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (!authLoading && token) load();
+  }, [authLoading, token, load]);
+
+  const removeBookmark = async (workerId: string) => {
+    setSavedWorkers((prev) => prev.filter((w) => w.id !== workerId));
+    await fetch(`${API}/users/me/bookmarks/${workerId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    }).catch(() => {});
+  };
+
+  if (authLoading || (!user && !authLoading)) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 size={28} className="animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          Welcome back, {user!.firstName}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Your activity, saved workers, and messages in one place.
+        </p>
+      </div>
+
+      {/* Tab bar */}
+      <div className="mb-6 flex gap-1 rounded-xl bg-gray-100 dark:bg-gray-800 p-1 overflow-x-auto">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={cn(
+              "flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+              tab === t.id
+                ? "bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm"
+                : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+            )}
+          >
+            {t.icon}
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="rounded-xl border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-900 p-5">
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 size={24} className="animate-spin text-gray-400" />
+          </div>
+        ) : (
+          <>
+            {tab === "activity" && <ActivityTimeline items={activity} />}
+            {tab === "saved" && (
+              <SavedWorkers workers={savedWorkers} onRemove={removeBookmark} />
+            )}
+            {tab === "messages" && (
+              <div>
+                <MessagesPreview conversations={conversations} currentUserId={user!.id} />
+                {conversations.length > 0 && (
+                  <div className="mt-4 text-center">
+                    <Link href="/messages" className="text-sm text-brand-600 hover:underline">
+                      View all messages →
+                    </Link>
+                  </div>
+                )}
+              </div>
+            )}
+            {tab === "profile" && (
+              <QuickProfileEdit user={user!} token={token!} />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/Curator/ListingForm.tsx
+++ b/packages/app/src/components/Curator/ListingForm.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Input } from "@/components/Form/Input";
+import { Select } from "@/components/Form/Select";
+import { FileUpload } from "@/components/Form/FileUpload";
+import { getCategories } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import type { Category } from "@/types";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
+
+const schema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters"),
+  bio: z.string().max(500, "Bio too long").optional(),
+  categoryId: z.string().min(1, "Please select a category"),
+  phone: z
+    .string()
+    .regex(/^\+?[\d\s\-().]{7,20}$/, "Invalid phone number")
+    .optional()
+    .or(z.literal("")),
+  email: z.string().email("Invalid email").optional().or(z.literal("")),
+  walletAddress: z
+    .string()
+    .regex(/^G[A-Z2-7]{55}$/, "Must be a valid Stellar public key")
+    .optional()
+    .or(z.literal("")),
+});
+
+type Fields = z.infer<typeof schema>;
+
+export interface ListingFormProps {
+  /** If provided, the form is in edit mode and uses the X-HTTP-Method: PUT pattern */
+  workerId?: string;
+  defaultValues?: Partial<Fields>;
+  token: string;
+  onSuccess?: (workerId: string) => void;
+}
+
+export function ListingForm({ workerId, defaultValues, token, onSuccess }: ListingFormProps) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getCategories().then((r) => setCategories(r.data)).catch(() => {});
+  }, []);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<Fields>({
+    resolver: zodResolver(schema),
+    defaultValues: defaultValues ?? {},
+  });
+
+  const onSubmit = async (data: Fields) => {
+    setSubmitError(null);
+    try {
+      const form = new FormData();
+      Object.entries(data).forEach(([k, v]) => {
+        if (v !== undefined && v !== "") form.append(k, v as string);
+      });
+      if (avatarFile) form.append("avatar", avatarFile);
+
+      let res: Response;
+      if (workerId) {
+        // Update — use X-HTTP-Method: PUT pattern (method-override middleware)
+        res = await fetch(`${API}/workers/${workerId}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "X-HTTP-Method": "PUT",
+          },
+          body: form,
+        });
+      } else {
+        res = await fetch(`${API}/workers`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: form,
+        });
+      }
+
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error((j as { message?: string }).message ?? "Request failed");
+      }
+
+      const j = await res.json();
+      onSuccess?.(workerId ?? j.data.id);
+    } catch (err: unknown) {
+      setSubmitError(err instanceof Error ? err.message : "Something went wrong");
+    }
+  };
+
+  const categoryOptions = categories.map((c) => ({ label: c.name, value: c.id }));
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5" noValidate>
+      <Input
+        label="Full name"
+        {...register("name")}
+        error={errors.name?.message}
+        placeholder="e.g. João Silva"
+      />
+
+      <Select
+        label="Category"
+        options={categoryOptions}
+        placeholder="Select a category"
+        error={errors.categoryId?.message}
+        {...register("categoryId")}
+      />
+
+      {/* Bio */}
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          Bio <span className="font-normal text-gray-400">(optional)</span>
+        </label>
+        <textarea
+          {...register("bio")}
+          rows={3}
+          placeholder="Brief description of skills and experience..."
+          className={cn(
+            "w-full rounded-lg border px-3 py-2 text-sm",
+            "bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100",
+            "placeholder:text-gray-400 dark:placeholder:text-gray-500",
+            "transition-colors focus:outline-none focus:ring-2",
+            "border-gray-300 dark:border-gray-700 focus:border-brand-500 focus:ring-brand-500/20",
+            errors.bio && "border-error focus:border-error focus:ring-error/20"
+          )}
+        />
+        {errors.bio && <p className="text-xs text-error">{errors.bio.message}</p>}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Input
+          label="Phone"
+          type="tel"
+          {...register("phone")}
+          error={errors.phone?.message}
+          placeholder="+55 11 99999-9999"
+        />
+        <Input
+          label="Email"
+          type="email"
+          {...register("email")}
+          error={errors.email?.message}
+          placeholder="worker@example.com"
+        />
+      </div>
+
+      <Input
+        label="Stellar wallet address"
+        {...register("walletAddress")}
+        error={errors.walletAddress?.message}
+        placeholder="GABC…"
+        hint="Required for on-chain registration and tips."
+      />
+
+      <FileUpload
+        label="Profile image"
+        accept="image/*"
+        hint="PNG or JPG, up to 5 MB"
+        onChange={(fl) => setAvatarFile(fl?.[0] ?? null)}
+      />
+
+      {submitError && (
+        <p className="rounded-lg bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+          {submitError}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-600 py-2.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60 transition-colors"
+      >
+        {isSubmitting && <Loader2 size={15} className="animate-spin" />}
+        {workerId ? "Save changes" : "Create listing"}
+      </button>
+    </form>
+  );
+}

--- a/packages/app/src/components/Curator/ListingsTable.tsx
+++ b/packages/app/src/components/Curator/ListingsTable.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import Link from "next/link";
+import { Pencil, Trash2, ToggleLeft, ToggleRight, ExternalLink, Loader2 } from "lucide-react";
+import { cn, formatDate } from "@/lib/utils";
+
+export interface CuratorWorker {
+  id: string;
+  name: string;
+  isActive: boolean;
+  createdAt: string;
+  category: { id: string; name: string };
+  onChainStatus?: "registered" | "pending" | "unregistered";
+  ttlDaysLeft?: number;
+}
+
+interface Props {
+  workers: CuratorWorker[];
+  loading?: boolean;
+  onToggle: (worker: CuratorWorker) => void;
+  onDelete: (worker: CuratorWorker) => void;
+  toggling?: Set<string>;
+}
+
+function OnChainBadge({ status, ttlDaysLeft }: { status?: string; ttlDaysLeft?: number }) {
+  if (!status || status === "unregistered") {
+    return (
+      <span className="rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+        Off-chain
+      </span>
+    );
+  }
+  if (status === "pending") {
+    return (
+      <span className="rounded-full bg-yellow-100 dark:bg-yellow-900/30 px-2 py-0.5 text-[11px] font-medium text-yellow-700 dark:text-yellow-400">
+        Pending
+      </span>
+    );
+  }
+  return (
+    <span
+      className={cn(
+        "rounded-full px-2 py-0.5 text-[11px] font-medium",
+        ttlDaysLeft != null && ttlDaysLeft < 30
+          ? "bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400"
+          : "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400"
+      )}
+    >
+      On-chain{ttlDaysLeft != null ? ` · ${ttlDaysLeft}d TTL` : ""}
+    </span>
+  );
+}
+
+export function ListingsTable({ workers, loading, onToggle, onDelete, toggling }: Props) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 size={28} className="animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (workers.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center text-sm text-gray-400">
+        <p className="font-medium">No listings yet.</p>
+        <p className="mt-1">Create your first worker listing to get started.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Desktop */}
+      <div className="hidden sm:block overflow-x-auto">
+        <table className="w-full text-sm" aria-label="Worker listings">
+          <thead>
+            <tr className="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <th className="px-5 py-3">Name</th>
+              <th className="px-5 py-3">Category</th>
+              <th className="px-5 py-3">Status</th>
+              <th className="px-5 py-3">On-chain</th>
+              <th className="px-5 py-3">Created</th>
+              <th className="px-5 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+            {workers.map((w) => (
+              <tr key={w.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                <td className="px-5 py-4 font-medium text-gray-900 dark:text-gray-100">
+                  {w.name}
+                </td>
+                <td className="px-5 py-4">
+                  <span className="rounded-full bg-brand-50 dark:bg-brand-900/20 px-2.5 py-0.5 text-xs font-medium text-brand-600 dark:text-brand-400">
+                    {w.category.name}
+                  </span>
+                </td>
+                <td className="px-5 py-4">
+                  <span className={cn(
+                    "rounded-full px-2.5 py-0.5 text-xs font-medium",
+                    w.isActive
+                      ? "bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400"
+                      : "bg-gray-100 dark:bg-gray-700 text-gray-500"
+                  )}>
+                    {w.isActive ? "Active" : "Inactive"}
+                  </span>
+                </td>
+                <td className="px-5 py-4">
+                  <OnChainBadge status={w.onChainStatus} ttlDaysLeft={w.ttlDaysLeft} />
+                </td>
+                <td className="px-5 py-4 text-gray-400 dark:text-gray-500">
+                  {formatDate(w.createdAt)}
+                </td>
+                <td className="px-5 py-4">
+                  <div className="flex items-center justify-end gap-1">
+                    <Link
+                      href={`/workers/${w.id}`}
+                      target="_blank"
+                      className="rounded p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-brand-600 transition-colors"
+                      title="View public profile"
+                    >
+                      <ExternalLink size={14} />
+                    </Link>
+                    <Link
+                      href={`/curator/${w.id}/edit`}
+                      className="rounded p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-brand-600 transition-colors"
+                      title="Edit"
+                    >
+                      <Pencil size={14} />
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => onToggle(w)}
+                      disabled={toggling?.has(w.id)}
+                      title={w.isActive ? "Deactivate" : "Activate"}
+                      className="rounded p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-brand-600 transition-colors disabled:opacity-50"
+                    >
+                      {toggling?.has(w.id) ? (
+                        <Loader2 size={14} className="animate-spin" />
+                      ) : w.isActive ? (
+                        <ToggleRight size={16} className="text-green-500" />
+                      ) : (
+                        <ToggleLeft size={16} />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(w)}
+                      title="Delete"
+                      className="rounded p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-red-500 transition-colors"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile stacked */}
+      <div className="flex flex-col divide-y divide-gray-100 dark:divide-gray-700 sm:hidden">
+        {workers.map((w) => (
+          <div key={w.id} className="p-4 space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <p className="font-medium text-gray-900 dark:text-gray-100">{w.name}</p>
+                <p className="text-xs text-gray-500">{w.category.name}</p>
+              </div>
+              <div className="flex gap-1">
+                <span className={cn(
+                  "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                  w.isActive ? "bg-green-50 text-green-600" : "bg-gray-100 text-gray-500"
+                )}>
+                  {w.isActive ? "Active" : "Inactive"}
+                </span>
+                <OnChainBadge status={w.onChainStatus} ttlDaysLeft={w.ttlDaysLeft} />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Link href={`/curator/${w.id}/edit`} className="flex-1 rounded-lg border dark:border-gray-700 py-1.5 text-center text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800">
+                Edit
+              </Link>
+              <button type="button" onClick={() => onToggle(w)} disabled={toggling?.has(w.id)} className="flex-1 rounded-lg border dark:border-gray-700 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50">
+                {w.isActive ? "Deactivate" : "Activate"}
+              </button>
+              <button type="button" onClick={() => onDelete(w)} className="flex-1 rounded-lg border border-red-200 dark:border-red-900/50 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20">
+                Delete
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/packages/app/src/components/Curator/index.ts
+++ b/packages/app/src/components/Curator/index.ts
@@ -1,0 +1,5 @@
+export { ListingsTable } from "./ListingsTable";
+export type { CuratorWorker } from "./ListingsTable";
+
+export { ListingForm } from "./ListingForm";
+export type { ListingFormProps } from "./ListingForm";

--- a/packages/app/src/components/Dashboard/ActivityTimeline.tsx
+++ b/packages/app/src/components/Dashboard/ActivityTimeline.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Clock, Star, MessageSquare, Wallet, Heart } from "lucide-react";
+import { cn, formatDate } from "@/lib/utils";
+
+export type ActivityType = "tip" | "review" | "message" | "bookmark" | "escrow";
+
+export interface ActivityItem {
+  id: string;
+  type: ActivityType;
+  title: string;
+  description?: string;
+  createdAt: string;
+  href?: string;
+}
+
+const iconMap: Record<ActivityType, React.ReactNode> = {
+  tip: <Wallet size={14} />,
+  review: <Star size={14} />,
+  message: <MessageSquare size={14} />,
+  bookmark: <Heart size={14} />,
+  escrow: <Wallet size={14} />,
+};
+
+const colorMap: Record<ActivityType, string> = {
+  tip: "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400",
+  review: "bg-yellow-100 text-yellow-600 dark:bg-yellow-900/30 dark:text-yellow-400",
+  message: "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400",
+  bookmark: "bg-pink-100 text-pink-600 dark:bg-pink-900/30 dark:text-pink-400",
+  escrow: "bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400",
+};
+
+export function ActivityTimeline({ items }: { items: ActivityItem[] }) {
+  if (items.length === 0) {
+    return (
+      <div className="py-10 text-center text-sm text-gray-400">No activity yet.</div>
+    );
+  }
+
+  return (
+    <ol className="relative space-y-4 border-l border-gray-200 dark:border-gray-700 pl-6">
+      {items.map((item) => (
+        <li key={item.id} className="relative">
+          <span
+            className={cn(
+              "absolute -left-[1.65rem] flex h-8 w-8 items-center justify-center rounded-full ring-2 ring-white dark:ring-gray-900",
+              colorMap[item.type]
+            )}
+            aria-hidden
+          >
+            {iconMap[item.type]}
+          </span>
+          <div className="rounded-lg border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3">
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+              {item.href ? (
+                <a href={item.href} className="hover:underline">
+                  {item.title}
+                </a>
+              ) : (
+                item.title
+              )}
+            </p>
+            {item.description && (
+              <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{item.description}</p>
+            )}
+            <time className="mt-1 flex items-center gap-1 text-xs text-gray-400">
+              <Clock size={11} />
+              {formatDate(item.createdAt)}
+            </time>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/packages/app/src/components/Dashboard/MessagesPreview.tsx
+++ b/packages/app/src/components/Dashboard/MessagesPreview.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { MessageSquare } from "lucide-react";
+import { cn, formatDate } from "@/lib/utils";
+import type { Conversation } from "@/types";
+
+interface Props {
+  conversations: Conversation[];
+  currentUserId: string;
+}
+
+export function MessagesPreview({ conversations, currentUserId }: Props) {
+  if (conversations.length === 0) {
+    return (
+      <div className="py-10 text-center">
+        <MessageSquare size={32} className="mx-auto mb-2 text-gray-300" />
+        <p className="text-sm text-gray-400">No messages yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+      {conversations.slice(0, 5).map((conv) => {
+        const other = conv.participants.find((p) => p.userId !== currentUserId);
+        const lastMsg = conv.messages?.[conv.messages.length - 1];
+        const isUnread = (conv.unreadCount ?? 0) > 0;
+
+        return (
+          <li key={conv.id}>
+            <Link
+              href={`/messages?id=${conv.id}`}
+              className="flex items-center gap-3 px-1 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 rounded-lg transition-colors"
+            >
+              {other?.user.avatar ? (
+                <Image
+                  src={other.user.avatar}
+                  alt={`${other.user.firstName} ${other.user.lastName}`}
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-full object-cover shrink-0"
+                />
+              ) : (
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-600 text-sm font-bold">
+                  {other?.user.firstName?.[0] ?? "?"}
+                </div>
+              )}
+              <div className="flex-1 min-w-0">
+                <p className={cn("text-sm truncate", isUnread ? "font-semibold text-gray-900 dark:text-gray-100" : "font-medium text-gray-700 dark:text-gray-300")}>
+                  {other ? `${other.user.firstName} ${other.user.lastName}` : conv.subject ?? "Conversation"}
+                </p>
+                {lastMsg && (
+                  <p className="truncate text-xs text-gray-400">{lastMsg.body}</p>
+                )}
+              </div>
+              <div className="shrink-0 flex flex-col items-end gap-1">
+                {lastMsg && (
+                  <time className="text-[10px] text-gray-400">{formatDate(lastMsg.createdAt)}</time>
+                )}
+                {isUnread && (
+                  <span className="flex h-5 w-5 items-center justify-center rounded-full bg-brand-600 text-[10px] font-bold text-white">
+                    {conv.unreadCount}
+                  </span>
+                )}
+              </div>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/app/src/components/Dashboard/QuickProfileEdit.tsx
+++ b/packages/app/src/components/Dashboard/QuickProfileEdit.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2, Check } from "lucide-react";
+import { Input } from "@/components/Form/Input";
+import type { AuthUser } from "@/types";
+
+const schema = z.object({
+  firstName: z.string().min(1, "Required"),
+  lastName: z.string().min(1, "Required"),
+  email: z.string().email("Invalid email"),
+});
+
+type Fields = z.infer<typeof schema>;
+
+interface Props {
+  user: AuthUser;
+  token: string;
+  onSaved?: (updated: Pick<AuthUser, "firstName" | "lastName" | "email">) => void;
+}
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
+
+export function QuickProfileEdit({ user, token, onSaved }: Props) {
+  const [saved, setSaved] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<Fields>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+    },
+  });
+
+  const onSubmit = async (data: Fields) => {
+    const res = await fetch(`${API}/users/me`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error("Failed to save");
+    setSaved(true);
+    onSaved?.(data);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Input
+          label="First name"
+          {...register("firstName")}
+          error={errors.firstName?.message}
+        />
+        <Input
+          label="Last name"
+          {...register("lastName")}
+          error={errors.lastName?.message}
+        />
+      </div>
+      <Input
+        label="Email"
+        type="email"
+        {...register("email")}
+        error={errors.email?.message}
+      />
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60 transition-colors"
+        >
+          {isSubmitting ? <Loader2 size={14} className="animate-spin" /> : saved ? <Check size={14} /> : null}
+          {saved ? "Saved!" : "Save changes"}
+        </button>
+        <a
+          href="/settings/profile"
+          className="text-sm text-brand-600 hover:underline"
+        >
+          Full profile settings
+        </a>
+      </div>
+    </form>
+  );
+}

--- a/packages/app/src/components/Dashboard/SavedWorkers.tsx
+++ b/packages/app/src/components/Dashboard/SavedWorkers.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Bookmark, Star } from "lucide-react";
+import type { Worker } from "@/types";
+
+interface Props {
+  workers: Pick<Worker, "id" | "name" | "avatar" | "category" | "averageRating" | "location">[];
+  onRemove?: (id: string) => void;
+}
+
+export function SavedWorkers({ workers, onRemove }: Props) {
+  if (workers.length === 0) {
+    return (
+      <div className="py-10 text-center">
+        <Bookmark size={32} className="mx-auto mb-2 text-gray-300" />
+        <p className="text-sm text-gray-400">No saved workers yet.</p>
+        <Link href="/workers" className="mt-3 inline-block text-sm text-brand-600 hover:underline">
+          Browse workers
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      {workers.map((w) => (
+        <div
+          key={w.id}
+          className="flex items-center gap-3 rounded-xl border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-900 p-3"
+        >
+          {w.avatar ? (
+            <Image
+              src={w.avatar}
+              alt={w.name}
+              width={44}
+              height={44}
+              className="h-11 w-11 rounded-full object-cover shrink-0"
+            />
+          ) : (
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-600 text-base font-bold">
+              {w.name[0]}
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <Link
+              href={`/workers/${w.id}`}
+              className="block truncate text-sm font-medium text-gray-900 dark:text-gray-100 hover:underline"
+            >
+              {w.name}
+            </Link>
+            <p className="truncate text-xs text-gray-500 dark:text-gray-400">{w.category.name}</p>
+            {w.averageRating != null && (
+              <span className="inline-flex items-center gap-0.5 text-xs text-yellow-500">
+                <Star size={11} fill="currentColor" />
+                {w.averageRating.toFixed(1)}
+              </span>
+            )}
+          </div>
+          {onRemove && (
+            <button
+              type="button"
+              onClick={() => onRemove(w.id)}
+              aria-label={`Remove ${w.name} from saved`}
+              className="shrink-0 rounded-md p-1.5 text-gray-400 hover:text-red-500 transition-colors"
+            >
+              <Bookmark size={15} fill="currentColor" />
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/app/src/components/Dashboard/index.ts
+++ b/packages/app/src/components/Dashboard/index.ts
@@ -1,0 +1,6 @@
+export { ActivityTimeline } from "./ActivityTimeline";
+export type { ActivityItem, ActivityType } from "./ActivityTimeline";
+
+export { SavedWorkers } from "./SavedWorkers";
+export { MessagesPreview } from "./MessagesPreview";
+export { QuickProfileEdit } from "./QuickProfileEdit";

--- a/packages/app/src/components/Form/Checkbox.tsx
+++ b/packages/app/src/components/Form/Checkbox.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  label: string;
+  error?: string;
+  hint?: string;
+}
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ label, error, hint, className, id, ...props }, ref) => {
+    const checkId = id ?? React.useId();
+    const errorId = `${checkId}-error`;
+
+    return (
+      <div className="flex flex-col gap-1">
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            ref={ref}
+            id={checkId}
+            type="checkbox"
+            aria-invalid={!!error}
+            aria-describedby={error ? errorId : undefined}
+            className={cn(
+              "h-4 w-4 rounded border-gray-300 dark:border-gray-600",
+              "accent-brand-600 focus:ring-2 focus:ring-brand-500/20",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              className
+            )}
+            {...props}
+          />
+          <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+        </label>
+        {error && (
+          <p id={errorId} role="alert" className="text-xs text-error ml-6">
+            {error}
+          </p>
+        )}
+        {!error && hint && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 ml-6">{hint}</p>
+        )}
+      </div>
+    );
+  }
+);
+Checkbox.displayName = "FormCheckbox";
+
+export { Checkbox };

--- a/packages/app/src/components/Form/DatePicker.tsx
+++ b/packages/app/src/components/Form/DatePicker.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface DatePickerProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  label: string;
+  error?: string;
+  hint?: string;
+}
+
+const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
+  ({ label, error, hint, className, id, disabled, ...props }, ref) => {
+    const inputId = id ?? React.useId();
+    const hintId = `${inputId}-hint`;
+    const errorId = `${inputId}-error`;
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor={inputId}
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {label}
+        </label>
+        <input
+          ref={ref}
+          id={inputId}
+          type="date"
+          disabled={disabled}
+          aria-invalid={!!error}
+          aria-describedby={error ? errorId : hint ? hintId : undefined}
+          className={cn(
+            "h-10 w-full rounded-lg border px-3 py-2 text-sm",
+            "bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100",
+            "transition-colors focus:outline-none focus:ring-2",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            error
+              ? "border-error focus:border-error focus:ring-error/20"
+              : "border-gray-300 dark:border-gray-700 focus:border-brand-500 focus:ring-brand-500/20",
+            className
+          )}
+          {...props}
+        />
+        {error && (
+          <p id={errorId} role="alert" className="text-xs text-error">
+            {error}
+          </p>
+        )}
+        {!error && hint && (
+          <p id={hintId} className="text-xs text-gray-400 dark:text-gray-500">
+            {hint}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+DatePicker.displayName = "FormDatePicker";
+
+export { DatePicker };

--- a/packages/app/src/components/Form/FileUpload.tsx
+++ b/packages/app/src/components/Form/FileUpload.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import * as React from "react";
+import { Upload, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface FileUploadProps {
+  label: string;
+  accept?: string;
+  multiple?: boolean;
+  error?: string;
+  hint?: string;
+  disabled?: boolean;
+  onChange?: (files: FileList | null) => void;
+  className?: string;
+}
+
+function FileUpload({ label, accept, multiple, error, hint, disabled, onChange, className }: FileUploadProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [files, setFiles] = React.useState<File[]>([]);
+  const inputId = React.useId();
+  const errorId = `${inputId}-error`;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const fl = e.target.files;
+    setFiles(fl ? Array.from(fl) : []);
+    onChange?.(fl);
+  };
+
+  const removeFile = (idx: number) => {
+    setFiles((prev) => {
+      const next = prev.filter((_, i) => i !== idx);
+      // rebuild DataTransfer to update input
+      const dt = new DataTransfer();
+      next.forEach((f) => dt.items.add(f));
+      if (inputRef.current) inputRef.current.files = dt.files;
+      onChange?.(dt.files);
+      return next;
+    });
+  };
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</span>
+      <label
+        htmlFor={inputId}
+        className={cn(
+          "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-6",
+          "text-sm text-gray-500 dark:text-gray-400",
+          "transition-colors hover:border-brand-400 hover:text-brand-600",
+          "dark:border-gray-700 dark:hover:border-brand-500",
+          error ? "border-error" : "border-gray-300",
+          disabled && "pointer-events-none opacity-50"
+        )}
+      >
+        <Upload size={20} />
+        <span>Click to upload{multiple ? " files" : " a file"}</span>
+        {accept && <span className="text-xs text-gray-400">{accept}</span>}
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="file"
+          accept={accept}
+          multiple={multiple}
+          disabled={disabled}
+          onChange={handleChange}
+          aria-invalid={!!error}
+          aria-describedby={error ? errorId : undefined}
+          className="sr-only"
+        />
+      </label>
+      {files.length > 0 && (
+        <ul className="flex flex-col gap-1 mt-1">
+          {files.map((f, i) => (
+            <li key={i} className="flex items-center justify-between rounded-md bg-gray-50 dark:bg-gray-800 px-3 py-1.5 text-xs">
+              <span className="truncate max-w-[calc(100%-2rem)]">{f.name}</span>
+              <button type="button" onClick={() => removeFile(i)} aria-label={`Remove ${f.name}`} className="ml-2 text-gray-400 hover:text-error">
+                <X size={14} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {error && (
+        <p id={errorId} role="alert" className="text-xs text-error">
+          {error}
+        </p>
+      )}
+      {!error && hint && (
+        <p className="text-xs text-gray-400 dark:text-gray-500">{hint}</p>
+      )}
+    </div>
+  );
+}
+
+export { FileUpload };

--- a/packages/app/src/components/Form/Form.stories.tsx
+++ b/packages/app/src/components/Form/Form.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Input } from "./Input";
+import { Select } from "./Select";
+import { Checkbox } from "./Checkbox";
+import { RadioGroup } from "./Radio";
+import { DatePicker } from "./DatePicker";
+import { FileUpload } from "./FileUpload";
+
+// ─── Input ────────────────────────────────────────────────────────────────────
+
+const inputMeta: Meta<typeof Input> = {
+  title: "Form/Input",
+  component: Input,
+  tags: ["autodocs"],
+};
+export default inputMeta;
+type InputStory = StoryObj<typeof Input>;
+
+export const Default: InputStory = { args: { label: "Name", placeholder: "John Doe" } };
+export const WithHint: InputStory = { args: { label: "Email", type: "email", hint: "We'll never share your email." } };
+export const WithError: InputStory = { args: { label: "Email", type: "email", value: "bad", error: "Invalid email address." } };
+export const Disabled: InputStory = { args: { label: "Username", value: "jdoe", disabled: true } };
+
+// ─── Select ───────────────────────────────────────────────────────────────────
+
+export const SelectDefault: StoryObj<typeof Select> = {
+  render: () => (
+    <Select
+      label="Category"
+      placeholder="Pick a category"
+      options={[
+        { label: "Plumber", value: "plumber" },
+        { label: "Electrician", value: "electrician" },
+      ]}
+    />
+  ),
+};
+
+export const SelectError: StoryObj<typeof Select> = {
+  render: () => (
+    <Select
+      label="Category"
+      placeholder="Pick a category"
+      options={[{ label: "Plumber", value: "plumber" }]}
+      error="Please select a category."
+    />
+  ),
+};
+
+// ─── Checkbox ─────────────────────────────────────────────────────────────────
+
+export const CheckboxDefault: StoryObj<typeof Checkbox> = {
+  render: () => <Checkbox label="I agree to the terms" />,
+};
+export const CheckboxChecked: StoryObj<typeof Checkbox> = {
+  render: () => <Checkbox label="Receive notifications" defaultChecked />,
+};
+export const CheckboxError: StoryObj<typeof Checkbox> = {
+  render: () => <Checkbox label="I agree to the terms" error="You must accept the terms." />,
+};
+
+// ─── RadioGroup ───────────────────────────────────────────────────────────────
+
+export const RadioDefault: StoryObj<typeof RadioGroup> = {
+  render: () => (
+    <RadioGroup
+      label="Role"
+      name="role"
+      options={[
+        { label: "User", value: "user" },
+        { label: "Curator", value: "curator" },
+      ]}
+    />
+  ),
+};
+
+// ─── DatePicker ───────────────────────────────────────────────────────────────
+
+export const DatePickerDefault: StoryObj<typeof DatePicker> = {
+  render: () => <DatePicker label="Start date" />,
+};
+export const DatePickerError: StoryObj<typeof DatePicker> = {
+  render: () => <DatePicker label="Start date" error="Date is required." />,
+};
+
+// ─── FileUpload ───────────────────────────────────────────────────────────────
+
+export const FileUploadDefault: StoryObj<typeof FileUpload> = {
+  render: () => <FileUpload label="Profile image" accept="image/*" hint="PNG, JPG up to 5 MB" />,
+};
+export const FileUploadError: StoryObj<typeof FileUpload> = {
+  render: () => <FileUpload label="Profile image" accept="image/*" error="Image is required." />,
+};

--- a/packages/app/src/components/Form/Input.tsx
+++ b/packages/app/src/components/Form/Input.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+  hint?: string;
+  loading?: boolean;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, hint, loading, className, id, disabled, ...props }, ref) => {
+    const inputId = id ?? React.useId();
+    const hintId = `${inputId}-hint`;
+    const errorId = `${inputId}-error`;
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor={inputId}
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {label}
+        </label>
+        <input
+          ref={ref}
+          id={inputId}
+          disabled={disabled || loading}
+          aria-invalid={!!error}
+          aria-describedby={error ? errorId : hint ? hintId : undefined}
+          className={cn(
+            "h-10 w-full rounded-lg border px-3 py-2 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100",
+            "placeholder:text-gray-400 dark:placeholder:text-gray-500",
+            "transition-colors focus:outline-none focus:ring-2",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            error
+              ? "border-error focus:border-error focus:ring-error/20"
+              : "border-gray-300 dark:border-gray-700 focus:border-brand-500 focus:ring-brand-500/20",
+            className
+          )}
+          {...props}
+        />
+        {error && (
+          <p id={errorId} role="alert" className="text-xs text-error">
+            {error}
+          </p>
+        )}
+        {!error && hint && (
+          <p id={hintId} className="text-xs text-gray-400 dark:text-gray-500">
+            {hint}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+Input.displayName = "FormInput";
+
+export { Input };

--- a/packages/app/src/components/Form/Radio.tsx
+++ b/packages/app/src/components/Form/Radio.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface RadioOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface RadioGroupProps {
+  label: string;
+  name: string;
+  options: RadioOption[];
+  value?: string;
+  onChange?: (value: string) => void;
+  error?: string;
+  hint?: string;
+  className?: string;
+}
+
+function RadioGroup({ label, name, options, value, onChange, error, hint, className }: RadioGroupProps) {
+  const groupId = React.useId();
+  const errorId = `${groupId}-error`;
+
+  return (
+    <fieldset className={cn("flex flex-col gap-2", className)}>
+      <legend className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</legend>
+      <div className="flex flex-col gap-2" role="radiogroup" aria-describedby={error ? errorId : undefined}>
+        {options.map((opt) => {
+          const optId = `${groupId}-${opt.value}`;
+          return (
+            <label key={opt.value} className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="radio"
+                id={optId}
+                name={name}
+                value={opt.value}
+                checked={value === opt.value}
+                onChange={() => onChange?.(opt.value)}
+                disabled={opt.disabled}
+                className={cn(
+                  "h-4 w-4 accent-brand-600 border-gray-300 dark:border-gray-600",
+                  "focus:ring-2 focus:ring-brand-500/20",
+                  "disabled:cursor-not-allowed disabled:opacity-50"
+                )}
+              />
+              <span className="text-sm text-gray-700 dark:text-gray-300">{opt.label}</span>
+            </label>
+          );
+        })}
+      </div>
+      {error && (
+        <p id={errorId} role="alert" className="text-xs text-error">
+          {error}
+        </p>
+      )}
+      {!error && hint && (
+        <p className="text-xs text-gray-400 dark:text-gray-500">{hint}</p>
+      )}
+    </fieldset>
+  );
+}
+
+export { RadioGroup };

--- a/packages/app/src/components/Form/Select.tsx
+++ b/packages/app/src/components/Form/Select.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface SelectOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  label: string;
+  options: SelectOption[];
+  placeholder?: string;
+  error?: string;
+  hint?: string;
+}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ label, options, placeholder, error, hint, className, id, ...props }, ref) => {
+    const selectId = id ?? React.useId();
+    const hintId = `${selectId}-hint`;
+    const errorId = `${selectId}-error`;
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor={selectId}
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {label}
+        </label>
+        <div className="relative">
+          <select
+            ref={ref}
+            id={selectId}
+            aria-invalid={!!error}
+            aria-describedby={error ? errorId : hint ? hintId : undefined}
+            className={cn(
+              "h-10 w-full appearance-none rounded-lg border px-3 py-2 pr-9 text-sm",
+              "bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100",
+              "transition-colors focus:outline-none focus:ring-2",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              error
+                ? "border-error focus:border-error focus:ring-error/20"
+                : "border-gray-300 dark:border-gray-700 focus:border-brand-500 focus:ring-brand-500/20",
+              className
+            )}
+            {...props}
+          >
+            {placeholder && (
+              <option value="" disabled>
+                {placeholder}
+              </option>
+            )}
+            {options.map((o) => (
+              <option key={o.value} value={o.value} disabled={o.disabled}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            size={16}
+            className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-400"
+          />
+        </div>
+        {error && (
+          <p id={errorId} role="alert" className="text-xs text-error">
+            {error}
+          </p>
+        )}
+        {!error && hint && (
+          <p id={hintId} className="text-xs text-gray-400 dark:text-gray-500">
+            {hint}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+Select.displayName = "FormSelect";
+
+export { Select };

--- a/packages/app/src/components/Form/index.ts
+++ b/packages/app/src/components/Form/index.ts
@@ -1,0 +1,17 @@
+export { Input } from "./Input";
+export type { InputProps } from "./Input";
+
+export { Select } from "./Select";
+export type { SelectProps, SelectOption } from "./Select";
+
+export { Checkbox } from "./Checkbox";
+export type { CheckboxProps } from "./Checkbox";
+
+export { RadioGroup } from "./Radio";
+export type { RadioGroupProps, RadioOption } from "./Radio";
+
+export { DatePicker } from "./DatePicker";
+export type { DatePickerProps } from "./DatePicker";
+
+export { FileUpload } from "./FileUpload";
+export type { FileUploadProps } from "./FileUpload";

--- a/packages/app/src/components/Table/Table.stories.tsx
+++ b/packages/app/src/components/Table/Table.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Pencil, Trash2 } from "lucide-react";
+import { Table } from "./Table";
+import type { ColumnDef, RowAction, SortDirection } from "./Table";
+
+interface Row {
+  id: number;
+  name: string;
+  category: string;
+  status: string;
+  views: number;
+}
+
+const sampleData: Row[] = Array.from({ length: 8 }, (_, i) => ({
+  id: i + 1,
+  name: `Worker ${i + 1}`,
+  category: ["Plumber", "Electrician", "Carpenter"][i % 3],
+  status: i % 3 === 0 ? "Inactive" : "Active",
+  views: (i + 1) * 47,
+}));
+
+const columns: ColumnDef<Row>[] = [
+  { key: "name", header: "Name", sortable: true },
+  { key: "category", header: "Category", sortable: true },
+  { key: "status", header: "Status" },
+  { key: "views", header: "Views", sortable: true, hideOnMobile: true },
+];
+
+const actions: RowAction<Row>[] = [
+  { label: "Edit", icon: <Pencil size={13} />, onClick: (r) => alert(`Edit ${r.name}`) },
+  { label: "Delete", icon: <Trash2 size={13} />, onClick: (r) => alert(`Delete ${r.name}`), variant: "danger" },
+];
+
+const meta: Meta<typeof Table<Row>> = {
+  title: "Components/Table",
+  component: Table,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Table<Row>>;
+
+export const Default: Story = {
+  render: () => <Table columns={columns} data={sampleData} aria-label="Workers" />,
+};
+
+export const WithActions: Story = {
+  render: () => <Table columns={columns} data={sampleData} rowActions={actions} aria-label="Workers" />,
+};
+
+export const Selectable: Story = {
+  render: () => {
+    const [sel, setSel] = useState<Set<string | number>>(new Set());
+    return (
+      <Table
+        columns={columns}
+        data={sampleData}
+        selectable
+        selectedIds={sel}
+        onSelectionChange={setSel}
+        rowActions={actions}
+        aria-label="Workers selectable"
+      />
+    );
+  },
+};
+
+export const WithPagination: Story = {
+  render: () => {
+    const [page, setPage] = useState(1);
+    return (
+      <Table
+        columns={columns}
+        data={sampleData.slice((page - 1) * 3, page * 3)}
+        total={sampleData.length}
+        page={page}
+        pageSize={3}
+        onPageChange={setPage}
+        aria-label="Workers paginated"
+      />
+    );
+  },
+};
+
+export const WithSorting: Story = {
+  render: () => {
+    const [sortKey, setSortKey] = useState<string>("");
+    const [sortDir, setSortDir] = useState<SortDirection>("asc");
+    const sorted = [...sampleData].sort((a, b) => {
+      if (!sortKey) return 0;
+      const av = (a as Record<string, unknown>)[sortKey];
+      const bv = (b as Record<string, unknown>)[sortKey];
+      return sortDir === "asc"
+        ? String(av).localeCompare(String(bv))
+        : String(bv).localeCompare(String(av));
+    });
+    return (
+      <Table
+        columns={columns}
+        data={sorted}
+        sortKey={sortKey}
+        sortDir={sortDir}
+        onSort={(k, d) => { setSortKey(k); setSortDir(d); }}
+        aria-label="Sortable workers"
+      />
+    );
+  },
+};
+
+export const Loading: Story = {
+  render: () => <Table columns={columns} data={[]} loading aria-label="Loading" />,
+};
+
+export const Empty: Story = {
+  render: () => (
+    <Table
+      columns={columns}
+      data={[]}
+      emptyMessage="No workers found. Create your first listing."
+      aria-label="Empty"
+    />
+  ),
+};

--- a/packages/app/src/components/Table/Table.tsx
+++ b/packages/app/src/components/Table/Table.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import * as React from "react";
+import {
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SortDirection = "asc" | "desc";
+
+export interface ColumnDef<T> {
+  key: string;
+  header: string;
+  /** Render cell content; receives the row. Defaults to `(row as any)[key]`. */
+  cell?: (row: T) => React.ReactNode;
+  sortable?: boolean;
+  /** Hide on mobile (stacked layout shows only non-hidden columns). */
+  hideOnMobile?: boolean;
+  className?: string;
+}
+
+export interface RowAction<T> {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: (row: T) => void;
+  variant?: "default" | "danger";
+  disabled?: (row: T) => boolean;
+}
+
+export interface TableProps<T extends { id: string | number }> {
+  columns: ColumnDef<T>[];
+  data: T[];
+  loading?: boolean;
+  /** Total records for server-side pagination */
+  total?: number;
+  page?: number;
+  pageSize?: number;
+  onPageChange?: (page: number) => void;
+  sortKey?: string;
+  sortDir?: SortDirection;
+  onSort?: (key: string, dir: SortDirection) => void;
+  rowActions?: RowAction<T>[];
+  selectable?: boolean;
+  selectedIds?: Set<string | number>;
+  onSelectionChange?: (ids: Set<string | number>) => void;
+  emptyMessage?: string;
+  className?: string;
+  "aria-label"?: string;
+}
+
+// ─── Sort icon helper ─────────────────────────────────────────────────────────
+
+function SortIcon({ active, dir }: { active: boolean; dir?: SortDirection }) {
+  if (!active) return <ChevronsUpDown size={14} className="text-gray-400" />;
+  return dir === "asc"
+    ? <ChevronUp size={14} className="text-brand-600" />
+    : <ChevronDown size={14} className="text-brand-600" />;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function Table<T extends { id: string | number }>({
+  columns,
+  data,
+  loading,
+  total,
+  page = 1,
+  pageSize = 20,
+  onPageChange,
+  sortKey,
+  sortDir,
+  onSort,
+  rowActions,
+  selectable,
+  selectedIds,
+  onSelectionChange,
+  emptyMessage = "No results found.",
+  className,
+  "aria-label": ariaLabel,
+}: TableProps<T>) {
+  const allIds = data.map((r) => r.id);
+  const allSelected = allIds.length > 0 && allIds.every((id) => selectedIds?.has(id));
+  const someSelected = !allSelected && allIds.some((id) => selectedIds?.has(id));
+  const totalPages = total !== undefined ? Math.max(1, Math.ceil(total / pageSize)) : undefined;
+
+  const toggleAll = () => {
+    if (!onSelectionChange) return;
+    if (allSelected) {
+      const next = new Set(selectedIds);
+      allIds.forEach((id) => next.delete(id));
+      onSelectionChange(next);
+    } else {
+      const next = new Set(selectedIds);
+      allIds.forEach((id) => next.add(id));
+      onSelectionChange(next);
+    }
+  };
+
+  const toggleRow = (id: string | number) => {
+    if (!onSelectionChange) return;
+    const next = new Set(selectedIds);
+    next.has(id) ? next.delete(id) : next.add(id);
+    onSelectionChange(next);
+  };
+
+  const handleSort = (col: ColumnDef<T>) => {
+    if (!col.sortable || !onSort) return;
+    if (sortKey === col.key) {
+      onSort(col.key, sortDir === "asc" ? "desc" : "asc");
+    } else {
+      onSort(col.key, "asc");
+    }
+  };
+
+  const visibleCols = columns.filter((c) => !c.hideOnMobile);
+
+  return (
+    <div className={cn("w-full overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700", className)}>
+      {/* Desktop table */}
+      <div className="overflow-x-auto">
+        <table
+          className="hidden w-full min-w-full text-sm sm:table"
+          aria-label={ariaLabel}
+          aria-busy={loading}
+        >
+          <thead className="bg-gray-50 dark:bg-gray-800 text-xs uppercase text-gray-500 dark:text-gray-400">
+            <tr>
+              {selectable && (
+                <th className="w-10 px-4 py-3">
+                  <input
+                    type="checkbox"
+                    aria-label="Select all"
+                    checked={allSelected}
+                    ref={(el) => { if (el) el.indeterminate = someSelected; }}
+                    onChange={toggleAll}
+                    className="accent-brand-600 cursor-pointer"
+                  />
+                </th>
+              )}
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  scope="col"
+                  className={cn(
+                    "px-4 py-3 text-left font-semibold",
+                    col.sortable && "cursor-pointer select-none hover:bg-gray-100 dark:hover:bg-gray-700",
+                    col.className
+                  )}
+                  onClick={() => handleSort(col)}
+                  aria-sort={
+                    sortKey === col.key
+                      ? sortDir === "asc" ? "ascending" : "descending"
+                      : undefined
+                  }
+                >
+                  <span className="inline-flex items-center gap-1">
+                    {col.header}
+                    {col.sortable && <SortIcon active={sortKey === col.key} dir={sortDir} />}
+                  </span>
+                </th>
+              ))}
+              {rowActions && rowActions.length > 0 && (
+                <th scope="col" className="px-4 py-3 text-right font-semibold">
+                  Actions
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-900">
+            {loading ? (
+              <tr>
+                <td
+                  colSpan={columns.length + (selectable ? 1 : 0) + (rowActions ? 1 : 0)}
+                  className="py-16 text-center text-gray-400"
+                >
+                  <Loader2 size={28} className="mx-auto animate-spin" aria-label="Loading" />
+                </td>
+              </tr>
+            ) : data.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length + (selectable ? 1 : 0) + (rowActions ? 1 : 0)}
+                  className="py-16 text-center text-gray-400"
+                >
+                  {emptyMessage}
+                </td>
+              </tr>
+            ) : (
+              data.map((row) => (
+                <tr
+                  key={row.id}
+                  className={cn(
+                    "transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/50",
+                    selectedIds?.has(row.id) && "bg-brand-50 dark:bg-brand-900/20"
+                  )}
+                >
+                  {selectable && (
+                    <td className="px-4 py-3">
+                      <input
+                        type="checkbox"
+                        aria-label={`Select row ${row.id}`}
+                        checked={selectedIds?.has(row.id) ?? false}
+                        onChange={() => toggleRow(row.id)}
+                        className="accent-brand-600 cursor-pointer"
+                      />
+                    </td>
+                  )}
+                  {columns.map((col) => (
+                    <td key={col.key} className={cn("px-4 py-3 text-gray-900 dark:text-gray-100", col.className)}>
+                      {col.cell ? col.cell(row) : String((row as Record<string, unknown>)[col.key] ?? "")}
+                    </td>
+                  ))}
+                  {rowActions && rowActions.length > 0 && (
+                    <td className="px-4 py-3 text-right">
+                      <div className="inline-flex items-center gap-2">
+                        {rowActions.map((action) => (
+                          <button
+                            key={action.label}
+                            type="button"
+                            onClick={() => action.onClick(row)}
+                            disabled={action.disabled?.(row)}
+                            title={action.label}
+                            aria-label={action.label}
+                            className={cn(
+                              "inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                              "disabled:pointer-events-none disabled:opacity-50",
+                              action.variant === "danger"
+                                ? "text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                                : "text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                            )}
+                          >
+                            {action.icon}
+                            <span className="hidden lg:inline">{action.label}</span>
+                          </button>
+                        ))}
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile stacked cards */}
+      <div className="flex flex-col divide-y divide-gray-100 dark:divide-gray-700 sm:hidden bg-white dark:bg-gray-900">
+        {loading ? (
+          <div className="py-12 text-center text-gray-400">
+            <Loader2 size={28} className="mx-auto animate-spin" />
+          </div>
+        ) : data.length === 0 ? (
+          <div className="py-12 text-center text-sm text-gray-400">{emptyMessage}</div>
+        ) : (
+          data.map((row) => (
+            <div key={row.id} className={cn("p-4 space-y-2", selectedIds?.has(row.id) && "bg-brand-50 dark:bg-brand-900/20")}>
+              {selectable && (
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds?.has(row.id) ?? false}
+                    onChange={() => toggleRow(row.id)}
+                    aria-label={`Select row ${row.id}`}
+                    className="accent-brand-600"
+                  />
+                  <span className="text-xs text-gray-400">Select</span>
+                </div>
+              )}
+              {visibleCols.map((col) => (
+                <div key={col.key} className="flex justify-between text-sm">
+                  <span className="font-medium text-gray-500 dark:text-gray-400">{col.header}</span>
+                  <span className="text-gray-900 dark:text-gray-100 text-right">
+                    {col.cell ? col.cell(row) : String((row as Record<string, unknown>)[col.key] ?? "")}
+                  </span>
+                </div>
+              ))}
+              {rowActions && rowActions.length > 0 && (
+                <div className="flex gap-2 pt-1">
+                  {rowActions.map((action) => (
+                    <button
+                      key={action.label}
+                      type="button"
+                      onClick={() => action.onClick(row)}
+                      disabled={action.disabled?.(row)}
+                      className={cn(
+                        "flex-1 rounded-md py-1.5 text-xs font-medium border transition-colors",
+                        "disabled:pointer-events-none disabled:opacity-50",
+                        action.variant === "danger"
+                          ? "border-red-200 text-red-600 hover:bg-red-50"
+                          : "border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300"
+                      )}
+                    >
+                      {action.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages !== undefined && totalPages > 1 && (
+        <div className="flex items-center justify-between border-t border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 text-sm">
+          <span className="text-gray-500 dark:text-gray-400">
+            Page {page} of {totalPages}
+            {total !== undefined && ` · ${total} total`}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => onPageChange?.(page - 1)}
+              disabled={page <= 1}
+              aria-label="Previous page"
+              className="rounded p-1.5 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:pointer-events-none disabled:opacity-40"
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <button
+              type="button"
+              onClick={() => onPageChange?.(page + 1)}
+              disabled={page >= totalPages}
+              aria-label="Next page"
+              className="rounded p-1.5 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:pointer-events-none disabled:opacity-40"
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/Table/index.ts
+++ b/packages/app/src/components/Table/index.ts
@@ -1,0 +1,2 @@
+export { Table } from "./Table";
+export type { TableProps, ColumnDef, RowAction, SortDirection } from "./Table";


### PR DESCRIPTION
closes #735 
closes #736 
closes #737 
closes #738 


- Form primitives (Input, Select, Checkbox, Radio, DatePicker, FileUpload) with a11y labels/errors, dark mode, disabled states, and Storybook stories
- Reusable Table component with sorting, server-side pagination, row selection, row actions, mobile stacked layout, empty/loading states, and Storybook stories
- User Dashboard page (/dashboard/user) with ActivityTimeline, SavedWorkers, MessagesPreview, and QuickProfileEdit components
- Curator Console (/curator) with ListingsTable and ListingForm components; create/edit/toggle/delete listings, X-HTTP-Method: PUT image upload pattern, on-chain registration and TTL status badges, optimistic UI