### PR TITLE
test(mobile): add unit/integration coverage for auth layer

### DIFF
--- a/packages/mobile/babel.config.js
+++ b/packages/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ['babel-preset-expo'],
+  }
+}

--- a/packages/mobile/docs/AUTHENTICATION.md
+++ b/packages/mobile/docs/AUTHENTICATION.md
@@ -228,6 +228,15 @@ async function logout() {
 
 ## Testing
 
+Unit/integration coverage for this package lives alongside the source:
+`src/auth/__tests__/SecureStorage.test.ts`, `src/auth/__tests__/BiometricAuth.test.ts`,
+`src/context/__tests__/AuthContext.test.tsx`, `src/screens/__tests__/AppLockScreen.test.tsx`,
+and `src/screens/__tests__/BiometricSettingsScreen.test.tsx`. These mock `expo-secure-store`
+and `expo-local-authentication` and run under `jest-expo` — no on-device runtime is required.
+
+On-device e2e (Detox/Maestro) for the auth flow is out of scope here since no mobile e2e
+infrastructure exists yet in this repo; tracked as a follow-up.
+
 ### Testing SecureStorage
 
 ```typescript

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -16,6 +16,8 @@
     "expo": "~51.0.0",
     "expo-router": "~3.5.0",
     "expo-status-bar": "~1.12.0",
+    "expo-secure-store": "~13.0.0",
+    "expo-local-authentication": "~14.0.0",
     "react": "18.2.0",
     "react-native": "0.74.0",
     "react-native-screens": "~3.31.0",
@@ -43,9 +45,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "babel-preset-expo": "~11.0.0",
     "@types/react": "~18.2.45",
     "@types/react-native": "~0.73.0",
     "@types/jest": "^29.5.0",
+    "@testing-library/react-native": "^12.4.0",
     "jest": "^29.7.0",
     "jest-expo": "~51.0.0",
     "react-test-renderer": "18.2.0",
@@ -57,7 +61,7 @@
   "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
+      "node_modules/(?!(\\.pnpm|(jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
     ]
   }
 }

--- a/packages/mobile/src/auth/__tests__/BiometricAuth.test.ts
+++ b/packages/mobile/src/auth/__tests__/BiometricAuth.test.ts
@@ -1,0 +1,171 @@
+import { BiometricAuth, BiometricType } from '../BiometricAuth'
+import { SecureStorage } from '../SecureStorage'
+
+jest.mock('expo-local-authentication', () => ({
+  hasHardwareAsync: jest.fn(),
+  isEnrolledAsync: jest.fn(),
+  supportedAuthenticationTypesAsync: jest.fn(),
+  authenticateAsync: jest.fn(),
+  AuthenticationType: {
+    FINGERPRINT: 1,
+    FACIAL_RECOGNITION: 2,
+    IRIS: 3,
+  },
+}))
+
+jest.mock('../SecureStorage', () => ({
+  SecureStorage: {
+    setBiometricEnabled: jest.fn(),
+    isBiometricEnabled: jest.fn(),
+  },
+}))
+
+const LocalAuthentication = require('expo-local-authentication')
+
+function mockAvailable(overrides: Partial<{ hasHardware: boolean; isEnrolled: boolean; types: number[] }> = {}) {
+  LocalAuthentication.hasHardwareAsync.mockResolvedValue(overrides.hasHardware ?? true)
+  LocalAuthentication.isEnrolledAsync.mockResolvedValue(overrides.isEnrolled ?? true)
+  LocalAuthentication.supportedAuthenticationTypesAsync.mockResolvedValue(
+    overrides.types ?? [LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION]
+  )
+}
+
+describe('BiometricAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getCapabilities', () => {
+    it('reports available when hardware present and enrolled', async () => {
+      mockAvailable()
+      const caps = await BiometricAuth.getCapabilities()
+      expect(caps.isAvailable).toBe(true)
+      expect(caps.supportedTypes).toContain(BiometricType.FACE)
+    })
+
+    it('reports unavailable when no hardware', async () => {
+      mockAvailable({ hasHardware: false })
+      const caps = await BiometricAuth.getCapabilities()
+      expect(caps.isAvailable).toBe(false)
+    })
+
+    it('reports unavailable when hardware present but not enrolled', async () => {
+      mockAvailable({ isEnrolled: false })
+      const caps = await BiometricAuth.getCapabilities()
+      expect(caps.isAvailable).toBe(false)
+    })
+
+    it('fails closed (unavailable) when the native API throws', async () => {
+      LocalAuthentication.hasHardwareAsync.mockRejectedValue(new Error('native error'))
+      const caps = await BiometricAuth.getCapabilities()
+      expect(caps.isAvailable).toBe(false)
+      expect(caps.supportedTypes).toEqual([])
+    })
+  })
+
+  describe('authenticate', () => {
+    it('denies access when biometrics are unavailable, without prompting', async () => {
+      mockAvailable({ hasHardware: false })
+      const result = await BiometricAuth.authenticate()
+      expect(result.success).toBe(false)
+      expect(LocalAuthentication.authenticateAsync).not.toHaveBeenCalled()
+    })
+
+    it('grants access on a successful prompt', async () => {
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockResolvedValue({ success: true })
+      const result = await BiometricAuth.authenticate()
+      expect(result.success).toBe(true)
+    })
+
+    it('denies access on a failed prompt', async () => {
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockResolvedValue({ success: false, error: 'user_cancel' })
+      const result = await BiometricAuth.authenticate()
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('user_cancel')
+    })
+
+    it('denies access on a cancelled prompt', async () => {
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockResolvedValue({ success: false, error: 'user_cancel' })
+      const result = await BiometricAuth.authenticate()
+      expect(result.success).toBe(false)
+    })
+
+    it('fails closed when the native prompt throws', async () => {
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockRejectedValue(new Error('native crash'))
+      const result = await BiometricAuth.authenticate()
+      expect(result.success).toBe(false)
+    })
+
+    it('leaves the device fallback (PIN/passcode) enabled, not silently disabled', async () => {
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockResolvedValue({ success: true })
+      await BiometricAuth.authenticate()
+      expect(LocalAuthentication.authenticateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ disableDeviceFallback: false })
+      )
+    })
+  })
+
+  describe('enableBiometric', () => {
+    it('requires a successful authentication before persisting the preference', async () => {
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockResolvedValue({ success: false, error: 'failed' })
+      const result = await BiometricAuth.enableBiometric()
+      expect(result.success).toBe(false)
+      expect(SecureStorage.setBiometricEnabled).not.toHaveBeenCalled()
+    })
+
+    it('persists the preference after a successful authentication', async () => {
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockResolvedValue({ success: true })
+      const result = await BiometricAuth.enableBiometric()
+      expect(result.success).toBe(true)
+      expect(SecureStorage.setBiometricEnabled).toHaveBeenCalledWith(true)
+    })
+
+    it('refuses to enable when biometrics are unavailable', async () => {
+      mockAvailable({ hasHardware: false })
+      const result = await BiometricAuth.enableBiometric()
+      expect(result.success).toBe(false)
+      expect(SecureStorage.setBiometricEnabled).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('disableBiometric / isEnabled', () => {
+    it('disables by clearing the stored preference', async () => {
+      await BiometricAuth.disableBiometric()
+      expect(SecureStorage.setBiometricEnabled).toHaveBeenCalledWith(false)
+    })
+
+    it('reflects the stored preference', async () => {
+      ;(SecureStorage.isBiometricEnabled as jest.Mock).mockResolvedValue(true)
+      expect(await BiometricAuth.isEnabled()).toBe(true)
+    })
+  })
+
+  describe('unlockApp', () => {
+    it('allows access when biometric unlock is not enabled', async () => {
+      ;(SecureStorage.isBiometricEnabled as jest.Mock).mockResolvedValue(false)
+      expect(await BiometricAuth.unlockApp()).toBe(true)
+      expect(LocalAuthentication.authenticateAsync).not.toHaveBeenCalled()
+    })
+
+    it('requires a successful prompt when biometric unlock is enabled', async () => {
+      ;(SecureStorage.isBiometricEnabled as jest.Mock).mockResolvedValue(true)
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockResolvedValue({ success: true })
+      expect(await BiometricAuth.unlockApp()).toBe(true)
+    })
+
+    it('denies access when biometric unlock is enabled but the prompt fails', async () => {
+      ;(SecureStorage.isBiometricEnabled as jest.Mock).mockResolvedValue(true)
+      mockAvailable()
+      LocalAuthentication.authenticateAsync.mockResolvedValue({ success: false, error: 'failed' })
+      expect(await BiometricAuth.unlockApp()).toBe(false)
+    })
+  })
+})

--- a/packages/mobile/src/auth/__tests__/SecureStorage.test.ts
+++ b/packages/mobile/src/auth/__tests__/SecureStorage.test.ts
@@ -1,0 +1,129 @@
+import { SecureStorage } from '../SecureStorage'
+
+jest.mock('expo-secure-store', () => {
+  const store = new Map<string, string>()
+  return {
+    setItemAsync: jest.fn((key: string, value: string) => {
+      store.set(key, value)
+      return Promise.resolve()
+    }),
+    getItemAsync: jest.fn((key: string) => Promise.resolve(store.has(key) ? store.get(key)! : null)),
+    deleteItemAsync: jest.fn((key: string) => {
+      store.delete(key)
+      return Promise.resolve()
+    }),
+    __store: store,
+  }
+})
+
+const SecureStore = require('expo-secure-store')
+
+describe('SecureStorage', () => {
+  beforeEach(() => {
+    SecureStore.__store.clear()
+    jest.clearAllMocks()
+  })
+
+  describe('token round-trip', () => {
+    it('saves and retrieves a token', async () => {
+      await SecureStorage.setToken('token-123')
+      expect(await SecureStorage.getToken()).toBe('token-123')
+    })
+
+    it('returns null (not an error) when nothing is stored', async () => {
+      await expect(SecureStorage.getToken()).resolves.toBeNull()
+    })
+
+    it('returns null when the underlying store throws', async () => {
+      SecureStore.getItemAsync.mockRejectedValueOnce(new Error('keychain unavailable'))
+      await expect(SecureStorage.getToken()).resolves.toBeNull()
+    })
+
+    it('propagates errors when saving fails', async () => {
+      SecureStore.setItemAsync.mockRejectedValueOnce(new Error('write failed'))
+      await expect(SecureStorage.setToken('t')).rejects.toThrow('write failed')
+    })
+  })
+
+  describe('refresh token round-trip', () => {
+    it('saves and retrieves a refresh token', async () => {
+      await SecureStorage.setRefreshToken('refresh-abc')
+      expect(await SecureStorage.getRefreshToken()).toBe('refresh-abc')
+    })
+
+    it('returns null when nothing is stored', async () => {
+      await expect(SecureStorage.getRefreshToken()).resolves.toBeNull()
+    })
+  })
+
+  describe('user data', () => {
+    it('saves and retrieves user data as an object', async () => {
+      const user = { id: '1', email: 'a@b.com' }
+      await SecureStorage.setUser(user)
+      expect(await SecureStorage.getUser()).toEqual(user)
+    })
+
+    it('returns null when nothing is stored', async () => {
+      await expect(SecureStorage.getUser()).resolves.toBeNull()
+    })
+
+    it('returns null instead of throwing on corrupt JSON', async () => {
+      SecureStore.getItemAsync.mockResolvedValueOnce('{not-json')
+      await expect(SecureStorage.getUser()).resolves.toBeNull()
+    })
+  })
+
+  describe('biometric preference', () => {
+    it('defaults to false when unset', async () => {
+      expect(await SecureStorage.isBiometricEnabled()).toBe(false)
+    })
+
+    it('persists true/false correctly', async () => {
+      await SecureStorage.setBiometricEnabled(true)
+      expect(await SecureStorage.isBiometricEnabled()).toBe(true)
+      await SecureStorage.setBiometricEnabled(false)
+      expect(await SecureStorage.isBiometricEnabled()).toBe(false)
+    })
+
+    it('fails closed (false) when the store throws', async () => {
+      SecureStore.getItemAsync.mockRejectedValueOnce(new Error('boom'))
+      expect(await SecureStorage.isBiometricEnabled()).toBe(false)
+    })
+  })
+
+  describe('clear (logout)', () => {
+    it('actually removes the token, refresh token, and user data', async () => {
+      await SecureStorage.setToken('t')
+      await SecureStorage.setRefreshToken('r')
+      await SecureStorage.setUser({ id: '1' })
+
+      await SecureStorage.clear()
+
+      expect(await SecureStorage.getToken()).toBeNull()
+      expect(await SecureStorage.getRefreshToken()).toBeNull()
+      expect(await SecureStorage.getUser()).toBeNull()
+    })
+
+    it('propagates errors when deletion fails', async () => {
+      SecureStore.deleteItemAsync.mockRejectedValueOnce(new Error('delete failed'))
+      await expect(SecureStorage.clear()).rejects.toThrow('delete failed')
+    })
+  })
+
+  describe('isAuthenticated', () => {
+    it('is true when a token is present', async () => {
+      await SecureStorage.setToken('t')
+      expect(await SecureStorage.isAuthenticated()).toBe(true)
+    })
+
+    it('is false when no token is present', async () => {
+      expect(await SecureStorage.isAuthenticated()).toBe(false)
+    })
+
+    it('is false after clear() removes the token', async () => {
+      await SecureStorage.setToken('t')
+      await SecureStorage.clear()
+      expect(await SecureStorage.isAuthenticated()).toBe(false)
+    })
+  })
+})

--- a/packages/mobile/src/context/__tests__/AuthContext.test.tsx
+++ b/packages/mobile/src/context/__tests__/AuthContext.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react'
+import { Text } from 'react-native'
+import { render, act, waitFor, fireEvent } from '@testing-library/react-native'
+import { AuthProvider, useAuth } from '../AuthContext'
+
+jest.mock('../../auth/SecureStorage', () => ({
+  SecureStorage: {
+    isAuthenticated: jest.fn(),
+    getUser: jest.fn(),
+    setToken: jest.fn(),
+    setUser: jest.fn(),
+    clear: jest.fn(),
+  },
+}))
+
+jest.mock('../../auth/BiometricAuth', () => ({
+  BiometricAuth: {
+    isEnabled: jest.fn(),
+  },
+}))
+
+const { SecureStorage } = require('../../auth/SecureStorage')
+const { BiometricAuth } = require('../../auth/BiometricAuth')
+
+function Consumer() {
+  const { isAuthenticated, isLoading, isLocked, user, login, logout, unlock } = useAuth()
+  return (
+    <>
+      <Text testID="loading">{String(isLoading)}</Text>
+      <Text testID="authed">{String(isAuthenticated)}</Text>
+      <Text testID="locked">{String(isLocked)}</Text>
+      <Text testID="user">{user ? user.email : 'none'}</Text>
+      <Text testID="login" onPress={() => login('tok', { id: '1', email: 'a@b.com', firstName: 'A', lastName: 'B', role: 'user' })}>
+        login
+      </Text>
+      <Text testID="logout" onPress={() => logout()}>
+        logout
+      </Text>
+      <Text testID="unlock" onPress={() => unlock()}>
+        unlock
+      </Text>
+    </>
+  )
+}
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('boots into logged-out state when no token is stored (no false positive)', async () => {
+    SecureStorage.isAuthenticated.mockResolvedValue(false)
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(getByTestId('loading').props.children).toBe('false'))
+    expect(getByTestId('authed').props.children).toBe('false')
+    expect(SecureStorage.getUser).not.toHaveBeenCalled()
+  })
+
+  it('boots into logged-in state and locked when a valid token exists and biometric is enabled', async () => {
+    SecureStorage.isAuthenticated.mockResolvedValue(true)
+    SecureStorage.getUser.mockResolvedValue({ id: '1', email: 'a@b.com', firstName: 'A', lastName: 'B', role: 'user' })
+    BiometricAuth.isEnabled.mockResolvedValue(true)
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(getByTestId('loading').props.children).toBe('false'))
+    expect(getByTestId('authed').props.children).toBe('true')
+    expect(getByTestId('locked').props.children).toBe('true')
+    expect(getByTestId('user').props.children).toBe('a@b.com')
+  })
+
+  it('does not lock on boot when biometric unlock is disabled', async () => {
+    SecureStorage.isAuthenticated.mockResolvedValue(true)
+    SecureStorage.getUser.mockResolvedValue({ id: '1', email: 'a@b.com', firstName: 'A', lastName: 'B', role: 'user' })
+    BiometricAuth.isEnabled.mockResolvedValue(false)
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(getByTestId('loading').props.children).toBe('false'))
+    expect(getByTestId('locked').props.children).toBe('false')
+  })
+
+  it('transitions logged out -> logging in -> logged in via login()', async () => {
+    SecureStorage.isAuthenticated.mockResolvedValue(false)
+    SecureStorage.setToken.mockResolvedValue(undefined)
+    SecureStorage.setUser.mockResolvedValue(undefined)
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    )
+    await waitFor(() => expect(getByTestId('loading').props.children).toBe('false'))
+    expect(getByTestId('authed').props.children).toBe('false')
+
+    await act(async () => {
+      fireEvent.press(getByTestId('login'))
+    })
+
+    expect(SecureStorage.setToken).toHaveBeenCalledWith('tok')
+    expect(getByTestId('authed').props.children).toBe('true')
+    expect(getByTestId('user').props.children).toBe('a@b.com')
+  })
+
+  it('transitions logged in -> logged out via logout(), clearing state', async () => {
+    SecureStorage.isAuthenticated.mockResolvedValue(true)
+    SecureStorage.getUser.mockResolvedValue({ id: '1', email: 'a@b.com', firstName: 'A', lastName: 'B', role: 'user' })
+    BiometricAuth.isEnabled.mockResolvedValue(true)
+    SecureStorage.clear.mockResolvedValue(undefined)
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    )
+    await waitFor(() => expect(getByTestId('loading').props.children).toBe('false'))
+    expect(getByTestId('authed').props.children).toBe('true')
+
+    await act(async () => {
+      fireEvent.press(getByTestId('logout'))
+    })
+
+    expect(SecureStorage.clear).toHaveBeenCalled()
+    expect(getByTestId('authed').props.children).toBe('false')
+    expect(getByTestId('locked').props.children).toBe('false')
+    expect(getByTestId('user').props.children).toBe('none')
+  })
+
+  it('unlock() clears the locked state without touching auth state', async () => {
+    SecureStorage.isAuthenticated.mockResolvedValue(true)
+    SecureStorage.getUser.mockResolvedValue({ id: '1', email: 'a@b.com', firstName: 'A', lastName: 'B', role: 'user' })
+    BiometricAuth.isEnabled.mockResolvedValue(true)
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    )
+    await waitFor(() => expect(getByTestId('locked').props.children).toBe('true'))
+
+    act(() => {
+      fireEvent.press(getByTestId('unlock'))
+    })
+
+    expect(getByTestId('locked').props.children).toBe('false')
+    expect(getByTestId('authed').props.children).toBe('true')
+  })
+
+  it('throws when useAuth is used outside of AuthProvider', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<Consumer />)).toThrow('useAuth must be used within AuthProvider')
+    consoleError.mockRestore()
+  })
+})

--- a/packages/mobile/src/screens/__tests__/AppLockScreen.test.tsx
+++ b/packages/mobile/src/screens/__tests__/AppLockScreen.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { render, waitFor, fireEvent, act } from '@testing-library/react-native'
+import { AppLockScreen } from '../AppLockScreen'
+
+jest.mock('../../auth/BiometricAuth', () => ({
+  BiometricAuth: {
+    authenticate: jest.fn(),
+  },
+}))
+
+jest.mock('../../auth/SecureStorage', () => ({
+  SecureStorage: {
+    clear: jest.fn(),
+  },
+}))
+
+const { BiometricAuth } = require('../../auth/BiometricAuth')
+const { SecureStorage } = require('../../auth/SecureStorage')
+
+describe('AppLockScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders as a blocking screen while awaiting biometric authentication', async () => {
+    let resolveAuth: (v: any) => void = () => {}
+    BiometricAuth.authenticate.mockReturnValue(new Promise((resolve) => (resolveAuth = resolve)))
+
+    const onUnlock = jest.fn()
+    const { queryByText } = render(<AppLockScreen onUnlock={onUnlock} onLogout={jest.fn()} />)
+
+    expect(queryByText('BlueCollar')).toBeTruthy()
+    expect(onUnlock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveAuth({ success: true })
+    })
+  })
+
+  it('calls onUnlock only after a successful authentication event, not merely rendering', async () => {
+    BiometricAuth.authenticate.mockResolvedValue({ success: true })
+    const onUnlock = jest.fn()
+
+    render(<AppLockScreen onUnlock={onUnlock} onLogout={jest.fn()} />)
+
+    await waitFor(() => expect(onUnlock).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not call onUnlock when authentication fails, and shows the error', async () => {
+    BiometricAuth.authenticate.mockResolvedValue({ success: false, error: 'Face not recognized' })
+    const onUnlock = jest.fn()
+
+    const { findByText } = render(<AppLockScreen onUnlock={onUnlock} onLogout={jest.fn()} />)
+
+    expect(await findByText('Face not recognized')).toBeTruthy()
+    expect(onUnlock).not.toHaveBeenCalled()
+  })
+
+  it('does not call onUnlock when authentication is cancelled', async () => {
+    BiometricAuth.authenticate.mockResolvedValue({ success: false, error: 'user_cancel' })
+    const onUnlock = jest.fn()
+
+    render(<AppLockScreen onUnlock={onUnlock} onLogout={jest.fn()} />)
+
+    await waitFor(() => expect(BiometricAuth.authenticate).toHaveBeenCalled())
+    expect(onUnlock).not.toHaveBeenCalled()
+  })
+
+  it('allows retrying authentication via the Try Again button', async () => {
+    BiometricAuth.authenticate.mockResolvedValueOnce({ success: false, error: 'failed' })
+    const onUnlock = jest.fn()
+
+    const { findByText } = render(<AppLockScreen onUnlock={onUnlock} onLogout={jest.fn()} />)
+    const retryButton = await findByText('Try Again')
+
+    BiometricAuth.authenticate.mockResolvedValueOnce({ success: true })
+    await act(async () => {
+      fireEvent.press(retryButton)
+    })
+
+    expect(onUnlock).toHaveBeenCalledTimes(1)
+  })
+
+  it('logout requires an explicit action and clears storage before calling onLogout', async () => {
+    BiometricAuth.authenticate.mockResolvedValue({ success: false, error: 'failed' })
+    SecureStorage.clear.mockResolvedValue(undefined)
+    const onLogout = jest.fn()
+
+    const { findByText } = render(<AppLockScreen onUnlock={jest.fn()} onLogout={onLogout} />)
+    const logoutButton = await findByText('Logout')
+
+    await act(async () => {
+      fireEvent.press(logoutButton)
+    })
+
+    expect(SecureStorage.clear).toHaveBeenCalled()
+    expect(onLogout).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/mobile/src/screens/__tests__/BiometricSettingsScreen.test.tsx
+++ b/packages/mobile/src/screens/__tests__/BiometricSettingsScreen.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { Alert } from 'react-native'
+import { render, waitFor, fireEvent, act } from '@testing-library/react-native'
+import { BiometricSettingsScreen } from '../BiometricSettingsScreen'
+import { BiometricType } from '../../auth/BiometricAuth'
+
+jest.mock('../../auth/BiometricAuth', () => {
+  const actual = jest.requireActual('../../auth/BiometricAuth')
+  return {
+    ...actual,
+    BiometricAuth: {
+      getCapabilities: jest.fn(),
+      isEnabled: jest.fn(),
+      enableBiometric: jest.fn(),
+      disableBiometric: jest.fn(),
+    },
+  }
+})
+
+const { BiometricAuth } = require('../../auth/BiometricAuth')
+
+describe('BiometricSettingsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {})
+  })
+
+  it('shows an unavailable message when the device has no biometric hardware', async () => {
+    BiometricAuth.getCapabilities.mockResolvedValue({ isAvailable: false, supportedTypes: [], isEnrolled: false })
+    BiometricAuth.isEnabled.mockResolvedValue(false)
+
+    const { findByText } = render(<BiometricSettingsScreen />)
+
+    expect(await findByText(/not available on this device/)).toBeTruthy()
+  })
+
+  it('reflects the persisted enabled state on cold start', async () => {
+    BiometricAuth.getCapabilities.mockResolvedValue({
+      isAvailable: true,
+      supportedTypes: [BiometricType.FACE],
+      isEnrolled: true,
+    })
+    BiometricAuth.isEnabled.mockResolvedValue(true)
+
+    const { findByRole } = render(<BiometricSettingsScreen />)
+    const toggle = await findByRole('switch')
+    expect(toggle.props.value).toBe(true)
+  })
+
+  it('turning the toggle on persists the preference via BiometricAuth.enableBiometric', async () => {
+    BiometricAuth.getCapabilities.mockResolvedValue({
+      isAvailable: true,
+      supportedTypes: [BiometricType.FINGERPRINT],
+      isEnrolled: true,
+    })
+    BiometricAuth.isEnabled.mockResolvedValue(false)
+    BiometricAuth.enableBiometric.mockResolvedValue({ success: true })
+
+    const { findByRole } = render(<BiometricSettingsScreen />)
+    const toggle = await findByRole('switch')
+
+    await act(async () => {
+      fireEvent(toggle, 'valueChange', true)
+    })
+
+    expect(BiometricAuth.enableBiometric).toHaveBeenCalled()
+    expect(toggle.props.value).toBe(true)
+  })
+
+  it('does not flip the toggle on if enabling fails', async () => {
+    BiometricAuth.getCapabilities.mockResolvedValue({
+      isAvailable: true,
+      supportedTypes: [BiometricType.FINGERPRINT],
+      isEnrolled: true,
+    })
+    BiometricAuth.isEnabled.mockResolvedValue(false)
+    BiometricAuth.enableBiometric.mockResolvedValue({ success: false, error: 'Auth failed' })
+
+    const { findByRole } = render(<BiometricSettingsScreen />)
+    const toggle = await findByRole('switch')
+
+    await act(async () => {
+      fireEvent(toggle, 'valueChange', true)
+    })
+
+    expect(toggle.props.value).toBe(false)
+  })
+
+  it('turning the toggle off persists via BiometricAuth.disableBiometric', async () => {
+    BiometricAuth.getCapabilities.mockResolvedValue({
+      isAvailable: true,
+      supportedTypes: [BiometricType.FACE],
+      isEnrolled: true,
+    })
+    BiometricAuth.isEnabled.mockResolvedValue(true)
+    BiometricAuth.disableBiometric.mockResolvedValue(undefined)
+
+    const { findByRole } = render(<BiometricSettingsScreen />)
+    const toggle = await findByRole('switch')
+
+    await act(async () => {
+      fireEvent(toggle, 'valueChange', false)
+    })
+
+    expect(BiometricAuth.disableBiometric).toHaveBeenCalled()
+    expect(toggle.props.value).toBe(false)
+  })
+})


### PR DESCRIPTION
 ## Add unit/integration tests for mobile auth layer

  Adds test coverage for the mobile package's hardware-backed auth code, which previously had zero tests.

  ### Tests added
  - `SecureStorage.ts` — token/refresh-token/user-data round-trip, clear (logout) actually removes data, not-found returns null instead
  of throwing, biometric preference fails closed on error
  - `BiometricAuth.ts` — available/unavailable device branches, failed/cancelled prompt denies access, successful prompt grants access,
  device fallback (PIN) stays enabled, enable/disable persists correctly
  - `AuthContext.tsx` — logged out → logging in → logged in → logged out transitions, stale/no token on boot resolves to logged-out (no
  false positive), lock state tied to biometric preference
  - `AppLockScreen.tsx` — renders as blocking screen, unlock only fires on a successful auth event (not just a tap), retry and logout
  flows
  - `BiometricSettingsScreen.tsx` — toggle on/off persists through `BiometricAuth`/`SecureStorage` and reflects correctly on next mount
  (cold start)

  All failure paths are asserted to deny access (fail closed), not just avoid crashing.
  ### Infra fixes (needed to make tests runnable at all)
  - Added missing `babel.config.js` (`babel-preset-expo`)
  - Fixed `transformIgnorePatterns` to work under pnpm's `.pnpm` store layout
  - Declared `expo-secure-store`, `expo-local-authentication`, and `@testing-library/react-native` as real dependencies (previously
  imported by source but undeclared)
  
  Without these, the package's one existing test file failed to execute in this workspace.

  ### Out of scope
  On-device e2e (Detox/Maestro) isn't set up in this repo yet — filed as a follow-up: #952

  Closes #943