### PR TITLE
feat(contracts): #778 add VerificationLevel and CertifiedSkills to re…

### DIFF
--- a/packages/contracts/contracts/registry/src/lib.rs
+++ b/packages/contracts/contracts/registry/src/lib.rs
@@ -24,6 +24,10 @@ use soroban_sdk::{
     Symbol, Vec,
 };
 
+// On-chain reputation scoring design reference (#779).
+#[cfg(doc)]
+mod reputation;
+
 /// Approximate TTL extension target (~1 year at 5 s/ledger).
 const TTL_EXTEND_TO: u32 = 535_000;
 /// Extend TTL only when it drops below this threshold (~6 months).
@@ -210,6 +214,34 @@ pub struct Badge {
     pub active: bool,
 }
 
+/// Verification level for a worker (#778).
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum VerificationLevel {
+    /// No verification — default state.
+    None = 0,
+    /// Identity checked by a curator.
+    Basic = 1,
+    /// Credentials and category skills verified.
+    Verified = 2,
+    /// Expert-level — multiple verified credentials and peer reviews.
+    Expert = 3,
+}
+
+/// A certified skill entry for a worker (#778).
+#[contracttype]
+#[derive(Clone)]
+pub struct CertifiedSkill {
+    /// Skill identifier (e.g., "pipe_fitting", "arc_welding").
+    pub skill: Symbol,
+    /// Curator or admin who certified this skill.
+    pub certified_by: Address,
+    /// Unix timestamp when certification was granted.
+    pub certified_at: u64,
+    /// Unix timestamp when certification expires (0 = no expiry).
+    pub expires_at: u64,
+}
+
 /// A single immutable reputation history entry (#677).
 #[contracttype]
 #[derive(Clone)]
@@ -326,6 +358,10 @@ pub enum DataKey {
     ReputationHistory(Symbol),
     /// Persistent storage — [`ReputationInputs`] keyed by worker id (#677).
     ReputationInputs(Symbol),
+    /// Persistent storage — [`VerificationLevel`] keyed by worker id (#778).
+    VerificationLevel(Symbol),
+    /// Persistent storage — `Vec<CertifiedSkill>` keyed by worker id (#778).
+    CertifiedSkills(Symbol),
 }
 
 // =============================================================================
