### PR TITLE
test(escrow): E2E coverage for the escrow payment lifecycle

### DIFF
--- a/packages/api/src/__tests__/e2e/escrow.e2e.test.ts
+++ b/packages/api/src/__tests__/e2e/escrow.e2e.test.ts
@@ -1,0 +1,351 @@
+/**
+ * E2E tests for the escrow payment lifecycle using Supertest against the real Express app.
+ * Covers create -> activate -> release, cancel (time-locked), and dispute -> resolve.
+ * Requires a live test database (TEST_DATABASE_URL env var).
+ * Database is seeded/cleaned by testSetup.ts.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest'
+import request from 'supertest'
+import { db } from '../../db.js'
+import app from '../../app.js'
+
+vi.mock('../../mailer/transport.js', () => ({
+  transporter: { sendMail: vi.fn().mockResolvedValue({ messageId: 'mock' }) },
+}))
+
+import { vi } from 'vitest'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function createVerifiedUser(email: string, role: 'user' | 'curator' | 'admin' = 'user') {
+  const argon2 = await import('argon2')
+  return db.user.create({
+    data: {
+      email,
+      password: await argon2.hash('Password123!'),
+      firstName: 'Test',
+      lastName: 'User',
+      role,
+      verified: true,
+    },
+  })
+}
+
+async function loginAs(email: string): Promise<string> {
+  const res = await request(app).post('/api/auth/login').send({ email, password: 'Password123!' })
+  return res.body.token as string
+}
+
+function futureDate(msFromNow = 60 * 60 * 1000): string {
+  return new Date(Date.now() + msFromNow).toISOString()
+}
+
+async function createEscrowAs(token: string, payeeId: string, amountXlm = 100) {
+  return request(app)
+    .post('/api/escrow')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ payeeId, amountXlm, expiresAt: futureDate() })
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+let payerToken: string
+let payerId: string
+let payeeToken: string
+let payeeId: string
+let thirdPartyToken: string
+let adminToken: string
+let adminId: string
+
+describe('Escrow E2E', () => {
+  beforeAll(async () => {
+    const payer = await createVerifiedUser('escrow-payer@e2e.com')
+    const payee = await createVerifiedUser('escrow-payee@e2e.com')
+    const thirdParty = await createVerifiedUser('escrow-third@e2e.com')
+    const admin = await createVerifiedUser('escrow-admin@e2e.com', 'admin')
+
+    payerId = payer.id
+    payeeId = payee.id
+    adminId = admin.id
+
+    payerToken = await loginAs('escrow-payer@e2e.com')
+    payeeToken = await loginAs('escrow-payee@e2e.com')
+    thirdPartyToken = await loginAs('escrow-third@e2e.com')
+    adminToken = await loginAs('escrow-admin@e2e.com')
+  })
+
+  // ── Create ──────────────────────────────────────────────────────────────────
+  describe('POST /api/escrow', () => {
+    it('creates an escrow between payer and payee and returns 201 with pending status', async () => {
+      const res = await createEscrowAs(payerToken, payeeId)
+      expect(res.status).toBe(201)
+      expect(res.body.data.status).toBe('pending')
+      expect(res.body.data.payerId).toBe(payerId)
+      expect(res.body.data.payeeId).toBe(payeeId)
+    })
+
+    it('returns 401 without auth', async () => {
+      const res = await request(app).post('/api/escrow').send({ payeeId, amountXlm: 100, expiresAt: futureDate() })
+      expect(res.status).toBe(401)
+    })
+  })
+
+  // ── Activate ────────────────────────────────────────────────────────────────
+  describe('PATCH /api/escrow/:id/activate', () => {
+    it('rejects activation by someone other than the payer', async () => {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/activate`)
+        .set('Authorization', `Bearer ${thirdPartyToken}`)
+        .send({ txId: 'tx-unauthorized' })
+      expect(res.status).toBe(403)
+    })
+
+    it('activates a pending escrow as the payer', async () => {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/activate`)
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ txId: 'tx-activate-1' })
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('active')
+      expect(res.body.data.txId).toBe('tx-activate-1')
+    })
+
+    it('returns 400 when activating an already-active escrow', async () => {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+      await request(app)
+        .patch(`/api/escrow/${escrowId}/activate`)
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ txId: 'tx-activate-2' })
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/activate`)
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ txId: 'tx-activate-2-again' })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  // ── Release ─────────────────────────────────────────────────────────────────
+  describe('PATCH /api/escrow/:id/release', () => {
+    async function createActiveEscrow() {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+      await request(app)
+        .patch(`/api/escrow/${escrowId}/activate`)
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ txId: `tx-${escrowId}` })
+      return escrowId
+    }
+
+    it('returns 403 when a non-payer, non-admin party attempts release', async () => {
+      const escrowId = await createActiveEscrow()
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payeeToken}`)
+      expect(res.status).toBe(403)
+    })
+
+    it('releases an active escrow as the payer', async () => {
+      const escrowId = await createActiveEscrow()
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('released')
+      expect(res.body.data.releasedAt).toBeTruthy()
+    })
+
+    it('cannot re-release an already-released escrow', async () => {
+      const escrowId = await createActiveEscrow()
+      await request(app).patch(`/api/escrow/${escrowId}/release`).set('Authorization', `Bearer ${payerToken}`)
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('cannot cancel an already-released escrow', async () => {
+      const escrowId = await createActiveEscrow()
+      await request(app).patch(`/api/escrow/${escrowId}/release`).set('Authorization', `Bearer ${payerToken}`)
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(400)
+    })
+  })
+
+  // ── Cancel (time-locked) ────────────────────────────────────────────────────
+  describe('PATCH /api/escrow/:id/cancel', () => {
+    it('rejects cancellation by the payer while still within the lock period', async () => {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('allows cancellation by the payer once the lock period has elapsed', async () => {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+      // Simulate elapsed time by backdating expiresAt directly (server-side lock check).
+      await db.escrowRecord.update({ where: { id: escrowId }, data: { expiresAt: new Date(Date.now() - 60_000) } })
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('cancelled')
+      expect(res.body.data.cancelledAt).toBeTruthy()
+    })
+
+    it('allows an admin to cancel within the lock period', async () => {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${adminToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('cancelled')
+    })
+
+    it('returns 403 when a non-payer, non-admin party attempts cancellation', async () => {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+      await db.escrowRecord.update({ where: { id: escrowId }, data: { expiresAt: new Date(Date.now() - 60_000) } })
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${thirdPartyToken}`)
+      expect(res.status).toBe(403)
+    })
+  })
+
+  // ── Dispute: file ───────────────────────────────────────────────────────────
+  describe('POST /api/escrow/:id/disputes', () => {
+    async function createActiveEscrow() {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+      await request(app)
+        .patch(`/api/escrow/${escrowId}/activate`)
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ txId: `tx-${escrowId}` })
+      return escrowId
+    }
+
+    it('returns 403 when a non-party files a dispute', async () => {
+      const escrowId = await createActiveEscrow()
+      const res = await request(app)
+        .post(`/api/escrow/${escrowId}/disputes`)
+        .set('Authorization', `Bearer ${thirdPartyToken}`)
+        .send({ reason: 'Work not completed' })
+      expect(res.status).toBe(403)
+    })
+
+    it('files a dispute as the payee and transitions the escrow to disputed', async () => {
+      const escrowId = await createActiveEscrow()
+      const res = await request(app)
+        .post(`/api/escrow/${escrowId}/disputes`)
+        .set('Authorization', `Bearer ${payeeToken}`)
+        .send({ reason: 'Work not completed' })
+      expect(res.status).toBe(201)
+      expect(res.body.data.status).toBe('open')
+
+      const escrow = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+      expect(escrow!.status).toBe('disputed')
+    })
+
+    it('blocks release once an escrow is disputed', async () => {
+      const escrowId = await createActiveEscrow()
+      await request(app)
+        .post(`/api/escrow/${escrowId}/disputes`)
+        .set('Authorization', `Bearer ${payeeToken}`)
+        .send({ reason: 'Work not completed' })
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('blocks cancellation once an escrow is disputed', async () => {
+      const escrowId = await createActiveEscrow()
+      await request(app)
+        .post(`/api/escrow/${escrowId}/disputes`)
+        .set('Authorization', `Bearer ${payeeToken}`)
+        .send({ reason: 'Work not completed' })
+      await db.escrowRecord.update({ where: { id: escrowId }, data: { expiresAt: new Date(Date.now() - 60_000) } })
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(400)
+    })
+  })
+
+  // ── Dispute: resolve (admin only) ───────────────────────────────────────────
+  describe('PATCH /api/escrow/:id/disputes/:disputeId', () => {
+    async function createDisputedEscrow() {
+      const created = await createEscrowAs(payerToken, payeeId)
+      const escrowId = created.body.data.id
+      await request(app)
+        .patch(`/api/escrow/${escrowId}/activate`)
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ txId: `tx-${escrowId}` })
+      const dispute = await request(app)
+        .post(`/api/escrow/${escrowId}/disputes`)
+        .set('Authorization', `Bearer ${payeeToken}`)
+        .send({ reason: 'Work not completed' })
+      return { escrowId, disputeId: dispute.body.data.id as string }
+    }
+
+    it('returns 403 when a non-admin attempts to resolve a dispute', async () => {
+      const { escrowId, disputeId } = await createDisputedEscrow()
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/disputes/${disputeId}`)
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ status: 'resolved', resolution: 'Refund issued' })
+      expect(res.status).toBe(403)
+    })
+
+    it('resolves a dispute as admin (resolved -> escrow released, a terminal state)', async () => {
+      const { escrowId, disputeId } = await createDisputedEscrow()
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/disputes/${disputeId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'resolved', resolution: 'Funds released to worker' })
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('resolved')
+
+      const escrow = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+      expect(escrow!.status).toBe('released')
+      expect(escrow!.releasedAt).toBeTruthy()
+    })
+
+    it('resolves a dispute as admin (dismissed -> escrow cancelled, a terminal state)', async () => {
+      const { escrowId, disputeId } = await createDisputedEscrow()
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/disputes/${disputeId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'dismissed', resolution: 'No evidence of incomplete work' })
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('dismissed')
+
+      const escrow = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+      expect(escrow!.status).toBe('cancelled')
+      expect(escrow!.cancelledAt).toBeTruthy()
+    })
+  })
+})

--- a/packages/api/src/controllers/escrow.ts
+++ b/packages/api/src/controllers/escrow.ts
@@ -32,7 +32,7 @@ export const createEscrow = catchAsync(async (req: Request, res: Response) => {
 export const activateEscrow = catchAsync(async (req: Request, res: Response) => {
   const { txId } = req.body
   if (!txId) return res.status(400).json({ status: 'error', message: 'txId is required', code: 400 })
-  const record = await escrowService.activateEscrow(req.params.id, txId)
+  const record = await escrowService.activateEscrow(req.params.id, txId, req.user!.id, req.user!.role)
   return res.json({ data: record, status: 'success', code: 200 })
 })
 

--- a/packages/api/src/services/escrow.service.ts
+++ b/packages/api/src/services/escrow.service.ts
@@ -46,11 +46,13 @@ export async function createEscrow(data: {
 
 /**
  * Activate an escrow (funds confirmed on-chain).
+ * Only the payer (or admin) should call this.
  */
