### PR TITLE
Worker Insights & Earnings Dashboard FIXED

### DIFF
--- a/packages/api/prisma/migrations/20260629_worker_personal_analytics/migration.sql
+++ b/packages/api/prisma/migrations/20260629_worker_personal_analytics/migration.sql
@@ -1,0 +1,14 @@
+-- Issue: per-worker personal analytics dashboard
+CREATE TABLE "WorkerTipEvent" (
+    "id" TEXT NOT NULL,
+    "workerId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "txHash" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WorkerTipEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "WorkerTipEvent_workerId_createdAt_idx" ON "WorkerTipEvent"("workerId", "createdAt");
+
+ALTER TABLE "WorkerTipEvent" ADD CONSTRAINT "WorkerTipEvent_workerId_fkey" FOREIGN KEY ("workerId") REFERENCES "Worker"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -75,6 +75,7 @@ model User {
   messagesSent                Message[]
   initiatedConversations      Conversation[]           @relation("ConversationInitiator")
   stellarAccounts             StellarAccount[]
+  bookingRequests             Booking[]              @relation("BookingRequester")
 }
 
 model Category {
@@ -129,6 +130,8 @@ model Worker {
   jobApplications     JobApplication[]
   profileViews        ProfileView[]
   analytics           WorkerAnalytics?
+  tipEvents           WorkerTipEvent[]
+  bookings            Booking[]
 
   @@index([isActive, categoryId])
   @@index([curatorId])
@@ -456,6 +459,17 @@ model ProfileView {
   worker    Worker   @relation(fields: [workerId], references: [id], onDelete: Cascade)
 
   @@index([workerId, ip, viewedAt])
+}
+
+model WorkerTipEvent {
+  id        String   @id @default(cuid())
+  workerId  String
+  amount    Float
+  txHash    String?
+  createdAt DateTime @default(now())
+  worker    Worker   @relation(fields: [workerId], references: [id], onDelete: Cascade)
+
+  @@index([workerId, createdAt])
 }
 
 model WorkerAnalytics {
@@ -840,6 +854,8 @@ enum BookingStatus {
   confirmed
   cancelled
   completed
+}
+
 // ─── Issue #749: Device & Session Management ─────────────────────────────────
 
 model Device {

--- a/packages/api/src/controllers/analytics.ts
+++ b/packages/api/src/controllers/analytics.ts
@@ -2,10 +2,15 @@ import type { Request, Response } from 'express'
 import * as analyticsService from '../services/analytics.service.js'
 import { handleError } from '../utils/handleError.js'
 
+function routeId(req: Request): string {
+  return String(req.params.id)
+}
+
 /** GET /api/workers/:id/analytics — curator or admin only */
 export async function getAnalytics(req: Request, res: Response) {
   try {
-    const data = await analyticsService.getWorkerAnalytics(req.params.id)
+    await analyticsService.assertCanAccessWorkerAnalytics(routeId(req), req.user!.id, req.user!.role)
+    const data = await analyticsService.getWorkerAnalytics(routeId(req))
     return res.json({ data, status: 'success', code: 200 })
   } catch (err) {
     return handleError(res, err)
@@ -16,7 +21,7 @@ export async function getAnalytics(req: Request, res: Response) {
 export async function trackView(req: Request, res: Response) {
   try {
     const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.socket.remoteAddress ?? 'unknown'
-    await analyticsService.recordProfileView(req.params.id, ip)
+    await analyticsService.recordProfileView(routeId(req), ip)
     return res.json({ status: 'success', code: 200 })
   } catch (err) {
     return handleError(res, err)
@@ -26,9 +31,36 @@ export async function trackView(req: Request, res: Response) {
 /** GET /api/workers/:id/analytics/trends — view trends over N days */
 export async function getViewTrends(req: Request, res: Response) {
   try {
+    await analyticsService.assertCanAccessWorkerAnalytics(routeId(req), req.user!.id, req.user!.role)
     const days = Math.min(Number(req.query.days) || 30, 90)
-    const data = await analyticsService.getWorkerViewTrends(req.params.id, days)
+    const data = await analyticsService.getWorkerViewTrends(routeId(req), days)
     return res.json({ data, status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}
+
+/** GET /api/workers/:id/analytics/dashboard — personal dashboard metrics */
+export async function getWorkerPersonalDashboard(req: Request, res: Response) {
+  try {
+    await analyticsService.assertCanAccessWorkerAnalytics(routeId(req), req.user!.id, req.user!.role)
+    const range = analyticsService.parseAnalyticsDateRange(req.query)
+    const data = await analyticsService.getWorkerPersonalDashboard(routeId(req), range)
+    return res.json({ data, status: 'success', code: 200 })
+  } catch (err) {
+    return handleError(res, err)
+  }
+}
+
+/** GET /api/workers/:id/analytics/export — CSV export for one worker */
+export async function exportWorkerPersonalCsv(req: Request, res: Response) {
+  try {
+    await analyticsService.assertCanAccessWorkerAnalytics(routeId(req), req.user!.id, req.user!.role)
+    const range = analyticsService.parseAnalyticsDateRange(req.query)
+    const csv = await analyticsService.exportPersonalWorkerAnalyticsCsv(routeId(req), range)
+    res.setHeader('Content-Type', 'text/csv')
+    res.setHeader('Content-Disposition', `attachment; filename="worker-${routeId(req)}-analytics.csv"`)
+    return res.send(csv)
   } catch (err) {
     return handleError(res, err)
   }

--- a/packages/api/src/routes/workers.ts
+++ b/packages/api/src/routes/workers.ts
@@ -21,7 +21,7 @@ import { getAvailability, upsertAvailability, addAvailabilitySlot, deleteAvailab
 import { registerOnChain } from '../controllers/stellar.js'
 import { createContactRequest, getContactRequests, updateContactRequestStatus } from '../controllers/contact-request.js'
 import { getWorkerVerifications } from '../controllers/verifications.js'
-import { getAnalytics, trackView, getViewTrends } from '../controllers/analytics.js'
+import { getAnalytics, trackView, getViewTrends, getWorkerPersonalDashboard, exportWorkerPersonalCsv } from '../controllers/analytics.js'
 import { authenticate, authorize } from '../middleware/auth.js'
 import { validate } from '../middleware/validate.js'
 import { withAuth, withAuthAndValidation } from '../middleware/composition.js'
@@ -107,6 +107,8 @@ router.get('/:id/verifications', withAuth(['curator', 'admin']), getWorkerVerifi
 
 // Analytics
 router.post('/:id/analytics/view', trackView)
+router.get('/:id/analytics/dashboard', authenticate, authorize('curator', 'admin'), getWorkerPersonalDashboard)
+router.get('/:id/analytics/export', authenticate, authorize('curator', 'admin'), exportWorkerPersonalCsv)
 router.get('/:id/analytics', authenticate, authorize('curator', 'admin'), getAnalytics)
 router.get('/:id/analytics/trends', authenticate, authorize('curator', 'admin'), getViewTrends)
 router.get('/:id/analytics', withAuth(['curator', 'admin']), getAnalytics)

--- a/packages/api/src/services/analytics.service.ts
+++ b/packages/api/src/services/analytics.service.ts
@@ -1,6 +1,22 @@
 import { db } from '../db.js'
 import { AppError } from './AppError.js'
 
+type DateRange = {
+  startDate?: Date
+  endDate?: Date
+}
+
+type TimeSeriesPoint = {
+  date: string
+  views: number
+  uniqueViews: number
+  tips: number
+  tipCount: number
+  avgRating: number | null
+  reviewCount: number
+  earnings: number
+}
+
 // ── Recording helpers ────────────────────────────────────────────────────────
 
 export async function recordProfileView(workerId: string, ip: string) {
@@ -28,12 +44,19 @@ export async function recordProfileView(workerId: string, ip: string) {
   }
 }
 
-export async function recordTip(workerId: string, amount: number) {
-  await db.workerAnalytics.upsert({
-    where: { workerId },
-    create: { workerId, totalTips: amount, tipCount: 1 },
-    update: { totalTips: { increment: amount }, tipCount: { increment: 1 } },
-  })
+export async function recordTip(workerId: string, amount: number, txHash?: string) {
+  const worker = await db.worker.findUnique({ where: { id: workerId } })
+  if (!worker) throw new AppError('Worker not found', 404)
+  if (!Number.isFinite(amount) || amount <= 0) throw new AppError('Tip amount must be greater than 0', 400)
+
+  await db.$transaction([
+    db.workerAnalytics.upsert({
+      where: { workerId },
+      create: { workerId, totalTips: amount, tipCount: 1 },
+      update: { totalTips: { increment: amount }, tipCount: { increment: 1 } },
+    }),
+    db.workerTipEvent.create({ data: { workerId, amount, txHash } }),
+  ])
 }
 
 export async function updateBookmarkCount(workerId: string, delta: 1 | -1) {
@@ -452,11 +475,262 @@ async function getGrowthData(model: 'user' | 'worker', months: number) {
     const end = new Date(now.getFullYear(), now.getMonth() - i + 1, 1)
     const label = start.toLocaleDateString('en-US', { month: 'short', year: '2-digit' })
 
-    const count = await db[model].count({
-      where: { createdAt: { gte: start, lt: end } },
-    })
+    const count = model === 'user'
+      ? await db.user.count({ where: { createdAt: { gte: start, lt: end } } })
+      : await db.worker.count({ where: { createdAt: { gte: start, lt: end } } })
     data.push({ month: label, count })
   }
 
   return data
+}
+
+// ── Personal worker dashboard analytics ──────────────────────────────────────
+
+export async function assertCanAccessWorkerAnalytics(workerId: string, userId: string, role: string) {
+  const worker = await db.worker.findUnique({
+    where: { id: workerId },
+    select: { id: true, curatorId: true },
+  })
+  if (!worker) throw new AppError('Worker not found', 404)
+  if (role !== 'admin' && worker.curatorId !== userId) throw new AppError('Forbidden', 403)
+  return worker
+}
+
+export function parseAnalyticsDateRange(query: { startDate?: unknown; endDate?: unknown; days?: unknown }): Required<DateRange> {
+  const now = new Date()
+  const endDate = parseDateBoundary(query.endDate, 'end') ?? now
+  const defaultDays = Math.min(Math.max(Number(query.days) || 30, 1), 366)
+  const startDate = parseDateBoundary(query.startDate, 'start') ?? daysBefore(endDate, defaultDays - 1)
+
+  if (startDate > endDate) throw new AppError('startDate must be before or equal to endDate', 400)
+
+  const maxRangeMs = 366 * 24 * 60 * 60 * 1000
+  if (endDate.getTime() - startDate.getTime() > maxRangeMs) {
+    throw new AppError('Date range cannot exceed 366 days', 400)
+  }
+
+  return { startDate, endDate }
+}
+
+export async function getWorkerPersonalDashboard(workerId: string, range: Required<DateRange>) {
+  const worker = await db.worker.findUnique({
+    where: { id: workerId },
+    select: { id: true, name: true, walletAddress: true, category: { select: { name: true } } },
+  })
+  if (!worker) throw new AppError('Worker not found', 404)
+
+  const dateWhere = dateRangeWhere(range)
+  const previous = getPreviousRange(range)
+
+  const [
+    currentViews,
+    previousViews,
+    tipAgg,
+    previousTipAgg,
+    reviewAgg,
+    previousReviewAgg,
+    ratingDistribution,
+    contacts,
+    series,
+  ] = await Promise.all([
+    db.profileView.count({ where: { workerId, viewedAt: dateWhere } }),
+    db.profileView.count({ where: { workerId, viewedAt: dateRangeWhere(previous) } }),
+    db.workerTipEvent.aggregate({ where: { workerId, createdAt: dateWhere }, _sum: { amount: true }, _count: true }),
+    db.workerTipEvent.aggregate({ where: { workerId, createdAt: dateRangeWhere(previous) }, _sum: { amount: true }, _count: true }),
+    db.review.aggregate({ where: { workerId, status: 'approved', createdAt: dateWhere }, _avg: { rating: true }, _count: true }),
+    db.review.aggregate({ where: { workerId, status: 'approved', createdAt: dateRangeWhere(previous) }, _avg: { rating: true }, _count: true }),
+    db.review.groupBy({ by: ['rating'], where: { workerId, status: 'approved', createdAt: dateWhere }, _count: { rating: true }, orderBy: { rating: 'desc' } }),
+    db.contactRequest.count({ where: { workerId, createdAt: dateWhere } }),
+    getWorkerDashboardSeries(workerId, range),
+  ])
+
+  const uniqueViews = await countUniqueViews(workerId, range)
+  const previousUniqueViews = await countUniqueViews(workerId, previous)
+  const earnings = tipAgg._sum.amount ?? 0
+  const previousEarnings = previousTipAgg._sum.amount ?? 0
+
+  return {
+    worker: {
+      id: worker.id,
+      name: worker.name,
+      category: worker.category.name,
+      walletAddress: worker.walletAddress,
+    },
+    range: toRangePayload(range),
+    summary: {
+      totalViews: currentViews,
+      uniqueViews,
+      tipsReceived: earnings,
+      tipCount: tipAgg._count,
+      avgRating: reviewAgg._avg.rating ?? 0,
+      reviewCount: reviewAgg._count,
+      earnings,
+      contacts,
+    },
+    deltas: {
+      totalViews: calcGrowthPct(currentViews, previousViews),
+      uniqueViews: calcGrowthPct(uniqueViews, previousUniqueViews),
+      tipsReceived: calcGrowthPct(earnings, previousEarnings),
+      avgRating: calcRatingDelta(reviewAgg._avg.rating, previousReviewAgg._avg.rating),
+      earnings: calcGrowthPct(earnings, previousEarnings),
+    },
+    charts: {
+      series,
+      ratingDistribution: [5, 4, 3, 2, 1].map((rating) => {
+        const item = ratingDistribution.find((r) => r.rating === rating)
+        return { rating, count: item?._count.rating ?? 0 }
+      }),
+    },
+  }
+}
+
+export async function getWorkerDashboardSeries(workerId: string, range: Required<DateRange>): Promise<TimeSeriesPoint[]> {
+  const worker = await db.worker.findUnique({ where: { id: workerId }, select: { id: true } })
+  if (!worker) throw new AppError('Worker not found', 404)
+
+  const [views, tips, reviews] = await Promise.all([
+    db.profileView.findMany({ where: { workerId, viewedAt: dateRangeWhere(range) }, select: { viewedAt: true, ip: true }, orderBy: { viewedAt: 'asc' } }),
+    db.workerTipEvent.findMany({ where: { workerId, createdAt: dateRangeWhere(range) }, select: { amount: true, createdAt: true }, orderBy: { createdAt: 'asc' } }),
+    db.review.findMany({ where: { workerId, status: 'approved', createdAt: dateRangeWhere(range) }, select: { rating: true, createdAt: true }, orderBy: { createdAt: 'asc' } }),
+  ])
+
+  const dailyMap = buildDailyMap(range)
+
+  for (const view of views) {
+    const key = dayKey(view.viewedAt)
+    const point = dailyMap.get(key)
+    if (point) point.views += 1
+  }
+
+  const uniqueIpsByDay = new Map<string, Set<string>>()
+  for (const view of views) {
+    const key = dayKey(view.viewedAt)
+    if (!uniqueIpsByDay.has(key)) uniqueIpsByDay.set(key, new Set())
+    uniqueIpsByDay.get(key)!.add(view.ip)
+  }
+  for (const [key, ips] of uniqueIpsByDay) {
+    const point = dailyMap.get(key)
+    if (point) point.uniqueViews = ips.size
+  }
+
+  for (const tip of tips) {
+    const key = dayKey(tip.createdAt)
+    const point = dailyMap.get(key)
+    if (point) {
+      point.tips += tip.amount
+      point.earnings += tip.amount
+      point.tipCount += 1
+    }
+  }
+
+  const ratingsByDay = new Map<string, number[]>()
+  for (const review of reviews) {
+    const key = dayKey(review.createdAt)
+    if (!ratingsByDay.has(key)) ratingsByDay.set(key, [])
+    ratingsByDay.get(key)!.push(review.rating)
+  }
+  for (const [key, ratings] of ratingsByDay) {
+    const point = dailyMap.get(key)
+    if (point) {
+      point.reviewCount = ratings.length
+      point.avgRating = ratings.reduce((sum, rating) => sum + rating, 0) / ratings.length
+    }
+  }
+
+  return Array.from(dailyMap.values())
+}
+
+export async function exportPersonalWorkerAnalyticsCsv(workerId: string, range: Required<DateRange>) {
+  const dashboard = await getWorkerPersonalDashboard(workerId, range)
+  const lines = [
+    'Date,Views,Unique Views,Tips (XLM),Tip Count,Average Rating,Review Count,Earnings (XLM)',
+    ...dashboard.charts.series.map((p) => [
+      p.date,
+      p.views,
+      p.uniqueViews,
+      p.tips.toFixed(7),
+      p.tipCount,
+      p.avgRating == null ? '' : p.avgRating.toFixed(2),
+      p.reviewCount,
+      p.earnings.toFixed(7),
+    ].join(',')),
+    '',
+    `Worker,${csvEscape(dashboard.worker.name)}`,
+    `Category,${csvEscape(dashboard.worker.category)}`,
+    `Range,${dashboard.range.startDate} to ${dashboard.range.endDate}`,
+    `Total Views,${dashboard.summary.totalViews}`,
+    `Unique Views,${dashboard.summary.uniqueViews}`,
+    `Tips Received (XLM),${dashboard.summary.tipsReceived.toFixed(7)}`,
+    `Tip Count,${dashboard.summary.tipCount}`,
+    `Average Rating,${dashboard.summary.avgRating.toFixed(2)}`,
+    `Review Count,${dashboard.summary.reviewCount}`,
+    `Earnings (XLM),${dashboard.summary.earnings.toFixed(7)}`,
+  ]
+  return lines.join('\n')
+}
+
+function parseDateBoundary(value: unknown, boundary: 'start' | 'end'): Date | undefined {
+  if (!value) return undefined
+  const date = new Date(String(value))
+  if (Number.isNaN(date.getTime())) throw new AppError(`Invalid ${boundary === 'start' ? 'startDate' : 'endDate'}`, 400)
+  if (boundary === 'start') date.setUTCHours(0, 0, 0, 0)
+  else date.setUTCHours(23, 59, 59, 999)
+  return date
+}
+
+function dateRangeWhere(range: Required<DateRange>) {
+  return { gte: range.startDate, lte: range.endDate }
+}
+
+function daysBefore(anchor: Date, days: number): Date {
+  const d = new Date(anchor)
+  d.setUTCDate(d.getUTCDate() - days)
+  d.setUTCHours(0, 0, 0, 0)
+  return d
+}
+
+function getPreviousRange(range: Required<DateRange>): Required<DateRange> {
+  const duration = range.endDate.getTime() - range.startDate.getTime()
+  const endDate = new Date(range.startDate.getTime() - 1)
+  const startDate = new Date(endDate.getTime() - duration)
+  return { startDate, endDate }
+}
+
+function toRangePayload(range: Required<DateRange>) {
+  return {
+    startDate: dayKey(range.startDate),
+    endDate: dayKey(range.endDate),
+  }
+}
+
+function dayKey(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function buildDailyMap(range: Required<DateRange>): Map<string, TimeSeriesPoint> {
+  const map = new Map<string, TimeSeriesPoint>()
+  const cursor = new Date(range.startDate)
+  cursor.setUTCHours(0, 0, 0, 0)
+  const end = new Date(range.endDate)
+  end.setUTCHours(0, 0, 0, 0)
+
+  while (cursor <= end) {
+    const date = dayKey(cursor)
+    map.set(date, { date, views: 0, uniqueViews: 0, tips: 0, tipCount: 0, avgRating: null, reviewCount: 0, earnings: 0 })
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return map
+}
+
+async function countUniqueViews(workerId: string, range: Required<DateRange>) {
+  const rows = await db.profileView.findMany({
+    where: { workerId, viewedAt: dateRangeWhere(range) },
+    select: { ip: true },
+    distinct: ['ip'],
+  })
+  return rows.length
+}
+
+function calcRatingDelta(current: number | null, previous: number | null): number {
+  return Math.round(((current ?? 0) - (previous ?? 0)) * 10) / 10
 }

--- a/packages/app/src/app/[locale]/dashboard/worker/page.tsx
+++ b/packages/app/src/app/[locale]/dashboard/worker/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Download, Eye, Loader2, Star, TrendingUp, Wallet } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
+import { DashboardTableSkeleton } from "@/components/Skeleton";
+import { cn } from "@/lib/utils";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
+
+type DatePreset = "7" | "30" | "90" | "custom";
+
+type DashboardWorker = {
+  id: string;
+  name: string;
+  isActive: boolean;
+  category: { id: string; name: string };
+};
+
+type SeriesPoint = {
+  date: string;
+  views: number;
+  uniqueViews: number;
+  tips: number;
+  tipCount: number;
+  avgRating: number | null;
+  reviewCount: number;
+  earnings: number;
+};
+
+type PersonalAnalytics = {
+  worker: { id: string; name: string; category: string; walletAddress?: string | null };
+  range: { startDate: string; endDate: string };
+  summary: {
+    totalViews: number;
+    uniqueViews: number;
+    tipsReceived: number;
+    tipCount: number;
+    avgRating: number;
+    reviewCount: number;
+    earnings: number;
+    contacts: number;
+  };
+  deltas: {
+    totalViews: number;
+    uniqueViews: number;
+    tipsReceived: number;
+    avgRating: number;
+    earnings: number;
+  };
+  charts: {
+    series: SeriesPoint[];
+    ratingDistribution: Array<{ rating: number; count: number }>;
+  };
+};
+
+function dateDaysAgo(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() - (days - 1));
+  return date.toISOString().slice(0, 10);
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function formatDateLabel(value: string) {
+  return new Date(value).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatXlm(value: number) {
+  return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM`;
+}
+
+export default function WorkerPersonalDashboardPage() {
+  const { user, token, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const [workers, setWorkers] = useState<DashboardWorker[]>([]);
+  const [selectedWorkerId, setSelectedWorkerId] = useState("");
+  const [preset, setPreset] = useState<DatePreset>("30");
+  const [startDate, setStartDate] = useState(dateDaysAgo(30));
+  const [endDate, setEndDate] = useState(today());
+  const [data, setData] = useState<PersonalAnalytics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && (!user || (user.role !== "curator" && user.role !== "admin"))) {
+      router.replace("/auth/login");
+    }
+  }, [user, authLoading, router]);
+
+  const rangeParams = useMemo(() => {
+    const params = new URLSearchParams({ startDate, endDate });
+    return params.toString();
+  }, [startDate, endDate]);
+
+  const loadWorkers = useCallback(async () => {
+    if (!token) return;
+    const res = await fetch(`${API}/workers/mine?limit=100`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error("Failed to load your workers");
+    const json = await res.json();
+    const rows = json.data ?? [];
+    setWorkers(rows);
+    if (!selectedWorkerId && rows[0]?.id) setSelectedWorkerId(rows[0].id);
+  }, [token, selectedWorkerId]);
+
+  const loadAnalytics = useCallback(async () => {
+    if (!token || !selectedWorkerId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API}/workers/${selectedWorkerId}/analytics/dashboard?${rangeParams}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.message ?? "Failed to load worker analytics");
+      }
+      const json = await res.json();
+      setData(json.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load worker analytics");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [token, selectedWorkerId, rangeParams]);
+
+  useEffect(() => {
+    if (!authLoading && token) {
+      loadWorkers().catch((err) => {
+        setError(err instanceof Error ? err.message : "Failed to load your workers");
+        setLoading(false);
+      });
+    }
+  }, [authLoading, token, loadWorkers]);
+
+  useEffect(() => {
+    if (selectedWorkerId) loadAnalytics();
+  }, [selectedWorkerId, loadAnalytics]);
+
+  const applyPreset = (nextPreset: DatePreset) => {
+    setPreset(nextPreset);
+    if (nextPreset !== "custom") {
+      const days = Number(nextPreset);
+      setStartDate(dateDaysAgo(days));
+      setEndDate(today());
+    }
+  };
+
+  const exportCsv = () => {
+    if (!selectedWorkerId || !token) return;
+    window.open(`${API}/workers/${selectedWorkerId}/analytics/export?${rangeParams}`, "_blank");
+  };
+
+  if (authLoading || (!user && !authLoading)) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-10">
+        <DashboardTableSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10">
+      <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Worker Dashboard</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Personal profile views, tips, ratings, and earnings over time.
+          </p>
+        </div>
+        <button
+          onClick={exportCsv}
+          disabled={!data}
+          className="inline-flex items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+        >
+          <Download size={16} /> Export CSV
+        </button>
+      </div>
+
+      <div className="mb-6 rounded-xl border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Worker
+              <select
+                value={selectedWorkerId}
+                onChange={(event) => setSelectedWorkerId(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+              >
+                {workers.map((worker) => (
+                  <option key={worker.id} value={worker.id}>{worker.name}</option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Start date
+              <input
+                type="date"
+                value={startDate}
+                onChange={(event) => { setPreset("custom"); setStartDate(event.target.value); }}
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+              />
+            </label>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              End date
+              <input
+                type="date"
+                value={endDate}
+                onChange={(event) => { setPreset("custom"); setEndDate(event.target.value); }}
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+              />
+            </label>
+          </div>
+          <div className="flex rounded-lg bg-gray-100 p-1 dark:bg-gray-800">
+            {(["7", "30", "90", "custom"] as DatePreset[]).map((item) => (
+              <button
+                key={item}
+                onClick={() => applyPreset(item)}
+                className={cn(
+                  "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                  preset === item ? "bg-white text-gray-900 shadow-sm dark:bg-gray-950 dark:text-gray-100" : "text-gray-500 hover:text-gray-700 dark:text-gray-400"
+                )}
+              >
+                {item === "custom" ? "Custom" : `${item}D`}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {error && <div className="mb-6 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">{error}</div>}
+
+      {workers.length === 0 && !loading ? (
+        <div className="rounded-xl border bg-white py-16 text-center text-gray-500 dark:border-gray-700 dark:bg-gray-900">
+          Create a worker profile to start collecting dashboard metrics.
+        </div>
+      ) : loading ? (
+        <DashboardTableSkeleton />
+      ) : data ? (
+        <div className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <MetricCard icon={<Eye size={18} />} label="Profile views" value={data.summary.totalViews.toLocaleString()} delta={data.deltas.totalViews} />
+            <MetricCard icon={<TrendingUp size={18} />} label="Unique views" value={data.summary.uniqueViews.toLocaleString()} delta={data.deltas.uniqueViews} />
+            <MetricCard icon={<Wallet size={18} />} label="Tips received" value={formatXlm(data.summary.tipsReceived)} delta={data.deltas.tipsReceived} sub={`${data.summary.tipCount} tips`} />
+            <MetricCard icon={<Star size={18} />} label="Avg rating" value={data.summary.avgRating ? data.summary.avgRating.toFixed(1) : "—"} delta={data.deltas.avgRating} sub={`${data.summary.reviewCount} reviews`} />
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <ChartCard title="Views over time">
+              <ResponsiveContainer width="100%" height={280}>
+                <AreaChart data={data.charts.series}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" tickFormatter={formatDateLabel} fontSize={12} />
+                  <YAxis fontSize={12} />
+                  <Tooltip labelFormatter={(value) => new Date(String(value)).toLocaleDateString()} />
+                  <Area type="monotone" dataKey="views" name="Views" stroke="#2563eb" fill="#dbeafe" />
+                  <Area type="monotone" dataKey="uniqueViews" name="Unique views" stroke="#0891b2" fill="#cffafe" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard title="Tips and earnings">
+              <ResponsiveContainer width="100%" height={280}>
+                <BarChart data={data.charts.series}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" tickFormatter={formatDateLabel} fontSize={12} />
+                  <YAxis fontSize={12} />
+                  <Tooltip labelFormatter={(value) => new Date(String(value)).toLocaleDateString()} />
+                  <Bar dataKey="earnings" name="Earnings (XLM)" fill="#16a34a" radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard title="Ratings trend">
+              <ResponsiveContainer width="100%" height={280}>
+                <LineChart data={data.charts.series}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" tickFormatter={formatDateLabel} fontSize={12} />
+                  <YAxis domain={[0, 5]} fontSize={12} />
+                  <Tooltip labelFormatter={(value) => new Date(String(value)).toLocaleDateString()} />
+                  <Line type="monotone" dataKey="avgRating" name="Average rating" stroke="#f59e0b" strokeWidth={2} connectNulls />
+                </LineChart>
+              </ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard title="Rating distribution">
+              <ResponsiveContainer width="100%" height={280}>
+                <BarChart data={data.charts.ratingDistribution} layout="vertical">
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis type="number" allowDecimals={false} fontSize={12} />
+                  <YAxis type="category" dataKey="rating" tickFormatter={(rating) => `${rating}★`} fontSize={12} />
+                  <Tooltip />
+                  <Bar dataKey="count" name="Reviews" fill="#f59e0b" radius={[0, 4, 4, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </ChartCard>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center justify-center rounded-xl border bg-white py-16 dark:border-gray-700 dark:bg-gray-900">
+          <Loader2 size={24} className="animate-spin text-gray-400" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetricCard({ icon, label, value, delta, sub }: { icon: React.ReactNode; label: string; value: string; delta: number; sub?: string }) {
+  const isPositive = delta > 0;
+  const isNegative = delta < 0;
+  return (
+    <div className="rounded-xl border bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <div className="mb-2 flex items-center gap-2 text-gray-400">
+        {icon}<span className="text-xs font-medium uppercase tracking-wide">{label}</span>
+      </div>
+      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{value}</p>
+      <p className={cn("mt-1 text-xs", isPositive ? "text-green-600" : isNegative ? "text-red-600" : "text-gray-400")}>
+        {delta > 0 ? "+" : ""}{delta}{label === "Avg rating" ? "" : "%"} vs previous period{sub ? ` · ${sub}` : ""}
+      </p>
+    </div>
+  );
+}
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h2>
+      {children}
+    </div>
+  );
+}

--- a/packages/app/src/lib/api.ts
+++ b/packages/app/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   PlatformAnalytics,
   ViewTrend,
   TopWorker,
+  WorkerPersonalDashboard,
 } from "@/types";
 
 const BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
@@ -166,6 +167,16 @@ export const getWorkerAnalytics = (workerId: string) =>
 
 export const getWorkerViewTrends = (workerId: string, days = 30) =>
   request<ApiResponse<ViewTrend[]>>(`/workers/${workerId}/analytics/trends?days=${days}`);
+
+export const getWorkerPersonalDashboard = (workerId: string, params?: { startDate?: string; endDate?: string; days?: number }) => {
+  const qs = params ? `?${new URLSearchParams(Object.entries(params).filter(([, v]) => v !== undefined).map(([k, v]) => [k, String(v)])).toString()}` : "";
+  return request<ApiResponse<WorkerPersonalDashboard>>(`/workers/${workerId}/analytics/dashboard${qs}`);
+};
+
+export const exportWorkerPersonalAnalyticsCsv = (workerId: string, params?: { startDate?: string; endDate?: string; days?: number }) => {
+  const qs = params ? `?${new URLSearchParams(Object.entries(params).filter(([, v]) => v !== undefined).map(([k, v]) => [k, String(v)])).toString()}` : "";
+  return `${BASE}/workers/${workerId}/analytics/export${qs}`;
+};
 
 export const getCuratorAnalytics = () =>
   request<ApiResponse<CuratorAnalytics>>("/analytics/curator");

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -208,6 +208,43 @@ export interface ViewTrend {
   views: number;
 }
 
+export interface WorkerDashboardSeriesPoint {
+  date: string;
+  views: number;
+  uniqueViews: number;
+  tips: number;
+  tipCount: number;
+  avgRating: number | null;
+  reviewCount: number;
+  earnings: number;
+}
+
+export interface WorkerPersonalDashboard {
+  worker: { id: string; name: string; category: string; walletAddress?: string | null };
+  range: { startDate: string; endDate: string };
+  summary: {
+    totalViews: number;
+    uniqueViews: number;
+    tipsReceived: number;
+    tipCount: number;
+    avgRating: number;
+    reviewCount: number;
+    earnings: number;
+    contacts: number;
+  };
+  deltas: {
+    totalViews: number;
+    uniqueViews: number;
+    tipsReceived: number;
+    avgRating: number;
+    earnings: number;
+  };
+  charts: {
+    series: WorkerDashboardSeriesPoint[];
+    ratingDistribution: Array<{ rating: number; count: number }>;
+  };
+}
+
 export interface TopWorker {
   rank: number;
   workerId: string;


### PR DESCRIPTION
Summary
Adds a personal analytics dashboard for workers so a worker owner or admin can view profile views, unique views, tips received, ratings trends, and earnings over time.

This PR implements:

Per-worker analytics aggregation endpoints with date-range filtering.
Per-worker CSV export for dashboard metrics.
Privacy/access control so only the owning curator/worker profile manager or an admin can access a worker’s analytics.
A WorkerTipEvent persistence model and migration so tips/earnings can be charted over time instead of only using lifetime totals.
A new frontend dashboard page at /dashboard/worker with charts for views, tips/earnings, ratings trend, and rating distribution.
Typed API helpers and frontend TypeScript interfaces for the new dashboard response.
Related Issue
Closes #845 

Type of Change
 feat — New feature
 fix — Bug fix
 docs — Documentation
 refactor — Code restructuring (no functional change)
 test — Adding or updating tests
 chore — Build, deps, tooling
 i18n — Translations / localization
 Breaking change (include ! in commit title)
Checklist
General
 PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
 Changes are limited to a single scope (commit at a time)
 Branch is up to date with main
Code Quality
 Linter passes pnpm lint)
 Type checks pass pnpm type-check or pnpm build)
 Tests pass pnpm test -- --run)
 No new warnings introduced in the newly added frontend dashboard lint target
API (if applicable)
 Prisma migrations are included or not needed
 Destructive migrations are labelled migration:destructive — Not applicable; migration is additive only
Contracts (if applicable)
 make clippy passes with zero warnings
 make fmt has been run
 All contract tests pass make test)
App / Frontend (if applicable)
 Component tests pass
 No accessibility violations introduced by obvious static review of new controls/charts
Documentation (if applicable)
 Related docs are updated (README, docs/, JSDoc)
 Translation files are in sync with en.json
Screenshots (if applicable)
Not included. The new dashboard is available at:

/dashboard/worker
It includes:

Metric cards for profile views, unique views, tips, and average rating.
Date-range controls.
Worker selector.
CSV export button.
Charts for views, tips/earnings, ratings trend, and rating distribution.
Additional Notes
New API endpoints
GET /api/workers/:id/analytics/dashboard?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
GET /api/workers/:id/analytics/export?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
Both endpoints require authentication and are restricted to:

The curator who owns the worker profile via worker.curatorId.
Admin users.
Validation performed
The following checks were run successfully:

./node_modules/.bin/prisma validate from packages/api
./node_modules/.bin/prisma generate from packages/api
Isolated TypeScript check for the updated analytics service
npm run lint --prefix packages/app -- --file src/app/[locale]/dashboard/worker/page.tsx
Known repository-level validation blockers
Full repository build checks were attempted, but currently fail on pre-existing issues outside the scope of this PR:

packages/api build fails because src/controllers/auth.test.ts has existing TypeScript syntax errors.
packages/app build fails because next-intl cannot locate the request configuration module at src/i18n/request.{js,jsx,ts,tsx} or an equivalent custom plugin path.
These failures were present outside the implemented worker analytics changes and should be addressed separately.

Files changed
Modified:

packages/api/prisma/schema.prisma
packages/api/src/controllers/analytics.ts
packages/api/src/routes/workers.ts
packages/api/src/services/analytics.service.ts
packages/app/src/lib/api.ts
packages/app/src/types/index.ts
Created:

packages/api/prisma/migrations/20260629_worker_personal_analytics/migration.sql
packages/app/src/app/[locale]/dashboard/worker/page.tsx

Closes #845 