@@ -2587,6 +2623,180 @@ fn role_to_id_with_env(env: &Env, role: &Symbol) -> u64 {
     /// Get the pending upgrade, if any.
     pub fn get_pending_upgrade(env: Env) -> Option<PendingUpgrade> {
         env.storage().persistent().get(&DataKey::PendingUpgrade)
+    }
+
+    // -------------------------------------------------------------------------
+    // Verification levels & certified skills (#778)
+    // -------------------------------------------------------------------------
+
+    /// Set the verification level for a worker. Admin or curator-manager only.
+    ///
+    /// # Parameters
+    /// - `caller`: Must hold `ROLE_CURATOR_MGR` or `ROLE_ADMIN`; `require_auth()` enforced.
+    /// - `worker_id`: The worker's unique identifier.
+    /// - `level`: The new [`VerificationLevel`] to assign.
+    ///
+    /// # Panics
+    /// - `"Missing role"` if caller lacks the required role.
+    /// - `"Worker not found"` if no worker exists with the given `worker_id`.
+    ///
+    /// # Events
+    /// Emits `("VrfLvlSet", worker_id)` with data `(caller, level as u32)`.
+    pub fn set_verification_level(
+        env: Env,
+        caller: Address,
+        worker_id: Symbol,
+        level: VerificationLevel,
+    ) {
+        let curator_mgr = Self::role_symbol(&env, ROLE_CURATOR_MGR_CACHED);
+        Self::require_role(&env, &curator_mgr, &caller);
+        Self::require_not_paused(&env);
+        assert!(
+            env.storage().persistent().has(&DataKey::Worker(worker_id.clone())),
+            "Worker not found"
+        );
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::VerificationLevel(worker_id.clone()), &level);
+
+        env.events().publish(
+            (symbol_short!("VrfLvlSet"), worker_id),
+            (caller, level as u32),
+        );
+    }
+
+    /// Get the verification level for a worker.
+    ///
+    /// Returns [`VerificationLevel::None`] if no level has been set.
+    pub fn get_verification_level(env: Env, worker_id: Symbol) -> VerificationLevel {
+        env.storage()
+            .persistent()
+            .get(&DataKey::VerificationLevel(worker_id))
+            .unwrap_or(VerificationLevel::None)
+    }
+
+    /// Add or update a certified skill for a worker. Admin or curator-manager only.
+    ///
+    /// Replaces an existing entry for the same `skill` symbol. Appends if new.
+    ///
+    /// # Parameters
+    /// - `caller`: Must hold `ROLE_CURATOR_MGR` or `ROLE_ADMIN`.
+    /// - `worker_id`: The worker's unique identifier.
+    /// - `skill`: Skill symbol (e.g., `Symbol::new(&env, "arc_welding")`).
+    /// - `expires_at`: Unix timestamp when the cert expires (0 = no expiry).
+    ///
+    /// # Panics
+    /// - `"Missing role"` if caller lacks the required role.
+    /// - `"Worker not found"` if no worker exists with the given `worker_id`.
+    ///
+    /// # Events
+    /// Emits `("SkillCert", worker_id, skill)` with data `(caller, expires_at)`.
+    pub fn add_certified_skill(
+        env: Env,
+        caller: Address,
+        worker_id: Symbol,
+        skill: Symbol,
+        expires_at: u64,
+    ) {
+        let curator_mgr = Self::role_symbol(&env, ROLE_CURATOR_MGR_CACHED);
+        Self::require_role(&env, &curator_mgr, &caller);
+        Self::require_not_paused(&env);
+        assert!(
+            env.storage().persistent().has(&DataKey::Worker(worker_id.clone())),
+            "Worker not found"
+        );
+
+        let now = env.ledger().timestamp();
+        let entry = CertifiedSkill {
+            skill: skill.clone(),
+            certified_by: caller.clone(),
+            certified_at: now,
+            expires_at,
+        };
+
+        let mut skills: Vec<CertifiedSkill> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertifiedSkills(worker_id.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        // Replace existing entry for the same skill, or append.
+        let mut found = false;
+        let mut updated: Vec<CertifiedSkill> = Vec::new(&env);
+        for s in skills.iter() {
+            if s.skill == skill {
+                updated.push_back(entry.clone());
+                found = true;
+            } else {
+                updated.push_back(s);
+            }
+        }
+        if !found {
+            updated.push_back(entry);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::CertifiedSkills(worker_id.clone()), &updated);
+
+        env.events().publish(
+            (symbol_short!("SkillCert"), worker_id, skill),
+            (caller, expires_at),
+        );
+    }
+
+    /// Revoke a certified skill from a worker. Admin or curator-manager only.
+    ///
+    /// # Panics
+    /// - `"Missing role"` if caller lacks the required role.
+    /// - `"Skill not found"` if the skill is not in the worker's certified list.
+    ///
+    /// # Events
+    /// Emits `("SkillRvkd", worker_id, skill)` with data `caller`.
+    pub fn revoke_certified_skill(
+        env: Env,
+        caller: Address,
+        worker_id: Symbol,
+        skill: Symbol,
+    ) {
+        let curator_mgr = Self::role_symbol(&env, ROLE_CURATOR_MGR_CACHED);
+        Self::require_role(&env, &curator_mgr, &caller);
+        Self::require_not_paused(&env);
+
+        let skills: Vec<CertifiedSkill> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertifiedSkills(worker_id.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        let mut updated: Vec<CertifiedSkill> = Vec::new(&env);
+        let mut removed = false;
+        for s in skills.iter() {
+            if s.skill == skill {
+                removed = true;
+            } else {
+                updated.push_back(s);
+            }
+        }
+        assert!(removed, "Skill not found");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::CertifiedSkills(worker_id.clone()), &updated);
+
+        env.events().publish(
+            (symbol_short!("SkillRvkd"), worker_id, skill),
+            caller,
+        );
+    }
+
+    /// Get all certified skills for a worker.
+    pub fn get_certified_skills(env: Env, worker_id: Symbol) -> Vec<CertifiedSkill> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CertifiedSkills(worker_id))
+            .unwrap_or(Vec::new(&env))
     }
 }
 