-export async function activateEscrow(id: string, txId: string) {
+export async function activateEscrow(id: string, txId: string, callerId: string, callerRole: string) {
   const record = await db.escrowRecord.findUnique({ where: { id } })
   if (!record) throw new AppError('Escrow not found', 404)
   if (record.status !== 'pending') throw new AppError('Only pending escrows can be activated', 400)
+  if (callerRole !== 'admin' && record.payerId !== callerId) throw new AppError('Forbidden', 403)
 
   const updated = await db.escrowRecord.update({
     where: { id },

--- a/packages/app/e2e/payment.spec.ts
+++ b/packages/app/e2e/payment.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { injectFreighterMock, MOCK_WALLET_ADDRESS } from './freighter-mock'
 
 const BASE = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3001'
 
@@ -35,5 +36,35 @@ test.describe('Payment and escrow flows', () => {
       // Page should render without crashing
       await expect(page.locator('body')).not.toContainText('Internal Server Error')
     }
+  })
+})
+
+test.describe('Escrow creation flow (mocked wallet)', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectFreighterMock(page)
+  })
+
+  test('creates an escrow and reflects the resulting pending status in the UI', async ({ page }) => {
+    await page.goto(`${BASE}/en/escrow`)
+
+    const connectButton = page.locator('button:has-text("Connect Wallet")')
+    if (await connectButton.count() > 0) {
+      await connectButton.click()
+    }
+
+    const amountInput = page.locator('#amount')
+    await expect(amountInput).toBeVisible({ timeout: 15_000 })
+
+    await amountInput.fill('50')
+    await page.locator('#counterparty').fill(MOCK_WALLET_ADDRESS)
+    await page.locator('#terms').fill('Deliver the agreed work before funds are released.')
+    await page.locator('button[type="submit"]').click()
+
+    // The page simulates escrow submission asynchronously — assert the resulting
+    // record renders with the real data entered, not just that a request fired.
+    await expect(page.getByText('Your Escrows (1)')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Pending').first()).toBeVisible()
+    await expect(page.getByText('50 XLM').first()).toBeVisible()
+    await expect(page.getByText(MOCK_WALLET_ADDRESS).first()).toBeVisible()
   })
 })


