### PR TITLE
feat(search): full-text worker search with ranked results (#747)

### DIFF
--- a/packages/api/prisma/migrations/20260626_issue_747_search_analytics/migration.sql
+++ b/packages/api/prisma/migrations/20260626_issue_747_search_analytics/migration.sql
@@ -1,0 +1,42 @@
+-- Issue #747: Full-Text Worker Search with Ranked Results
+-- Create SearchAnalytics table for search logging
+CREATE TABLE IF NOT EXISTS "SearchAnalytics" (
+  "id"           TEXT          NOT NULL,
+  "query"        TEXT          NOT NULL,
+  "resultsCount" INTEGER       NOT NULL DEFAULT 0,
+  "hasFilters"   BOOLEAN       NOT NULL DEFAULT false,
+  "ipAddress"    TEXT,
+  "createdAt"    TIMESTAMP(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "SearchAnalytics_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "SearchAnalytics_query_idx"    ON "SearchAnalytics"("query");
+CREATE INDEX IF NOT EXISTS "SearchAnalytics_createdAt_idx" ON "SearchAnalytics"("createdAt");
+
+-- Enhance searchVector trigger to also include category name
+-- The trigger joins "Category" to get the name, weight: name=A, bio=B, category=C
+CREATE OR REPLACE FUNCTION worker_search_vector_update() RETURNS trigger AS $$
+DECLARE
+  cat_name TEXT;
+BEGIN
+  SELECT name INTO cat_name FROM "Category" WHERE id = NEW."categoryId";
+  NEW."searchVector" := setweight(to_tsvector('simple', coalesce(NEW.name, '')), 'A')
+                     || setweight(to_tsvector('simple', coalesce(NEW.bio, '')),  'B')
+                     || setweight(to_tsvector('simple', coalesce(cat_name, '')), 'C');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Re-populate existing rows with weighted vectors
+UPDATE "Worker" w
+SET "searchVector" = setweight(to_tsvector('simple', coalesce(w.name, '')), 'A')
+                  || setweight(to_tsvector('simple', coalesce(w.bio,  '')), 'B')
+                  || setweight(to_tsvector('simple', coalesce(c.name, '')), 'C')
+FROM "Category" c
+WHERE c.id = w."categoryId";
+
+DROP TRIGGER IF EXISTS worker_search_vector_trigger ON "Worker";
+CREATE TRIGGER worker_search_vector_trigger
+  BEFORE INSERT OR UPDATE OF name, bio, "categoryId"
+  ON "Worker"
+  FOR EACH ROW EXECUTE FUNCTION worker_search_vector_update();

--- a/packages/api/src/controllers/workers.ts
+++ b/packages/api/src/controllers/workers.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express'
 import * as workerService from '../services/worker.service.js'
+import { searchWorkers } from '../services/search.service.js'
 import { handleError } from '../utils/handleError.js'
 import { db } from '../db.js'
 import { WorkerResource, WorkerCollection } from '../resources/index.js'
@@ -306,6 +307,42 @@ export async function listMyWorkers(req: Request, res: Response) {
     status: 'success',
     code: 200,
   })
+}
+
+/**
+ * GET /api/workers/search
+ * Full-text worker search with ranked results, geo radius, rating, and availability filters.
+ * Issue #747
+ */
+export async function searchWorkersHandler(req: Request, res: Response) {
+  try {
+    const {
+      q, query, lang, lat, lng, radius,
+      categories, minRating, maxRating,
+      dayOfWeek, isVerified, sortBy,
+      page = '1', limit = '20',
+    } = req.query
+
+    const result = await searchWorkers({
+      query: (q || query) ? String(q ?? query) : undefined,
+      lang: lang ? String(lang) : undefined,
+      lat: lat ? Number(lat) : undefined,
+      lng: lng ? Number(lng) : undefined,
+      radius: radius ? Number(radius) : undefined,
+      categories: categories ? String(categories).split(',').map(c => c.trim()).filter(Boolean) : undefined,
+      minRating: minRating ? Number(minRating) : undefined,
+      maxRating: maxRating ? Number(maxRating) : undefined,
+      dayOfWeek: dayOfWeek !== undefined ? Number(dayOfWeek) : undefined,
+      isVerified: isVerified !== undefined ? isVerified === 'true' : undefined,
+      sortBy: sortBy as any,
+      page: Number(page),
+      limit: Math.min(Math.max(Number(limit) || 20, 1), 100),
+    }, req.ip)
+
+    return res.json({ ...result, status: 'success', code: 200 })
+  } catch (error) {
+    return handleError(res, error)
+  }
 }
 
 /**

--- a/packages/api/src/routes/workers.ts
+++ b/packages/api/src/routes/workers.ts
@@ -11,6 +11,7 @@ import {
   deleteWorker,
   toggleActivation,
   advancedSearch,
+  searchWorkersHandler,
   getReputation,
   syncReputation,
 } from '../controllers/workers.js'
@@ -55,6 +56,7 @@ async function showWorkerWithRatings(req: Request, res: Response) {
 }
 
 router.get('/', generalRateLimit, cacheMiddleware(TTL.SHORT), listWorkers)
+router.get('/search', generalRateLimit, cacheMiddleware(TTL.SHORT), searchWorkersHandler)
 router.get('/search/advanced', generalRateLimit, cacheMiddleware(TTL.SHORT), advancedSearch)
 router.get('/mine', authenticate, authorize('curator', 'admin'), listMyWorkers)
 router.get('/mine', withAuth(['curator', 'admin']), listMyWorkers)

--- a/packages/api/src/services/search.service.ts
+++ b/packages/api/src/services/search.service.ts
@@ -1,0 +1,243 @@
+/**
+ * Issue #747: Full-Text Worker Search Service
+ *
+ * PostgreSQL full-text search across worker name, bio, and category using
+ * tsvector/tsquery with ts_rank relevance ordering, geo radius filtering,
+ * rating/availability filters, and search analytics logging.
+ */
+
+import { db } from '../db.js'
+
+const VALID_LANG_CONFIGS = new Set([
+  'simple', 'english', 'french', 'german', 'spanish',
+  'portuguese', 'italian', 'dutch', 'russian', 'arabic',
+])
+
+function safeLang(lang?: string): string {
+  const l = (lang ?? 'simple').toLowerCase()
+  return VALID_LANG_CONFIGS.has(l) ? l : 'simple'
+}
+
+export interface SearchFilters {
+  query?: string
+  lang?: string
+  lat?: number
+  lng?: number
+  radius?: number       // km, default 10
+  categories?: string[]
+  minRating?: number
+  maxRating?: number
+  dayOfWeek?: number
+  available?: boolean
+  isVerified?: boolean
+  sortBy?: 'relevance' | 'rating' | 'distance' | 'newest'
+  page?: number
+  limit?: number
+}
+
+export interface SearchResult {
+  data: Array<Record<string, unknown> & {
+    rank?: number
+    distanceKm?: number
+    highlight?: { name: string | null; bio: string | null }
+  }>
+  meta: { total: number; page: number; limit: number; pages: number }
+}
+
+/**
+ * Full-text search with ranked results, geo filtering, and analytics logging.
+ */
+export async function searchWorkers(filters: SearchFilters, ipAddress?: string): Promise<SearchResult> {
+  const {
+    query,
+    lang,
+    lat,
+    lng,
+    radius = 10,
+    categories,
+    minRating,
+    maxRating,
+    dayOfWeek,
+    isVerified,
+    sortBy = 'relevance',
+    page = 1,
+    limit = 20,
+  } = filters
+
+  const safeLangVal = safeLang(lang)
+  const limitNum = Math.min(Math.max(limit, 1), 100)
+  const pageNum = Math.max(page, 1)
+  const offset = (pageNum - 1) * limitNum
+
+  // Build dynamic WHERE clauses
+  const clauses: string[] = ['w."isActive" = true', 'w."deletedAt" IS NULL']
+  const params: unknown[] = []
+  let pi = 1
+
+  const p = (val: unknown): string => {
+    params.push(val)
+    return '$' + pi++
+  }
+
+  // Full-text search
+  const hasFts = query && query.trim()
+  if (hasFts) {
+    const qp = p(query!.trim())
+    const lp = p(safeLangVal)
+    clauses.push(`w."searchVector" @@ websearch_to_tsquery(${lp}::regconfig, ${qp})`)
+  }
+
+  if (categories && categories.length > 0) {
+    const placeholders = categories.map(c => p(c)).join(', ')
+    clauses.push(`w."categoryId" IN (${placeholders})`)
+  }
+
+  if (isVerified !== undefined) {
+    clauses.push(`w."isVerified" = ${p(isVerified)}`)
+  }
+
+  if (minRating !== undefined) {
+    clauses.push(
+      `(SELECT AVG(rv.rating) FROM "Review" rv WHERE rv."workerId" = w.id) >= ${p(minRating)}`
+    )
+  }
+
+  if (maxRating !== undefined) {
+    clauses.push(
+      `(SELECT AVG(rv.rating) FROM "Review" rv WHERE rv."workerId" = w.id) <= ${p(maxRating)}`
+    )
+  }
+
+  if (dayOfWeek !== undefined) {
+    clauses.push(
+      `EXISTS (SELECT 1 FROM "Availability" av WHERE av."workerId" = w.id AND av."dayOfWeek" = ${p(dayOfWeek)})`
+    )
+  }
+
+  // Geo bounding-box pre-filter (exact haversine done in-app)
+  if (lat !== undefined && lng !== undefined) {
+    const delta = radius / 111
+    clauses.push(`loc.lat BETWEEN ${p(lat - delta)} AND ${p(lat + delta)}`)
+    clauses.push(`loc.lng BETWEEN ${p(lng - delta)} AND ${p(lng + delta)}`)
+  }
+
+  const whereSQL = clauses.join('\n  AND ')
+
+  // Build SELECT / ORDER depending on FTS
+  let rankExpr = '0::float AS rank'
+  let nameHL = 'w.name AS "nameHighlight"'
+  let bioHL = `coalesce(w.bio, '') AS "bioHighlight"`
+  let orderExpr = 'w."createdAt" DESC'
+
+  if (hasFts) {
+    // params[0]=query, params[1]=lang already set above (indices 1 and 2 in SQL)
+    const qIdx = 1
+    const lIdx = 2
+    const tsq = `websearch_to_tsquery($${lIdx}::regconfig, $${qIdx})`
+    rankExpr = `ts_rank(w."searchVector", ${tsq}) AS rank`
+    nameHL = `ts_headline($${lIdx}::regconfig, w.name, ${tsq}, 'StartSel=<mark>, StopSel=</mark>') AS "nameHighlight"`
+    bioHL  = `ts_headline($${lIdx}::regconfig, coalesce(w.bio, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=2, MaxWords=15, MinWords=5') AS "bioHighlight"`
+
+    if (sortBy === 'relevance') {
+      orderExpr = 'rank DESC'
+    }
+  }
+
+  if (sortBy === 'rating') orderExpr = '(SELECT AVG(rv.rating) FROM "Review" rv WHERE rv."workerId" = w.id) DESC NULLS LAST'
+  if (sortBy === 'newest') orderExpr = 'w."createdAt" DESC'
+
+  const limitParam = p(limitNum)
+  const offsetParam = p(offset)
+
+  const dataSQL = `
+SELECT
+  w.*,
+  ${rankExpr},
+  ${nameHL},
+  ${bioHL},
+  row_to_json(c.*)   AS category,
+  row_to_json(u.*)   AS curator,
+  row_to_json(loc.*) AS location
+FROM "Worker" w
+LEFT JOIN "Category" c   ON c.id   = w."categoryId"
+LEFT JOIN "User"     u   ON u.id   = w."curatorId"
+LEFT JOIN "Location" loc ON loc.id = w."locationId"
+WHERE ${whereSQL}
+ORDER BY ${orderExpr}
+LIMIT ${limitParam} OFFSET ${offsetParam}
+`
+
+  const countSQL = `
+SELECT COUNT(*) AS count
+FROM "Worker" w
+LEFT JOIN "Location" loc ON loc.id = w."locationId"
+WHERE ${whereSQL}
+`
+
+  const [rows, countResult] = await Promise.all([
+    db.$queryRawUnsafe<Record<string, unknown>[]>(dataSQL, ...params),
+    db.$queryRawUnsafe<[{ count: bigint }]>(
+      countSQL,
+      ...params.slice(0, params.length - 2) // strip limit/offset from count query
+    ),
+  ])
+
+  // Apply exact haversine geo filter post-query
+  let results = rows
+  if (lat !== undefined && lng !== undefined) {
+    results = rows.filter(row => {
+      const loc = row['location'] as any
+      if (!loc?.lat || !loc?.lng) return false
+      const dist = haversine(lat, lng, loc.lat, loc.lng)
+      ;(row as any)['distanceKm'] = dist
+      return dist <= radius
+    })
+    if (sortBy === 'distance') {
+      results.sort((a, b) => ((a as any)['distanceKm'] ?? Infinity) - ((b as any)['distanceKm'] ?? Infinity))
+    }
+  }
+
+  const total = Number(countResult[0]?.count ?? 0)
+
+  // Log search analytics (fire-and-forget)
+  if (query?.trim()) {
+    db.searchAnalytics.create({
+      data: {
+        id: crypto.randomUUID(),
+        query: query.trim(),
+        resultsCount: results.length,
+        hasFilters: !!(categories || lat || minRating !== undefined),
+        ipAddress: ipAddress ?? null,
+      },
+    }).catch(() => {})
+  }
+
+  return {
+    data: results.map(row => ({
+      ...row,
+      highlight: {
+        name: (row['nameHighlight'] as string) ?? null,
+        bio:  (row['bioHighlight']  as string) ?? null,
+      },
+      rank: parseFloat(String(row['rank'] ?? 0)),
+    })),
+    meta: {
+      total,
+      page: pageNum,
+      limit: limitNum,
+      pages: Math.ceil(total / limitNum),
+    },
+  }
+}
+
+function haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371
+  const dLat = ((lat2 - lat1) * Math.PI) / 180
+  const dLon = ((lon2 - lon1) * Math.PI) / 180
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+    Math.cos((lat2 * Math.PI) / 180) *
+    Math.sin(dLon / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}


### PR DESCRIPTION

## Summary

Implements full-text worker search with PostgreSQL tsvector/tsquery, geo radius filtering, relevance ranking, and search analytics logging.

Closes #747

---

## Changes

### Database Migration (`prisma/migrations/20260626_issue_747_search_analytics/`)

- Creates the `SearchAnalytics` table (was defined in schema but had no migration), with indexes on `query` and `createdAt` for efficient analytics queries.
- Upgrades the `worker_search_vector_update` trigger to produce **weighted** tsvectors:
  - `name` → weight **A** (highest relevance)
  - `bio` → weight **B**
  - `category.name` → weight **C**
- Back-fills existing rows with the new weighted vectors.
- Expands the trigger to fire on `categoryId` changes in addition to `name`/`bio`.

### New: `src/services/search.service.ts`

Core search logic extracted into a dedicated service:

- **Full-text search** via `websearch_to_tsquery` (supports natural-language input with `AND`, `OR`, `"phrase"` syntax).
- **`ts_rank` relevance ordering** — results ranked by how well they match across name, bio, and category with field weights respected.
- **`ts_headline` highlights** — matched terms wrapped in `<mark>` tags in both `name` and `bio` fields, returned as `highlight.name` / `highlight.bio`.
- **Multi-language support** — `lang` param maps to a PostgreSQL `regconfig` (e.g. `english`, `portuguese`); invalid values fall back to `simple`.
- **Geo radius filtering** — bounding-box SQL pre-filter (1° ≈ 111 km) followed by exact Haversine in-app filter; results include `distanceKm`.
- **Rating filters** — `minRating` / `maxRating` via aggregate subquery.
- **Availability filter** — `dayOfWeek` via `EXISTS` on the `Availability` table.
- **Sort modes** — `relevance` (default) | `rating` | `distance` | `newest`.
- **Pagination** — `page` / `limit` (max 100).
- **Search analytics** — fire-and-forget `SearchAnalytics.create` logs every query with result count, filter presence, and IP address.

### Updated: `src/controllers/workers.ts`

- Imports `searchWorkers` from `search.service.ts`.
- Adds `searchWorkersHandler` — parses query params (`q`, `lang`, `lat`, `lng`, `radius`, `categories`, `minRating`, `maxRating`, `dayOfWeek`, `isVerified`, `sortBy`, `page`, `limit`) and delegates to the service.

### Updated: `src/routes/workers.ts`

- Registers `GET /api/workers/search` (and `/api/v1/workers/search`, `/api/v2/workers/search` via versioned mounts in `app.ts`) with rate limiting and short-TTL caching.

---

## API Usage


GET /api/v1/workers/search?q=plumber&lat=-23.5&lng=-46.6&radius=15&minRating=4&sortBy=relevance&page=1&limit=20

**Response**
json
{
 "data": [
   {
     "id": "...",
     "name": "João Silva",
     "highlight": { "name": "<mark>plumber</mark>", "bio": "Expert <mark>plumber</mark> with 10 years..." },
     "rank": 0.412,
     "distanceKm": 3.7,
     "category": { "name": "Plumbing" }
   }
 ],
 "meta": { "total": 42, "page": 1, "limit": 20, "pages": 3 },
 "status": "success",
 "code": 200
}

---

## Files Changed

| File | Change |
|------|--------|
| `prisma/migrations/20260626_issue_747_search_analytics/migration.sql` | New migration |
| `src/services/search.service.ts` | New service |
| `src/controllers/workers.ts` | Added `searchWorkersHandler` |
| `src/routes/workers.ts` | Registered `GET /workers/search` |


