### PR TITLE
refactor(types): eliminate explicit `: any` annotations across api and app (#935)

### DIFF
--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -16,7 +16,7 @@
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
-    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "no-console": "off"
   },

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -5,6 +5,7 @@ import { redis, cacheMetrics } from './config/redis.js'
 import { db } from './db.js'
 import { disconnectDb } from './db.js'
 import { requestLogger } from './middleware/requestLogger.js'
+import { getErrorMessage } from './utils/getErrorMessage.js'
 import { registerEventHandlers } from './events/index.js'
 import { applySecurity, depthLimiter } from './middleware/security.js'
 import authRoutes from './routes/auth.js'
@@ -249,8 +250,8 @@ app.get('/ready', async (_req, res) => {
   try {
     await db.$queryRaw`SELECT 1`
     checks.database = { status: 'ok', latencyMs: Date.now() - dbStart }
-  } catch (err: any) {
-    checks.database = { status: 'error', latencyMs: Date.now() - dbStart, error: err?.message }
+  } catch (err) {
+    checks.database = { status: 'error', latencyMs: Date.now() - dbStart, error: getErrorMessage(err) }
   }
 
   // Redis check
@@ -258,8 +259,8 @@ app.get('/ready', async (_req, res) => {
   try {
     await redis.ping()
     checks.redis = { status: 'ok', latencyMs: Date.now() - redisStart }
-  } catch (err: any) {
-    checks.redis = { status: 'error', latencyMs: Date.now() - redisStart, error: err?.message }
+  } catch (err) {
+    checks.redis = { status: 'error', latencyMs: Date.now() - redisStart, error: getErrorMessage(err) }
   }
 
   const allOk = Object.values(checks).every((c) => c.status === 'ok')

--- a/packages/api/src/config/passport.ts
+++ b/packages/api/src/config/passport.ts
@@ -60,8 +60,8 @@ passport.use(
 );
 
 // Passport session setup (if using sessions, but we'll use JWT)
-passport.serializeUser((user: any, done) => {
-  done(null, user.id);
+passport.serializeUser((user: unknown, done) => {
+  done(null, (user as { id: string }).id);
 });
 
 passport.deserializeUser(async (id: string, done) => {

--- a/packages/api/src/controllers/csv-import.ts
+++ b/packages/api/src/controllers/csv-import.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express'
 import { importWorkersFromCsv } from '../services/csv-import.service.js'
 import { handleError } from '../utils/handleError.js'
+import { getErrorMessage } from '../utils/getErrorMessage.js'
 
 /**
  * POST /api/admin/workers/import
@@ -24,9 +25,10 @@ export async function importWorkersFromCsvController(req: Request, res: Response
       message: `Imported ${result.imported} worker(s). ${result.failed} row(s) failed.`,
       code: result.imported > 0 ? 201 : 400,
     })
-  } catch (err: any) {
-    if (err?.message?.startsWith('Missing required CSV column')) {
-      return res.status(400).json({ status: 'error', message: err.message, code: 400 })
+  } catch (err) {
+    const message = getErrorMessage(err)
+    if (message.startsWith('Missing required CSV column')) {
+      return res.status(400).json({ status: 'error', message, code: 400 })
     }
     return handleError(res, err)
   }

--- a/packages/api/src/controllers/export.ts
+++ b/packages/api/src/controllers/export.ts
@@ -8,10 +8,10 @@ import type { Request, Response } from 'express'
 import { db } from '../db.js'
 import { log } from '../services/audit.service.js'
 
-function toCSV(rows: Record<string, any>[]): string {
+function toCSV(rows: Record<string, unknown>[]): string {
   if (rows.length === 0) return ''
   const headers = Object.keys(rows[0])
-  const escape = (v: any) => {
+  const escape = (v: unknown) => {
     const s = v == null ? '' : String(v)
     return s.includes(',') || s.includes('"') || s.includes('\n')
       ? `"${s.replace(/"/g, '""')}"`

--- a/packages/api/src/controllers/users.ts
+++ b/packages/api/src/controllers/users.ts
@@ -4,6 +4,8 @@ import { sanitizeUser } from '../models/user.model.js'
 import * as userService from '../services/user.service.js'
 import { logger } from '../config/logger.js'
 import { ErrorMessages, HttpStatus } from '../constants/index.js'
+import { AppError } from '../services/AppError.js'
+import { ZodError } from 'zod'
 
 // ── Profile update ────────────────────────────────────────────────────────────
 
@@ -44,11 +46,11 @@ export async function updateMe(req: Request, res: Response) {
   try {
     const user = await userService.updateProfile(userId, req.body)
     return res.json({ data: user, status: 'success', code: 200 })
-  } catch (error: any) {
-    if (error?.name === 'ZodError') {
+  } catch (error: unknown) {
+    if (error instanceof ZodError) {
       return res.status(HttpStatus.BAD_REQUEST).json({ status: 'error', message: 'Validation failed', code: HttpStatus.BAD_REQUEST, errors: error.errors })
     }
-    if (error?.statusCode) {
+    if (error instanceof AppError) {
       return res.status(error.statusCode).json({ status: 'error', message: error.message, code: error.statusCode })
     }
     logger.error({ err: error }, '[updateMe] error')
@@ -71,8 +73,8 @@ export async function changePassword(req: Request, res: Response) {
   try {
     await userService.changePassword(userId, currentPassword, newPassword)
     return res.json({ status: 'success', message: 'Password updated', code: HttpStatus.OK })
-  } catch (error: any) {
-    if (error?.statusCode) {
+  } catch (error: unknown) {
+    if (error instanceof AppError) {
       return res.status(error.statusCode).json({ status: 'error', message: error.message, code: error.statusCode })
     }
     logger.error({ err: error }, '[changePassword] error')

--- a/packages/api/src/middleware/audit.ts
+++ b/packages/api/src/middleware/audit.ts
@@ -25,10 +25,12 @@ export function auditMiddleware(req: Request, res: Response, next: NextFunction)
   if (!match) return next()
 
   const originalJson = res.json.bind(res)
-  res.json = function (body: any) {
+  res.json = function (body: unknown) {
     // Only log on success (2xx)
     if (res.statusCode >= 200 && res.statusCode < 300) {
-      const resourceId = req.params?.id ?? body?.data?.id ?? undefined
+      const payload = body as { data?: { id?: string } } | null | undefined
+      const rawId = req.params?.id ?? payload?.data?.id
+      const resourceId = typeof rawId === 'string' ? rawId : undefined
       log({
         userId: req.user?.id,
         action: match.action,

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from 'express'
+import type { Prisma } from '@prisma/client'
 import { db } from '../db.js'
 
 const TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
@@ -17,7 +18,7 @@ export function idempotency(req: Request, res: Response, next: NextFunction) {
 
   // Intercept res.json to capture and store the response
   const originalJson = res.json.bind(res)
-  res.json = function (body: any) {
+  res.json = function (body: Prisma.InputJsonValue) {
     if (res.statusCode >= 200 && res.statusCode < 300) {
       const expiresAt = new Date(Date.now() + TTL_MS)
       db.idempotencyKey

--- a/packages/api/src/middleware/metrics.ts
+++ b/packages/api/src/middleware/metrics.ts
@@ -70,7 +70,7 @@ export const metricsMiddleware = (req: Request, res: Response, next: NextFunctio
 
   // Capture response
   const originalSend = res.send;
-  res.send = function(body: any): Response {
+  res.send = function(body: unknown): Response {
     const duration = (Date.now() - start) / 1000;
     const route = req.route?.path || req.path;
     const statusCode = res.statusCode.toString();

--- a/packages/api/src/middleware/requestLogger.ts
+++ b/packages/api/src/middleware/requestLogger.ts
@@ -2,6 +2,10 @@ import pinoHttp from 'pino-http'
 import pino from 'pino'
 import fs from 'node:fs'
 import path from 'node:path'
+import type { IncomingMessage } from 'node:http'
+
+/** Request augmented with the authenticated user attached by auth middleware. */
+type LoggedRequest = IncomingMessage & { user?: { id?: string } }
 
 const LOG_DIR = process.env.LOG_DIR ?? 'storage/logs'
 fs.mkdirSync(path.resolve(LOG_DIR), { recursive: true })
@@ -30,12 +34,12 @@ export const requestLogger = pinoHttp({
 
   // PII SAFETY: Only method, url, and statusCode are logged.
   // No headers, body, query params, or IP addresses are persisted.
-  customProps: (req: any) => ({
-    userId: req.user?.id ?? null,
+  customProps: (req: IncomingMessage) => ({
+    userId: (req as LoggedRequest).user?.id ?? null,
   }),
 
-  customSuccessMessage: (req: any, res) => `${req.method} ${req.url} ${res.statusCode}`,
-  customErrorMessage: (req: any, res, err) => `${req.method} ${req.url} ${res.statusCode} — ${err.message}`,
+  customSuccessMessage: (req: IncomingMessage, res) => `${req.method} ${req.url} ${res.statusCode}`,
+  customErrorMessage: (req: IncomingMessage, res, err) => `${req.method} ${req.url} ${res.statusCode} — ${err.message}`,
 
   serializers: {
     req: (req) => ({ method: req.method, url: req.url }),

--- a/packages/api/src/middleware/upload.ts
+++ b/packages/api/src/middleware/upload.ts
@@ -38,7 +38,7 @@ const fileFilter = (_req: Request, file: Express.Multer.File, cb: multer.FileFil
 
 export const upload = multer({ storage, fileFilter, limits: { fileSize: MAX_FILE_SIZE } })
 
-export const handleMulterError = (err: any, _req: Request, _res: Response, next: NextFunction) => {
+export const handleMulterError = (err: unknown, _req: Request, _res: Response, next: NextFunction) => {
   if (err instanceof multer.MulterError) {
     if (err.code === 'LIMIT_FILE_SIZE') {
       return next(new AppError(`File too large. Maximum size is ${MAX_FILE_SIZE / (1024 * 1024)}MB`, 400))

--- a/packages/api/src/monitoring/business-metrics.ts
+++ b/packages/api/src/monitoring/business-metrics.ts
@@ -17,6 +17,7 @@ import {
 } from '../middleware/metrics.js'
 import { db } from '../db.js'
 import { logger } from '../config/logger.js'
+import { getErrorMessage } from '../utils/getErrorMessage.js'
 
 class BusinessMetricsRecorder {
   /**
@@ -28,8 +29,8 @@ class BusinessMetricsRecorder {
         where: { isActive: true },
       })
       setActiveWorkers(activeCount)
-    } catch (err: any) {
-      logger.error('Failed to sync worker metrics:', err.message)
+    } catch (err) {
+      logger.error(`Failed to sync worker metrics: ${getErrorMessage(err)}`)
     }
   }
 
@@ -60,8 +61,8 @@ class BusinessMetricsRecorder {
         })
         setUsersVerified(verifiedByRole, stat.role)
       }
-    } catch (err: any) {
-      logger.error('Failed to sync user metrics:', err.message)
+    } catch (err) {
+      logger.error(`Failed to sync user metrics: ${getErrorMessage(err)}`)
     }
   }
 
@@ -71,8 +72,8 @@ class BusinessMetricsRecorder {
   recordWorkerCreated(category: string) {
     try {
       recordWorkerRegistration(category, 'success')
-    } catch (err: any) {
-      logger.error('Failed to record worker registration:', err.message)
+    } catch (err) {
+      logger.error(`Failed to record worker registration: ${getErrorMessage(err)}`)
     }
   }
 
@@ -82,8 +83,8 @@ class BusinessMetricsRecorder {
   recordPayment(amount: number, currency: string = 'XLM', usdValue: number = 0) {
     try {
       recordTip(amount, currency, usdValue)
-    } catch (err: any) {
-      logger.error('Failed to record payment metric:', err.message)
+    } catch (err) {
+      logger.error(`Failed to record payment metric: ${getErrorMessage(err)}`)
     }
   }
 
@@ -93,8 +94,8 @@ class BusinessMetricsRecorder {
   recordReviewCreated(rating: number, category: string = 'all') {
     try {
       recordReview(rating, category)
-    } catch (err: any) {
-      logger.error('Failed to record review metric:', err.message)
+    } catch (err) {
+      logger.error(`Failed to record review metric: ${getErrorMessage(err)}`)
     }
   }
 
@@ -104,8 +105,8 @@ class BusinessMetricsRecorder {
   recordContractRegistrationAttempt(success: boolean) {
     try {
       recordContractRegistration(success ? 'success' : 'failure')
-    } catch (err: any) {
-      logger.error('Failed to record contract registration metric:', err.message)
+    } catch (err) {
+      logger.error(`Failed to record contract registration metric: ${getErrorMessage(err)}`)
     }
   }
 
@@ -115,8 +116,8 @@ class BusinessMetricsRecorder {
   recordContractTx(type: string, success: boolean, gasUsed?: number) {
     try {
       recordContractTransaction(type, success ? 'success' : 'failure', gasUsed)
-    } catch (err: any) {
-      logger.error('Failed to record contract transaction metric:', err.message)
+    } catch (err) {
+      logger.error(`Failed to record contract transaction metric: ${getErrorMessage(err)}`)
     }
   }
 

--- a/packages/api/src/monitoring/profiler.ts
+++ b/packages/api/src/monitoring/profiler.ts
@@ -2,6 +2,7 @@ import profiler from 'v8-profiler-next';
 import fs from 'fs';
 import path from 'path';
 import v8 from 'v8';
+import type { Application, Request, Response } from 'express';
 
 const PROFILE_DIR = process.env.PROFILE_DIR || './profiles';
 
@@ -138,36 +139,36 @@ export class PerformanceProfiler {
 export const profiler = new PerformanceProfiler();
 
 // Expose profiler endpoints for on-demand profiling
-export function setupProfilerEndpoints(app: any) {
+export function setupProfilerEndpoints(app: Application) {
   // Start CPU profiling
-  app.post('/admin/profiler/cpu/start', (req: any, res: any) => {
+  app.post('/admin/profiler/cpu/start', (req: Request, res: Response) => {
     const name = req.body.name || 'manual-cpu-profile';
     profiler.startCPUProfile(name);
     res.json({ message: 'CPU profiling started', name });
   });
 
   // Stop CPU profiling
-  app.post('/admin/profiler/cpu/stop', (req: any, res: any) => {
+  app.post('/admin/profiler/cpu/stop', (req: Request, res: Response) => {
     const name = req.body.name || 'manual-cpu-profile';
     profiler.stopCPUProfile(name);
     res.json({ message: 'CPU profiling stopped', name });
   });
 
   // Take heap snapshot
-  app.post('/admin/profiler/heap/snapshot', (req: any, res: any) => {
+  app.post('/admin/profiler/heap/snapshot', (req: Request, res: Response) => {
     const name = req.body.name || 'manual-heap-snapshot';
     const filename = profiler.takeHeapSnapshot(name);
     res.json({ message: 'Heap snapshot taken', filename });
   });
 
   // Get memory stats
-  app.get('/admin/profiler/memory', (req: any, res: any) => {
+  app.get('/admin/profiler/memory', (req: Request, res: Response) => {
     const stats = profiler.getMemoryStats();
     res.json(stats);
   });
 
   // Get CPU stats
-  app.get('/admin/profiler/cpu', (req: any, res: any) => {
+  app.get('/admin/profiler/cpu', (req: Request, res: Response) => {
     const stats = profiler.getCPUStats();
     res.json(stats);
   });

--- a/packages/api/src/repositories/worker.repository.ts
+++ b/packages/api/src/repositories/worker.repository.ts
@@ -176,8 +176,7 @@ export class WorkerRepository implements IWorkerRepository {
 
     // Availability filtering
     if (dayOfWeek !== undefined || startTime || endTime) {
-      where.availability = { some: {} }
-      const availWhere: any = where.availability.some
+      const availWhere: Prisma.AvailabilityWhereInput = {}
       if (dayOfWeek !== undefined) {
         availWhere.dayOfWeek = dayOfWeek
       }
@@ -187,6 +186,7 @@ export class WorkerRepository implements IWorkerRepository {
       if (endTime) {
         availWhere.endTime = { lte: endTime }
       }
+      where.availability = { some: availWhere }
     }
 
     // Fetch workers with essential relations only (no reviews — avoids N+1)
@@ -281,7 +281,7 @@ export class WorkerRepository implements IWorkerRepository {
   }
 
   private calculateRelevance(
-    worker: any,
+    worker: Pick<Worker, 'name' | 'bio' | 'isVerified'>,
     query?: string,
     avgRating?: number,
     distanceKm?: number,

--- a/packages/api/src/services/analytics/worker.service.ts
+++ b/packages/api/src/services/analytics/worker.service.ts
@@ -12,6 +12,7 @@
  */
 import { db } from '../../db.js'
 import { AppError } from '../AppError.js'
+import { getErrorMessage } from '../../utils/getErrorMessage.js'
 import {
   type DateRange,
   type TimeSeriesPoint,
@@ -137,8 +138,8 @@ export function parseAnalyticsDateRange(
     endDate = parseDateBoundary(query.endDate, 'end') ?? now
     const defaultDays = Math.min(Math.max(Number(query.days) || 30, 1), 366)
     startDate = parseDateBoundary(query.startDate, 'start') ?? daysBefore(endDate, defaultDays - 1)
-  } catch (err: any) {
-    throw new AppError(err.message, 400)
+  } catch (err) {
+    throw new AppError(getErrorMessage(err), 400)
   }
 
   if (startDate > endDate) throw new AppError('startDate must be before or equal to endDate', 400)

--- a/packages/api/src/services/audit.service.ts
+++ b/packages/api/src/services/audit.service.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client'
 import { db } from '../db.js'
 import { logger } from '../config/logger.js'
 
@@ -30,7 +31,7 @@ export async function queryLogs(opts: {
 }) {
   const { userId, action, resource, from, to, page = 1, limit = 50 } = opts
 
-  const where: any = {
+  const where: Prisma.AuditLogWhereInput = {
     ...(userId ? { userId } : {}),
     ...(action ? { action: { contains: action, mode: 'insensitive' } } : {}),
     ...(resource ? { resource } : {}),

--- a/packages/api/src/services/job.service.ts
+++ b/packages/api/src/services/job.service.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client'
 import { db } from '../db.js'
 import { AppError } from '../services/AppError.js'
 import { dispatchNotification } from '../services/notification.service.js'
@@ -56,8 +57,8 @@ export async function listJobs(opts: {
   await expireJobs()
   const { categoryId, status = 'open', search, skills, urgency, minBudget, maxBudget, page = 1, limit = 20 } = opts
 
-  const where: any = {
-    ...(status !== 'all' ? { status } : {}),
+  const where: Prisma.JobWhereInput = {
+    ...(status !== 'all' ? { status: status as Prisma.JobWhereInput['status'] } : {}),
     ...(categoryId ? { categoryId } : {}),
     ...(urgency ? { urgency } : {}),
     ...(minBudget !== undefined || maxBudget !== undefined

--- a/packages/api/src/services/notification.service.ts
+++ b/packages/api/src/services/notification.service.ts
@@ -133,20 +133,31 @@ async function sendEmailNotification(payload: NotificationPayload): Promise<void
   })
 }
 
-function shouldSendEmail(prefs: any, type: string): boolean {
+/**
+ * Minimal view of a user's notification preferences that the dispatch gates
+ * depend on. Both a persisted `NotificationPreferences` row and the in-memory
+ * `DEFAULT_PREFERENCES` fallback satisfy this shape.
+ */
+interface NotificationPrefsView {
+  reviewReply: boolean
+  announcements: boolean
+}
+
+function shouldSendEmail(prefs: NotificationPrefsView, type: string): boolean {
   // Keyed on the real NotificationType enum values (tip/review/contact/system/message) —
   // 'worker_nearby'/'status_change'/'review_reply'/'announcement' never match any
   // actual dispatch call site (every caller uses 'system'), so preferences never
   // took effect. 'newWorkerNearby'/'statusChange' have no corresponding enum
   // value yet, so they stay unmapped (default-on) until that type exists.
-  const typeMap: Record<string, keyof typeof prefs> = {
+  const typeMap: Record<string, keyof NotificationPrefsView> = {
     'review': 'reviewReply',
     'system': 'announcements',
   }
-  return prefs[typeMap[type]] ?? true
+  const key = typeMap[type]
+  return key ? prefs[key] : true
 }
 
-function shouldSendPush(prefs: any, type: string): boolean {
+function shouldSendPush(prefs: NotificationPrefsView, type: string): boolean {
   // Always send push for important notifications
   return !['review'].includes(type) || prefs.reviewReply
 }

--- a/packages/api/src/services/storage.service.ts
+++ b/packages/api/src/services/storage.service.ts
@@ -9,30 +9,58 @@ import path from 'node:path'
 import { logger } from '../config/logger.js'
 
 // ── Lazy S3 import (optional dep — graceful fallback) ─────────────────────────
-let s3Client: any = null
-let PutObjectCommand: any = null
-let GetObjectCommand: any = null
-let DeleteObjectCommand: any = null
-let getSignedUrl: any = null
+// `@aws-sdk/*` is an optional dependency that may not be installed, so its types
+// aren't available at build time. We model only the small surface we use with
+// local structural interfaces instead of falling back to `any`.
+interface S3CommandInput {
+  Bucket: string
+  Key: string
+  Body?: unknown
+  ContentType?: string
+}
+type S3Command = object
+interface S3CommandCtor {
+  new (input: S3CommandInput): S3Command
+}
+interface S3ClientLike {
+  send(command: S3Command): Promise<unknown>
+}
+type SignUrlFn = (
+  client: S3ClientLike,
+  command: S3Command,
+  options: { expiresIn: number },
+) => Promise<string>
 
-async function getS3() {
-  if (s3Client) return { s3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand, getSignedUrl }
+interface S3Bundle {
+  s3Client: S3ClientLike
+  PutObjectCommand: S3CommandCtor
+  GetObjectCommand: S3CommandCtor
+  DeleteObjectCommand: S3CommandCtor
+  getSignedUrl: SignUrlFn
+}
+
+let cachedS3: S3Bundle | null = null
+
+async function getS3(): Promise<S3Bundle | null> {
+  if (cachedS3) return cachedS3
   try {
     const s3Module = await import('@aws-sdk/client-s3')
     const signModule = await import('@aws-sdk/s3-request-presigner')
-    PutObjectCommand = s3Module.PutObjectCommand
-    GetObjectCommand = s3Module.GetObjectCommand
-    DeleteObjectCommand = s3Module.DeleteObjectCommand
-    getSignedUrl = signModule.getSignedUrl
-    s3Client = new s3Module.S3Client({
-      region: process.env['S3_REGION'] ?? 'us-east-1',
-      endpoint: process.env['S3_ENDPOINT'],           // for MinIO / R2
-      forcePathStyle: !!process.env['S3_ENDPOINT'],   // required for MinIO
-      credentials: process.env['S3_ACCESS_KEY']
-        ? { accessKeyId: process.env['S3_ACCESS_KEY']!, secretAccessKey: process.env['S3_SECRET_KEY']! }
-        : undefined,                                  // falls back to IAM role / env chain
-    })
-    return { s3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand, getSignedUrl }
+    cachedS3 = {
+      s3Client: new s3Module.S3Client({
+        region: process.env['S3_REGION'] ?? 'us-east-1',
+        endpoint: process.env['S3_ENDPOINT'],           // for MinIO / R2
+        forcePathStyle: !!process.env['S3_ENDPOINT'],   // required for MinIO
+        credentials: process.env['S3_ACCESS_KEY']
+          ? { accessKeyId: process.env['S3_ACCESS_KEY']!, secretAccessKey: process.env['S3_SECRET_KEY']! }
+          : undefined,                                  // falls back to IAM role / env chain
+      }),
+      PutObjectCommand: s3Module.PutObjectCommand,
+      GetObjectCommand: s3Module.GetObjectCommand,
+      DeleteObjectCommand: s3Module.DeleteObjectCommand,
+      getSignedUrl: signModule.getSignedUrl,
+    }
+    return cachedS3
   } catch {
     return null
   }

--- a/packages/api/src/services/webhook.service.ts
+++ b/packages/api/src/services/webhook.service.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto'
 import { db } from '../db.js'
 import { logger } from '../config/logger.js'
+import { getErrorMessage } from '../utils/getErrorMessage.js'
 
 const MAX_ATTEMPTS = 3
 const RETRY_DELAYS = [5_000, 30_000, 120_000] // 5s, 30s, 2min
@@ -36,10 +37,10 @@ async function deliver(logId: string, url: string, secret: string, event: string
     if (!res.ok && attempt < MAX_ATTEMPTS - 1) {
       setTimeout(() => deliver(logId, url, secret, event, payload, attempt + 1), RETRY_DELAYS[attempt])
     }
-  } catch (err: any) {
+  } catch (err) {
     await db.webhookLog.update({
       where: { id: logId },
-      data: { attempts: attempt + 1, error: err?.message ?? 'Unknown error' },
+      data: { attempts: attempt + 1, error: getErrorMessage(err) },
     })
     if (attempt < MAX_ATTEMPTS - 1) {
       setTimeout(() => deliver(logId, url, secret, event, payload, attempt + 1), RETRY_DELAYS[attempt])

--- a/packages/api/src/services/worker.service.ts
+++ b/packages/api/src/services/worker.service.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client'
 import { db } from '../db.js'
 import { AppError } from './AppError.js'
 import { formatWorker } from '../models/worker.model.js'
@@ -69,7 +70,7 @@ export async function listWorkers(opts: {
     ? { categoryId: category }
     : {}
 
-  const where: any = {
+  const where: Prisma.WorkerWhereInput = {
     isActive: true,
     deletedAt: null,
     ...categoryFilter,
@@ -90,7 +91,7 @@ export async function listWorkers(opts: {
   }
 
   if (minRating !== undefined || maxRating !== undefined) {
-    const havingClause: any = {}
+    const havingClause: { gte?: number; lte?: number } = {}
     if (minRating !== undefined) havingClause.gte = minRating
     if (maxRating !== undefined) havingClause.lte = maxRating
     const qualifiedIds = await db.review.groupBy({
@@ -102,7 +103,7 @@ export async function listWorkers(opts: {
   }
 
   // Build orderBy
-  let orderBy: any = { createdAt: 'desc' }
+  let orderBy: Prisma.WorkerOrderByWithRelationInput = { createdAt: 'desc' }
   if (sortBy === 'oldest') orderBy = { createdAt: 'asc' }
   else if (sortBy === 'name') orderBy = { name: sortOrder }
   else if (sortBy === 'newest') orderBy = { createdAt: sortOrder }
@@ -158,7 +159,7 @@ export async function listWorkersCursor(opts: {
     ? { categoryId: category }
     : {}
 
-  const where: any = {
+  const where: Prisma.WorkerWhereInput = {
     isActive: true,
     ...categoryFilter,
     ...(isVerified !== undefined ? { isVerified } : {}),
@@ -179,7 +180,7 @@ export async function listWorkersCursor(opts: {
   }
 
   if (minRating !== undefined || maxRating !== undefined) {
-    const havingClause: any = {}
+    const havingClause: { gte?: number; lte?: number } = {}
     if (minRating !== undefined) havingClause.gte = minRating
     if (maxRating !== undefined) havingClause.lte = maxRating
     const qualifiedIds = await db.review.groupBy({

--- a/packages/api/src/tracing/index.ts
+++ b/packages/api/src/tracing/index.ts
@@ -101,8 +101,19 @@ export const startSpan = (name: string, attributes?: Record<string, any>) => {
   return { span, ctx: trace.setSpan(context.active(), span) };
 };
 
+/**
+ * Minimal span surface used by the error helper. Declared locally because the
+ * `@opentelemetry/api` `Span` type is only available when the (optional) OTel
+ * packages are installed — this avoids `any` without a hard dependency.
+ */
+interface EndableSpan {
+  setStatus(status: { code: number; message?: string }): void
+  recordException(error: Error): void
+  end(): void
+}
+
 // Helper to end a span with error handling
-export const endSpanWithError = (span: any, error: Error) => {
+export const endSpanWithError = (span: EndableSpan, error: Error) => {
   span.setStatus({
     code: SpanStatusCode.ERROR,
     message: error.message,

--- a/packages/api/src/utils/getErrorMessage.ts
+++ b/packages/api/src/utils/getErrorMessage.ts
@@ -1,0 +1,16 @@
+/**
+ * Safely extract a human-readable message from an unknown caught value.
+ *
+ * `catch` clauses are typed `unknown` under `strict`, so this narrows the value
+ * to a string message without resorting to `any`. Handles `Error` instances,
+ * objects with a `message` property (e.g. non-`Error` throwables), and falls
+ * back to `String(err)` for primitives.
+ */
+export function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'object' && err !== null && 'message' in err) {
+    const message = (err as { message?: unknown }).message
+    if (typeof message === 'string') return message
+  }
+  return String(err)
+}

--- a/packages/api/src/utils/schemaVersioning.ts
+++ b/packages/api/src/utils/schemaVersioning.ts
@@ -7,9 +7,11 @@ import type { Request, Response, NextFunction } from 'express'
 /**
  * Define schema transformations between API versions
  */
+type JsonObject = Record<string, unknown>
+
 interface SchemaTransformer {
-  v1ToV2?: (data: any) => any
-  v2ToV1?: (data: any) => any
+  v1ToV2?: (data: JsonObject) => JsonObject
+  v2ToV1?: (data: JsonObject) => JsonObject
 }
 
 /**
@@ -17,22 +19,22 @@ interface SchemaTransformer {
  */
 const transformers: Record<string, SchemaTransformer> = {
   worker: {
-    v1ToV2: (worker: any) => ({
+    v1ToV2: (worker: JsonObject) => ({
       ...worker,
       verificationStatus: worker.verificationStatus || 'unverified',
     }),
-    v2ToV1: (worker: any) => {
-      const { verificationStatus, ...rest } = worker
+    v2ToV1: (worker: JsonObject) => {
+      const { verificationStatus: _verificationStatus, ...rest } = worker
       return rest
     },
   },
   user: {
-    v1ToV2: (user: any) => ({
+    v1ToV2: (user: JsonObject) => ({
       ...user,
       twoFactorEnabled: user.twoFactorEnabled ?? false,
     }),
-    v2ToV1: (user: any) => {
-      const { twoFactorEnabled, ...rest } = user
+    v2ToV1: (user: JsonObject) => {
+      const { twoFactorEnabled: _twoFactorEnabled, ...rest } = user
       return rest
     },
   },
@@ -42,11 +44,11 @@ const transformers: Record<string, SchemaTransformer> = {
  * Transform response data based on target API version
  */
 export function transformResponseData(
-  data: any,
+  data: unknown,
   resourceType: string,
   targetVersion: string,
   sourceVersion: string = 'v1'
-): any {
+): unknown {
   if (!data) return data
   if (targetVersion === sourceVersion) return data
 
@@ -56,13 +58,13 @@ export function transformResponseData(
   if (sourceVersion === 'v1' && targetVersion === 'v2') {
     return Array.isArray(data)
       ? data.map(item => transformer.v1ToV2?.(item) ?? item)
-      : transformer.v1ToV2?.(data) ?? data
+      : transformer.v1ToV2?.(data as JsonObject) ?? data
   }
 
   if (sourceVersion === 'v2' && targetVersion === 'v1') {
     return Array.isArray(data)
       ? data.map(item => transformer.v2ToV1?.(item) ?? item)
-      : transformer.v2ToV1?.(data) ?? data
+      : transformer.v2ToV1?.(data as JsonObject) ?? data
   }
 
   return data
@@ -90,7 +92,7 @@ export function getCompatibleFields(version: string, resourceType: string): stri
 /**
  * Filter response to only include compatible fields
  */
-export function filterCompatibleFields(data: any, version: string, resourceType: string): any {
+export function filterCompatibleFields(data: unknown, version: string, resourceType: string): unknown {
   const fields = getCompatibleFields(version, resourceType)
   if (!fields.length) return data
 
@@ -98,11 +100,11 @@ export function filterCompatibleFields(data: any, version: string, resourceType:
     return data.map(item => filterFields(item, fields))
   }
 
-  return filterFields(data, fields)
+  return filterFields(data as JsonObject, fields)
 }
 
-function filterFields(obj: Record<string, any>, fields: string[]): Record<string, any> {
-  const result: Record<string, any> = {}
+function filterFields(obj: JsonObject, fields: string[]): JsonObject {
+  const result: JsonObject = {}
   for (const field of fields) {
     if (field in obj) {
       result[field] = obj[field]
@@ -117,14 +119,15 @@ function filterFields(obj: Record<string, any>, fields: string[]): Record<string
 export function responseSchemaVersioning(req: Request, res: Response, next: NextFunction) {
   const originalJson = res.json.bind(res)
 
-  res.json = function(data: any) {
+  res.json = function(data: unknown) {
     const targetVersion = req.apiVersion || 'v1'
 
     // If response has a data field, transform it
     if (data && typeof data === 'object' && 'data' in data) {
       const resourceType = inferResourceType(req.path)
       if (resourceType) {
-        data.data = transformResponseData(data.data, resourceType, targetVersion, 'v1')
+        const envelope = data as { data: unknown }
+        envelope.data = transformResponseData(envelope.data, resourceType, targetVersion, 'v1')
       }
     }
 
@@ -149,7 +152,7 @@ function inferResourceType(path: string): string | null {
  * Returns 400 if the payload contains fields that are not valid for the given version.
  */
 export function validateRequestSchema(
-  data: any,
+  data: unknown,
   version: string,
   resourceType: string
 ): { valid: boolean; errors?: string[] } {
@@ -158,7 +161,7 @@ export function validateRequestSchema(
     return { valid: true }
   }
 
-  const dataFields = Object.keys(data || {})
+  const dataFields = Object.keys((data ?? {}) as JsonObject)
   const invalidFields = dataFields.filter(field => !compatibleFields.includes(field))
 
   if (invalidFields.length > 0) {
@@ -204,7 +207,7 @@ export function getSchemaDifferences(
   resourceType: string,
   v1Fields: string[],
   v2Fields: string[]
-): Record<string, any> {
+): Record<string, string[]> {
   return {
     added: v2Fields.filter(f => !v1Fields.includes(f)),
     removed: v1Fields.filter(f => !v2Fields.includes(f)),

--- a/packages/app/.eslintrc.json
+++ b/packages/app/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["next/core-web-vitals", "next/typescript"],
   "rules": {
-    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-explicit-any": "error"
   }
 }

--- a/packages/app/src/lib/analytics.ts
+++ b/packages/app/src/lib/analytics.ts
@@ -45,25 +45,28 @@ class Analytics {
     }
   }
 
-  private scrubPII(data: any): any {
-    if (!data) return data
-    if (typeof data !== 'object') return data
+  private scrubPII(data: unknown): unknown {
+    if (!data || typeof data !== 'object') return data
 
-    const scrubbed: any = Array.isArray(data) ? [] : {}
-    for (const key in data) {
-      // Block PII fields
-      if (['email', 'name', 'phone', 'address', 'ip', 'walletAddress'].includes(key)) {
-        continue
-      }
-      scrubbed[key] = typeof data[key] === 'object' ? this.scrubPII(data[key]) : data[key]
+    // Block PII fields
+    const BLOCKED = ['email', 'name', 'phone', 'address', 'ip', 'walletAddress']
+
+    if (Array.isArray(data)) {
+      return data.map((item) => (typeof item === 'object' ? this.scrubPII(item) : item))
+    }
+
+    const scrubbed: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      if (BLOCKED.includes(key)) continue
+      scrubbed[key] = typeof value === 'object' ? this.scrubPII(value) : value
     }
     return scrubbed
   }
 
-  private track(event: string, category: EventCategory, properties?: Record<string, any>) {
+  private track(event: string, category: EventCategory, properties?: Record<string, unknown>) {
     if (!this.consent.analytics) return
 
-    const scrubbedProperties = this.scrubPII(properties)
+    const scrubbedProperties = this.scrubPII(properties) as AnalyticsEvent['properties']
     const analyticsEvent: AnalyticsEvent = {
       event,
       category,


### PR DESCRIPTION
## Summary

Eliminates every explicit `: any` type annotation in the issue's worklist — `grep -rn ": any\b" packages/api/src --include="*.ts" | grep -v test` (57 hits) and the app `.ts` equivalent (2 hits) — replacing each with a real type. Where a type already existed it is wired in; where the value is genuinely dynamic it becomes `unknown` plus a runtime-narrowing step, not a blanket `any`.

Closes #935

## Worklist — `: any` triage

**API — `packages/api/src` (57 → 0)**

- [x] `app.ts` (×2) — `catch (err: any)` → `unknown` + `getErrorMessage()`
- [x] `repositories/worker.repository.ts` (×2) — `Prisma.AvailabilityWhereInput`; `Pick<Worker, …>` for relevance scoring
- [x] `middleware/audit.ts`, `middleware/idempotency.ts` — `res.json` overrides typed `unknown` / `Prisma.InputJsonValue`
- [x] `middleware/metrics.ts` — `res.send` body `unknown`
- [x] `middleware/upload.ts` — multer error handler `unknown`
- [x] `middleware/requestLogger.ts` (×3) — pino-http callbacks typed `IncomingMessage`
- [x] `services/webhook.service.ts`, `services/analytics/worker.service.ts`, `controllers/csv-import.ts`, `controllers/users.ts` (×2) — `catch` clauses `unknown` + narrowing (`getErrorMessage`, `AppError`/`ZodError` instanceof)
- [x] `services/worker.service.ts` (×5) — `Prisma.WorkerWhereInput` / `Prisma.WorkerOrderByWithRelationInput` / precise having-clause type
- [x] `services/audit.service.ts`, `services/job.service.ts` — `Prisma.AuditLogWhereInput` / `Prisma.JobWhereInput`
- [x] `services/storage.service.ts` (×5) — optional AWS SDK loader modelled with local structural interfaces (the SDK is an uninstalled optional dep, so its types aren't available at build time)
- [x] `services/notification.service.ts` (×2) — `NotificationPrefsView` interface (also removes a latent unsafe index access)
- [x] `config/passport.ts` — `serializeUser` no longer `any`
- [x] `controllers/export.ts` — CSV helpers use `unknown` / `Record<string, unknown>`
- [x] `monitoring/business-metrics.ts` (×7) — `catch` `unknown` + `getErrorMessage`
- [x] `monitoring/profiler.ts` (×6) — Express `Application` / `Request` / `Response`
- [x] `utils/schemaVersioning.ts` (×9) — `Record<string, unknown>` / `unknown` transforms
- [x] `tracing/index.ts` — minimal local `EndableSpan` interface

New shared util: `packages/api/src/utils/getErrorMessage.ts` — narrows an `unknown` caught value to a message string, replacing the repeated `catch (err: any) … err.message` pattern.

**App — `packages/app/src` (2 → 0)**

- [x] `lib/analytics.ts` — PII scrubber typed `unknown` with explicit array/object handling

## Regression lock

`@typescript-eslint/no-explicit-any` promoted from `warn` → `error` in both `packages/api/.eslintrc.json` and `packages/app/.eslintrc.json`.

## Verification

`main` currently does **not** build cleanly (`pnpm --filter api build` reports a large number of pre-existing errors — undefined `VERSION_CONFIG`, uninstalled optional deps such as `bullmq` / `@aws-sdk/*` / `@opentelemetry/*`, etc.), all unrelated to this change. Rather than claim a green build I can't honestly produce, I verified this diff against that baseline:

- Captured the full `tsc` error set before and after the change and compared it **line-number-independently** (line numbers shift as annotations are added).
- **Result: zero new type errors introduced**, and one pre-existing error in `notification.service.ts` is fixed.
- App package: `pnpm --filter app type-check` error count is unchanged (123 → 123) with `analytics.ts` clean.

## Scope / follow-ups

Per the issue's "land as several small PRs by directory" guidance, this PR covers the explicit `: any` worklist. Still open for a follow-up pass: `as any` casts (~53 in api, a handful in app `.tsx`) and `any` inside `.tsx` Storybook/component files (these were outside the issue's `--include="*.ts"` grep). Note also that `pnpm lint` cannot currently run in either package — ESLint 9 is installed but the repo still uses legacy `.eslintrc.json`; the config change here takes effect once that flat-config migration lands.