### PR DESCRIPTION
Closes #937


this PR:
Adds real E2E assertions on state transitions for the escrow payment lifecycle (`routes/escrow.ts` / `services/escrow.service.ts`), which previously had no automated coverage beyond `e2e/payment.spec.ts`'s tip-modal visibility checks.

**API — `packages/api/src/__tests__/e2e/escrow.e2e.test.ts`** (Supertest against the real Express app, follows the existing pattern in `auth.e2e.test.ts` / `workers.e2e.test.ts`):
- Create → `201`, `pending` status
- Activate → `active`; rejected (`403`) for anyone but the payer/admin; rejected (`400`) on an already-active escrow
- Release → only the payer/admin can release (`403` otherwise); released escrows can't be re-released or cancelled
- Cancel → time-lock enforced server-side: rejected within the lock window, allowed once elapsed (verified by backdating `expiresAt` directly in the DB, not assumed from the UI); admin can bypass the lock; non-payer/non-admin rejected
- Dispute filing → restricted to the escrow's parties (`403` otherwise); transitions the escrow to `disputed`; blocks further release/cancel
- Dispute resolution → admin-only (`403` for non-admins); `resolved`/`dismissed` drive the escrow to its terminal `released`/`cancelled` state

While writing the activation tests I found `PATCH /:id/activate` had no caller check at all — any authenticated user could activate someone else's escrow. Since the issue explicitly calls out "verify `activateEscrow` rejects activation by someone other than the payer" as a required assertion, I threaded `callerId`/`callerRole` through `activateEscrow`, mirroring the existing `releaseEscrow`/`cancelEscrow` checks, so only the payer or an admin can activate. This is the only non-test code touched.

**UI — `packages/app/e2e/payment.spec.ts`**: extends the existing wallet-mock pattern (`freighter-mock.ts`) to drive the `/escrow` page's form through to a created escrow, asserting the resulting card reflects the entered amount, counterparty, and `Pending` status — not just that a request fired.

## Testing/validation performed

- No dependencies are installed in this sandbox, so I could not run `pnpm test` / `pnpm build` / Playwright directly. I verified all changed/added files with `node --experimental-strip-types --check` (syntax-clean) and hand-traced every assertion against the actual `escrow.service.ts` control flow (status checks vs. auth checks vs. lock checks, in the order the service evaluates them) to make sure each expected status code matches real behavior.
- The new API e2e file follows the exact structure/conventions of the pre-existing `auth.e2e.test.ts` and `workers.e2e.test.ts` (same DB/user helpers, same `vitest.config.ts` `exclude: ['src/**/*.e2e.test.ts']` — like its siblings it's meant to run against a live `TEST_DATABASE_URL`, not part of the default `pnpm test` run).
- The `/escrow` page is a self-contained client component (mock local state, no backend call), so the new Playwright test needs no seeded data and is fully deterministic.