--- a/packages/contracts/contracts/registry/src/test.rs
+++ b/packages/contracts/contracts/registry/src/test.rs
@@ -537,3 +537,160 @@ mod security_regression {
         f.client().propose_upgrade(&f.admin, &hash);
     }
 }
+
+// ===========================================================================
+// 6. Verification levels & certified skills (#778)
+// ===========================================================================
+
+mod verification_levels {
+    use super::*;
+
+    fn setup() -> UpgradeFixture {
+        let f = UpgradeFixture::new();
+        f.client().add_curator(&f.admin, &f.curator);
+        f
+    }
+
+    #[test]
+    fn set_and_get_verification_level() {
+        let f = setup();
+        let id = f.register("worker1");
+
+        assert_eq!(
+            f.client().get_verification_level(&id),
+            VerificationLevel::None
+        );
+
+        f.client()
+            .set_verification_level(&f.admin, &id, &VerificationLevel::Verified);
+
+        assert_eq!(
+            f.client().get_verification_level(&id),
+            VerificationLevel::Verified
+        );
+    }
+
+    #[test]
+    fn set_verification_level_can_upgrade_and_downgrade() {
+        let f = setup();
+        let id = f.register("w1");
+
+        f.client()
+            .set_verification_level(&f.admin, &id, &VerificationLevel::Expert);
+        assert_eq!(
+            f.client().get_verification_level(&id),
+            VerificationLevel::Expert
+        );
+
+        f.client()
+            .set_verification_level(&f.admin, &id, &VerificationLevel::Basic);
+        assert_eq!(
+            f.client().get_verification_level(&id),
+            VerificationLevel::Basic
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Missing role")]
+    fn set_verification_level_requires_curator_mgr() {
+        let f = setup();
+        let id = f.register("w1");
+        let stranger = Address::generate(&f.env);
+        f.client()
+            .set_verification_level(&stranger, &id, &VerificationLevel::Basic);
+    }
+
+    #[test]
+    #[should_panic(expected = "Worker not found")]
+    fn set_verification_level_unknown_worker_panics() {
+        let f = setup();
+        let bad_id = Symbol::new(&f.env, "nobody");
+        f.client()
+            .set_verification_level(&f.admin, &bad_id, &VerificationLevel::Basic);
+    }
+
+    #[test]
+    fn add_certified_skill_stores_and_queryable() {
+        let f = setup();
+        let id = f.register("w1");
+        let skill = Symbol::new(&f.env, "arc_welding");
+
+        f.client().add_certified_skill(&f.admin, &id, &skill, &0);
+
+        let skills = f.client().get_certified_skills(&id);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills.get(0).unwrap().skill, skill);
+    }
+
+    #[test]
+    fn add_certified_skill_replaces_existing() {
+        let f = setup();
+        let id = f.register("w1");
+        let skill = Symbol::new(&f.env, "pipe_fitting");
+
+        f.client().add_certified_skill(&f.admin, &id, &skill, &0);
+        f.client().add_certified_skill(&f.admin, &id, &skill, &9999);
+
+        let skills = f.client().get_certified_skills(&id);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills.get(0).unwrap().expires_at, 9999);
+    }
+
+    #[test]
+    fn add_multiple_distinct_skills() {
+        let f = setup();
+        let id = f.register("w1");
+
+        f.client()
+            .add_certified_skill(&f.admin, &id, &Symbol::new(&f.env, "skill_a"), &0);
+        f.client()
+            .add_certified_skill(&f.admin, &id, &Symbol::new(&f.env, "skill_b"), &0);
+
+        assert_eq!(f.client().get_certified_skills(&id).len(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Missing role")]
+    fn add_certified_skill_requires_curator_mgr() {
+        let f = setup();
+        let id = f.register("w1");
+        let stranger = Address::generate(&f.env);
+        f.client().add_certified_skill(
+            &stranger,
+            &id,
+            &Symbol::new(&f.env, "skill_a"),
+            &0,
+        );
+    }
+
+    #[test]
+    fn revoke_certified_skill_removes_entry() {
+        let f = setup();
+        let id = f.register("w1");
+        let skill = Symbol::new(&f.env, "arc_welding");
+
+        f.client().add_certified_skill(&f.admin, &id, &skill, &0);
+        f.client().revoke_certified_skill(&f.admin, &id, &skill);
+
+        assert_eq!(f.client().get_certified_skills(&id).len(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Skill not found")]
+    fn revoke_nonexistent_skill_panics() {
+        let f = setup();
+        let id = f.register("w1");
+        f.client().revoke_certified_skill(
+            &f.admin,
+            &id,
+            &Symbol::new(&f.env, "nonexistent"),
+        );
+    }
+
+    #[test]
+    fn get_certified_skills_empty_for_new_worker() {
+        let f = setup();
+        let id = f.register("w1");
+        assert_eq!(f.client().get_certified_skills(&id).len(), 0);
+    }
+}


### PR DESCRIPTION
…gistry

- Add VerificationLevel enum (None/Basic/Verified/Expert)
- Add CertifiedSkill struct with expiry tracking
- Add DataKey::VerificationLevel and DataKey::CertifiedSkills
- Add set/get_verification_level (ROLE_CURATOR_MGR gated)
- Add add_certified_skill, revoke_certified_skill, get_certified_skills
- Emit VrfLvlSet, SkillCert, SkillRvkd events
- Add 11 tests covering CRUD, auth guards, and edge cases

## Summary

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the issue this PR addresses using "Closes #123". -->

Closes #

## Type of Change

<!-- Check the box that applies. -->

- [ ] feat — New feature
- [ ] fix — Bug fix
- [ ] docs — Documentation
- [ ] refactor — Code restructuring (no functional change)
- [ ] test — Adding or updating tests
- [ ] chore — Build, deps, tooling
- [ ] i18n — Translations / localization
- [ ] Breaking change (include `!` in commit title)

## Checklist

<!-- Verify that you've done the following before requesting review. -->

### General

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Changes are limited to a single scope (commit at a time)
- [ ] Branch is up to date with `main`

### Code Quality

- [ ] Linter passes (`pnpm lint`)
- [ ] Type checks pass (`pnpm type-check` or `pnpm build`)
- [ ] Tests pass (`pnpm test -- --run`)
- [ ] No new warnings introduced

### API (if applicable)

- [ ] Prisma migrations are included or not needed
- [ ] Destructive migrations are labelled `migration:destructive`

### Contracts (if applicable)

- [ ] `make clippy` passes with zero warnings
- [ ] `make fmt` has been run
- [ ] All contract tests pass (`make test`)

### App / Frontend (if applicable)

- [ ] Component tests pass
- [ ] No accessibility violations introduced

### Documentation (if applicable)

- [ ] Related docs are updated (README, docs/, JSDoc)
- [ ] Translation files are in sync with `en.json`

## Screenshots (if applicable)

<!-- Add screenshots to help reviewers understand visual changes. -->

## Additional Notes

<!-- Anything reviewers should know: testing instructions, edge cases, follow-up work. -->


closes #780
closes #779 
closes #778 
closes #777 
