### PR TITLE
feat(app): improve accessibility of the reviews panel

### DIFF
--- a/packages/app/src/__tests__/ReviewsSection.a11y.test.tsx
+++ b/packages/app/src/__tests__/ReviewsSection.a11y.test.tsx
@@ -1,0 +1,482 @@
+/**
+ * Accessibility regression tests for the reviews panel (ReviewsSection and the
+ * components it renders: ReviewSortFilter, RatingBreakdown, ReviewForm,
+ * ReviewCard, ReviewHelpfulButton).
+ *
+ * axe covers the static markup; the rest of the file covers what axe cannot
+ * see — keyboard operation, focus order, focus management across state
+ * changes, and live-region announcements.
+ */
+
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axe from 'axe-core'
+import React from 'react'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/workers/w1',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (key: string) => key,
+  useMessages: () => ({}),
+}))
+
+const mockUser = vi.fn(() => null as { id: string } | null)
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser() }),
+}))
+
+const getWorkerReviews = vi.fn()
+const createReview = vi.fn()
+const toggleReviewHelpful = vi.fn()
+vi.mock('@/lib/api', () => ({
+  getWorkerReviews: (...args: unknown[]) => getWorkerReviews(...args),
+  createReview: (...args: unknown[]) => createReview(...args),
+  toggleReviewHelpful: (...args: unknown[]) => toggleReviewHelpful(...args),
+}))
+
+import ReviewsSection from '@/components/ReviewsSection'
+import type { Review } from '@/types'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeReview(n: number, rating = 5): Review {
+  return {
+    id: `r${n}`,
+    rating,
+    comment: `Review number ${n}`,
+    createdAt: `2026-01-${String(n).padStart(2, '0')}T10:00:00.000Z`,
+    authorId: `a${n}`,
+    author: { id: `a${n}`, firstName: `First${n}`, lastName: `Last${n}`, avatar: null },
+  } as unknown as Review
+}
+
+const DISTRIBUTION = [
+  { rating: 5, count: 4, percentage: 67 },
+  { rating: 4, count: 1, percentage: 17 },
+  { rating: 3, count: 1, percentage: 17 },
+  { rating: 2, count: 0, percentage: 0 },
+  { rating: 1, count: 0, percentage: 0 },
+]
+
+function renderPanel(reviews: Review[] = [makeReview(1), makeReview(2, 3)]) {
+  return render(
+    <ReviewsSection
+      workerId="w1"
+      initialReviews={reviews}
+      reviewCount={reviews.length}
+      averageRating={4.2}
+      distribution={DISTRIBUTION as any}
+    />,
+  )
+}
+
+// ─── axe helper ───────────────────────────────────────────────────────────────
+
+async function runAxe(container: Element) {
+  const results = await axe.run(container, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'],
+    },
+  })
+  return results.violations
+}
+
+function formatViolations(violations: axe.Result[]): string {
+  return violations
+    .map((v) => `[${v.impact}] ${v.id}: ${v.help}\n  ${v.nodes.map((n) => n.html).join('\n  ')}`)
+    .join('\n')
+}
+
+/**
+ * Flush the pending filter request and its state update inside act(), so the
+ * async work a click kicked off doesn't land after the assertion.
+ */
+async function settled() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+/** The star-picker radio at 1-based position `n`. */
+function star(n: number): HTMLElement {
+  return screen.getByRole('radio', { name: `Rate ${n} star${n > 1 ? 's' : ''}` })
+}
+
+/** The panel's polite live region. */
+function liveRegion(container: Element): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[aria-live="polite"]')
+  if (!el) throw new Error('ReviewsSection rendered no polite live region')
+  return el
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUser.mockReturnValue(null)
+  getWorkerReviews.mockResolvedValue({ data: [makeReview(9, 5)] })
+  createReview.mockResolvedValue({ data: makeReview(99, 4) })
+  toggleReviewHelpful.mockResolvedValue({ data: { helpful: true, count: 1 } })
+})
+
+// ─── axe ──────────────────────────────────────────────────────────────────────
+
+describe('ReviewsSection — axe (WCAG 2.1 AA)', () => {
+  it('has no violations with reviews present', async () => {
+    const { container } = renderPanel()
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
+  })
+
+  it('has no violations in the empty state', async () => {
+    const { container } = render(
+      <ReviewsSection
+        workerId="w1"
+        initialReviews={[]}
+        reviewCount={0}
+        averageRating={null}
+        distribution={[] as any}
+      />,
+    )
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
+  })
+
+  it('has no violations once a rating filter is applied', async () => {
+    const user = userEvent.setup()
+    const { container } = renderPanel()
+    await user.click(screen.getByRole('button', { name: /Filter by 5 stars/ }))
+    await settled()
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
+  })
+
+  it('has no violations when the review form shows a validation error', async () => {
+    const user = userEvent.setup()
+    const { container } = renderPanel()
+    await user.click(screen.getByRole('button', { name: 'Submit Review' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Please select a rating.')
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
+  })
+})
+
+// ─── Roles, labels and structure ──────────────────────────────────────────────
+
+describe('ReviewsSection — ARIA roles and labels', () => {
+  it('exposes the panel as a region labelled by its heading', () => {
+    renderPanel()
+    const heading = screen.getByRole('heading', { level: 2, name: /Reviews/ })
+    const region = screen.getByRole('region', { name: /Reviews/ })
+    expect(region).toBeInTheDocument()
+    expect(heading.id).toBeTruthy()
+    expect(region).toHaveAttribute('aria-labelledby', heading.id)
+  })
+
+  it('exposes the reviews as a list so assistive tech announces the item count', () => {
+    renderPanel([makeReview(1), makeReview(2), makeReview(3)])
+    expect(within(screen.getByRole('list')).getAllByRole('listitem')).toHaveLength(3)
+  })
+
+  it('gives each review an article role labelled with its author', () => {
+    renderPanel([makeReview(1)])
+    expect(screen.getByRole('article', { name: 'Review by First1 Last1' })).toBeInTheDocument()
+  })
+
+  it('gives the sort control an accessible name', () => {
+    renderPanel()
+    expect(screen.getByRole('combobox', { name: 'Sort reviews' })).toBeInTheDocument()
+  })
+
+  it('groups the rating filters and labels each with its count and percentage', () => {
+    renderPanel()
+    const group = screen.getByRole('group', { name: 'Filter reviews by rating' })
+    expect(
+      within(group).getByRole('button', { name: 'Filter by 5 stars: 4 reviews, 67%' }),
+    ).toBeInTheDocument()
+    expect(
+      within(group).getByRole('button', { name: 'Filter by 4 stars: 1 review, 17%' }),
+    ).toBeInTheDocument()
+  })
+
+  it('reflects filter state via aria-pressed', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    const filter = screen.getByRole('button', { name: /Filter by 5 stars/ })
+    expect(filter).toHaveAttribute('aria-pressed', 'false')
+    await user.click(filter)
+    await waitFor(() => expect(filter).toHaveAttribute('aria-pressed', 'true'))
+    await settled()
+  })
+
+  it('exposes the average rating as a single labelled image', () => {
+    renderPanel()
+    expect(
+      screen.getByRole('img', { name: 'Average rating 4.2 out of 5 stars, from 2 reviews' }),
+    ).toBeInTheDocument()
+  })
+
+  it('describes the load-more button with the remaining count', () => {
+    renderPanel(Array.from({ length: 8 }, (_, i) => makeReview(i + 1)))
+    expect(
+      screen.getByRole('button', { name: 'Load more reviews, 3 remaining' }),
+    ).toBeInTheDocument()
+  })
+
+  it('marks the helpful toggle as a pressable button carrying its count', () => {
+    renderPanel([makeReview(1)])
+    expect(
+      screen.getByRole('button', { name: 'Mark as helpful (0 so far)' }),
+    ).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('renders the review date as a machine-readable time element', () => {
+    const { container } = renderPanel([makeReview(1)])
+    const time = container.querySelector('time')
+    expect(time).toHaveAttribute('dateTime', '2026-01-01T10:00:00.000Z')
+  })
+
+  it('provides the #review-form target that the empty-state CTA links to', () => {
+    const { container } = render(
+      <ReviewsSection
+        workerId="w1"
+        initialReviews={[]}
+        reviewCount={0}
+        averageRating={null}
+        distribution={[] as any}
+      />,
+    )
+    const cta = screen.getByRole('link', { name: /Write a Review/i })
+    expect(cta).toHaveAttribute('href', '#review-form')
+    // Without this element the CTA is a dead link.
+    expect(container.querySelector('#review-form')).toBeInTheDocument()
+  })
+})
+
+// ─── Keyboard navigation and focus order ──────────────────────────────────────
+
+describe('ReviewsSection — keyboard navigation', () => {
+  it('reaches the sort control, rating filters and review form by Tab alone', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.tab()
+    expect(screen.getByRole('combobox', { name: 'Sort reviews' })).toHaveFocus()
+
+    await user.tab()
+    expect(screen.getByRole('button', { name: /Filter by 5 stars/ })).toHaveFocus()
+
+    // Four remaining rating filters, then the star picker's single tab stop.
+    for (let i = 0; i < 4; i++) await user.tab()
+    await user.tab()
+    expect(screen.getByRole('radio', { name: 'Rate 1 star' })).toHaveFocus()
+  })
+
+  it('treats the star picker as one tab stop (roving tabindex)', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    const stars = screen.getAllByRole('radio')
+    expect(stars).toHaveLength(5)
+    // Only the active star is tabbable; the rest are reachable via arrow keys.
+    expect(stars.filter((s) => s.getAttribute('tabindex') === '0')).toHaveLength(1)
+
+    star(1).focus()
+    await user.tab()
+    expect(screen.getByRole('textbox', { name: 'Your review (optional)' })).toHaveFocus()
+  })
+
+  it('moves between stars with arrow keys and wraps at both ends', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    star(1).focus()
+    await user.keyboard('{ArrowRight}')
+    expect(star(2)).toHaveFocus()
+    expect(star(2)).toHaveAttribute('aria-checked', 'true')
+
+    await user.keyboard('{ArrowLeft}')
+    expect(star(1)).toHaveFocus()
+
+    // Wrap backwards from the first star to the last.
+    await user.keyboard('{ArrowLeft}')
+    expect(star(5)).toHaveFocus()
+    // And forwards from the last back to the first.
+    await user.keyboard('{ArrowRight}')
+    expect(star(1)).toHaveFocus()
+  })
+
+  it('supports Home and End within the star picker', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    star(1).focus()
+    await user.keyboard('{End}')
+    expect(star(5)).toHaveFocus()
+    expect(star(5)).toHaveAttribute('aria-checked', 'true')
+
+    await user.keyboard('{Home}')
+    expect(star(1)).toHaveFocus()
+    expect(star(1)).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('marks exactly one star as checked at a time', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(star(4))
+    const checked = screen.getAllByRole('radio').filter(
+      (s) => s.getAttribute('aria-checked') === 'true',
+    )
+    expect(checked).toHaveLength(1)
+    expect(star(4)).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('operates the rating filter with the keyboard', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    const filter = screen.getByRole('button', { name: /Filter by 3 stars/ })
+    filter.focus()
+    await user.keyboard('{Enter}')
+
+    await waitFor(() =>
+      expect(getWorkerReviews).toHaveBeenCalledWith('w1', { rating: '3', limit: '50' }),
+    )
+    await settled()
+  })
+})
+
+// ─── Focus management ─────────────────────────────────────────────────────────
+
+describe('ReviewsSection — focus management', () => {
+  it('moves focus to the first newly revealed review after Load more', async () => {
+    const user = userEvent.setup()
+    // 8 reviews, page size 5 — the 6th is the first revealed by Load more.
+    renderPanel(Array.from({ length: 8 }, (_, i) => makeReview(i + 1)))
+
+    await user.click(screen.getByRole('button', { name: /Load more reviews/ }))
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(8)
+    // Without this, focus would stay on a button that has moved down the page.
+    expect(items[5]).toHaveFocus()
+  })
+
+  it('returns focus to the star picker when submitting without a rating', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Submit Review' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Please select a rating.')
+    expect(star(1)).toHaveFocus()
+    expect(createReview).not.toHaveBeenCalled()
+  })
+
+  it('keeps focus on the chosen star after clicking it', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(star(3))
+    expect(star(3)).toHaveFocus()
+  })
+})
+
+// ─── Live regions ─────────────────────────────────────────────────────────────
+
+describe('ReviewsSection — live announcements', () => {
+  it('announces the result count when a rating filter is applied', async () => {
+    const user = userEvent.setup()
+    getWorkerReviews.mockResolvedValue({ data: [makeReview(9, 5), makeReview(10, 5)] })
+    const { container } = renderPanel()
+
+    await user.click(screen.getByRole('button', { name: /Filter by 5 stars/ }))
+
+    await waitFor(() =>
+      expect(liveRegion(container)).toHaveTextContent('Showing 2 5-star reviews.'),
+    )
+  })
+
+  it('announces when the filter is cleared', async () => {
+    const user = userEvent.setup()
+    const { container } = renderPanel()
+
+    const filter = screen.getByRole('button', { name: /Filter by 5 stars/ })
+    await user.click(filter)
+    await waitFor(() => expect(getWorkerReviews).toHaveBeenCalled())
+    await settled()
+    await user.click(filter)
+
+    await waitFor(() =>
+      expect(liveRegion(container)).toHaveTextContent('Rating filter cleared. Showing all reviews.'),
+    )
+  })
+
+  it('announces a sort change', async () => {
+    const user = userEvent.setup()
+    const { container } = renderPanel()
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Sort reviews' }), 'highest')
+
+    await waitFor(() =>
+      expect(liveRegion(container)).toHaveTextContent('Reviews sorted by highest rated first.'),
+    )
+  })
+
+  it('announces a failed filter request instead of failing silently', async () => {
+    const user = userEvent.setup()
+    getWorkerReviews.mockRejectedValue(new Error('network'))
+    const { container } = renderPanel()
+
+    await user.click(screen.getByRole('button', { name: /Filter by 5 stars/ }))
+
+    await waitFor(() =>
+      expect(liveRegion(container)).toHaveTextContent(
+        'Could not load filtered reviews. Showing all reviews.',
+      ),
+    )
+  })
+
+  it('announces a successfully posted review', async () => {
+    const user = userEvent.setup()
+    const { container } = renderPanel()
+
+    await user.click(star(5))
+    await user.click(screen.getByRole('button', { name: 'Submit Review' }))
+
+    await waitFor(() => expect(liveRegion(container)).toHaveTextContent('Your review was posted.'))
+  })
+
+  it('exposes the filter loading state as a status region', async () => {
+    const user = userEvent.setup()
+    let resolve: (v: unknown) => void = () => {}
+    getWorkerReviews.mockReturnValue(new Promise((r) => { resolve = r }))
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: /Filter by 5 stars/ }))
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Loading reviews…')
+
+    // Settle the request so the component's state update happens inside act().
+    await act(async () => {
+      resolve({ data: [] })
+    })
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+})

--- a/packages/app/src/components/RatingBreakdown.tsx
+++ b/packages/app/src/components/RatingBreakdown.tsx
@@ -31,41 +31,64 @@ export default function RatingBreakdown({ averageRating, reviewCount, distributi
     <div className="rounded-xl border bg-gray-50 p-4 mb-6">
       <div className="flex items-center gap-4 mb-4">
         <div className="text-center">
-          <p className="text-4xl font-bold text-gray-900">{averageRating?.toFixed(1)}</p>
-          <div className="flex items-center justify-center gap-0.5 mt-1">
-            {[1, 2, 3, 4, 5].map((s) => (
-              <Star
-                key={s}
-                size={14}
-                className={s <= Math.round(averageRating ?? 0) ? "text-yellow-400" : "text-gray-200"}
-                fill={s <= Math.round(averageRating ?? 0) ? "currentColor" : "none"}
-              />
-            ))}
+          {/* The numeral and the stars say the same thing; expose it once, as one label. */}
+          <div
+            role="img"
+            aria-label={`Average rating ${averageRating?.toFixed(1) ?? 0} out of 5 stars, from ${reviewCount} review${
+              reviewCount !== 1 ? "s" : ""
+            }`}
+          >
+            <p className="text-4xl font-bold text-gray-900" aria-hidden="true">
+              {averageRating?.toFixed(1)}
+            </p>
+            <div className="flex items-center justify-center gap-0.5 mt-1" aria-hidden="true">
+              {[1, 2, 3, 4, 5].map((s) => (
+                <Star
+                  key={s}
+                  size={14}
+                  className={s <= Math.round(averageRating ?? 0) ? "text-yellow-400" : "text-gray-200"}
+                  fill={s <= Math.round(averageRating ?? 0) ? "currentColor" : "none"}
+                />
+              ))}
+            </div>
+            <p className="text-xs text-gray-500 mt-1" aria-hidden="true">
+              {reviewCount} review{reviewCount !== 1 ? "s" : ""}
+            </p>
           </div>
-          <p className="text-xs text-gray-500 mt-1">{reviewCount} review{reviewCount !== 1 ? "s" : ""}</p>
         </div>
 
-        <div className="flex-1 flex flex-col gap-1.5">
+        <div className="flex-1 flex flex-col gap-1.5" role="group" aria-label="Filter reviews by rating">
           {distribution.map(({ rating, count, percentage }) => (
             <button
               key={rating}
+              type="button"
               onClick={() => handleFilter(rating)}
-              className={`flex items-center gap-2 rounded-md px-2 py-0.5 transition-colors text-left ${
+              className={`flex items-center gap-2 rounded-md px-2 py-0.5 transition-colors text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 activeFilter === rating ? "bg-blue-50 ring-1 ring-blue-300" : "hover:bg-white"
               }`}
               aria-pressed={activeFilter === rating}
-              aria-label={`Filter by ${rating} star${rating !== 1 ? "s" : ""}`}
+              aria-label={`Filter by ${rating} star${rating !== 1 ? "s" : ""}: ${count} review${
+                count !== 1 ? "s" : ""
+              }, ${percentage}%`}
             >
-              <span className="text-xs text-gray-500 w-3 shrink-0">{rating}</span>
-              <Star size={11} className="text-yellow-400 shrink-0" fill="currentColor" />
-              <div className="flex-1 h-2 rounded-full bg-gray-200 overflow-hidden">
+              {/* The button's aria-label already carries the numbers, so the bar,
+                  the count and the percentage are decorative for screen readers. */}
+              <span className="text-xs text-gray-500 w-3 shrink-0" aria-hidden="true">
+                {rating}
+              </span>
+              <Star size={11} className="text-yellow-400 shrink-0" fill="currentColor" aria-hidden="true" />
+              <div className="flex-1 h-2 rounded-full bg-gray-200 overflow-hidden" aria-hidden="true">
                 <div
                   className="h-full rounded-full bg-yellow-400 transition-all duration-300"
                   style={{ width: `${percentage}%` }}
                 />
               </div>
-              <span className="text-xs text-gray-400 w-8 text-right shrink-0">{percentage}%</span>
-              <span className="text-xs text-gray-400 w-5 text-right shrink-0">({count})</span>
+              <span className="text-xs text-gray-400 w-8 text-right shrink-0" aria-hidden="true">
+                {percentage}%
+              </span>
+              <span className="text-xs text-gray-400 w-5 text-right shrink-0" aria-hidden="true">
+                ({count})
+              </span>
             </button>
           ))}
         </div>
@@ -77,8 +100,9 @@ export default function RatingBreakdown({ averageRating, reviewCount, distributi
             Showing {activeFilter}-star reviews
           </p>
           <button
+            type="button"
             onClick={() => handleFilter(activeFilter)}
-            className="text-xs text-blue-600 hover:underline"
+            className="rounded text-xs text-blue-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             Clear filter
           </button>

--- a/packages/app/src/components/ReviewCard.tsx
+++ b/packages/app/src/components/ReviewCard.tsx
@@ -11,16 +11,25 @@ interface ReviewCardProps {
 export default function ReviewCard({ review, showVerifiedBadge }: ReviewCardProps) {
   const initials = `${review.author.firstName[0]}${review.author.lastName[0]}`.toUpperCase();
 
+  const authorName = `${review.author.firstName} ${review.author.lastName}`;
+
   return (
-    <div className="flex gap-3 py-4 border-b last:border-0 dark:border-gray-800">
+    <article
+      className="flex gap-3 py-4 border-b last:border-0 dark:border-gray-800"
+      aria-label={`Review by ${authorName}`}
+    >
       {review.author.avatar ? (
         <img
           src={review.author.avatar}
-          alt={`${review.author.firstName} ${review.author.lastName}`}
+          alt={authorName}
           className="h-9 w-9 rounded-full object-cover shrink-0"
         />
       ) : (
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 text-xs font-bold dark:bg-blue-900 dark:text-blue-400">
+        // Initials duplicate the author name rendered below — decorative.
+        <div
+          aria-hidden="true"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 text-xs font-bold dark:bg-blue-900 dark:text-blue-400"
+        >
           {initials}
         </div>
       )}
@@ -28,17 +37,17 @@ export default function ReviewCard({ review, showVerifiedBadge }: ReviewCardProp
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
-              {review.author.firstName} {review.author.lastName}
+              {authorName}
             </span>
             {showVerifiedBadge && <VerifiedTransactionBadge />}
           </div>
-          <span className="text-xs text-gray-400 shrink-0">
+          <time dateTime={review.createdAt} className="text-xs text-gray-400 shrink-0">
             {new Date(review.createdAt).toLocaleDateString("en-US", {
               month: "short",
               day: "numeric",
               year: "numeric",
             })}
-          </span>
+          </time>
         </div>
         <StarRating rating={review.rating} className="mt-0.5" />
         {review.comment && (
@@ -48,6 +57,6 @@ export default function ReviewCard({ review, showVerifiedBadge }: ReviewCardProp
           <ReviewHelpfulButton reviewId={review.id} />
         </div>
       </div>
-    </div>
+    </article>
   );
 }

--- a/packages/app/src/components/ReviewForm.tsx
+++ b/packages/app/src/components/ReviewForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useRef, useState } from "react";
 import { Star, Loader2 } from "lucide-react";
 import { createReview } from "@/lib/api";
 import type { Review } from "@/types";
@@ -10,9 +10,16 @@ interface ReviewFormProps {
   onReviewCreated: (review: Review) => void;
 }
 
+const STARS = [1, 2, 3, 4, 5];
+
 /**
  * Star-picker form for submitting a review.
  * Calls onReviewCreated with the new review on success.
+ *
+ * The star picker implements the ARIA radiogroup pattern: the group is a single
+ * tab stop, and Arrow/Home/End move between stars. Five separately tabbable
+ * buttons would otherwise force keyboard users through the whole scale to reach
+ * the comment field.
  */
 export default function ReviewForm({ workerId, onReviewCreated }: ReviewFormProps) {
   const [rating, setRating] = useState(0);
@@ -21,9 +28,43 @@ export default function ReviewForm({ workerId, onReviewCreated }: ReviewFormProp
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const groupId = useId();
+  const commentId = useId();
+  const errorId = useId();
+  const starRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  /** The star that owns the group's tab stop — the selection, or the first star. */
+  const focusableStar = rating || 1;
+
+  const selectStar = (star: number) => {
+    setRating(star);
+    setError(null);
+    starRefs.current[star - 1]?.focus();
+  };
+
+  const handleStarKeyDown = (e: React.KeyboardEvent, star: number) => {
+    const moves: Record<string, number> = {
+      ArrowRight: star + 1,
+      ArrowDown: star + 1,
+      ArrowLeft: star - 1,
+      ArrowUp: star - 1,
+      Home: 1,
+      End: STARS.length,
+    };
+    const next = moves[e.key];
+    if (next === undefined) return;
+    e.preventDefault();
+    // Wrap around, matching the radiogroup pattern.
+    selectStar(((next - 1 + STARS.length) % STARS.length) + 1);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (rating === 0) return setError("Please select a rating.");
+    if (rating === 0) {
+      setError("Please select a rating.");
+      starRefs.current[0]?.focus();
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -39,28 +80,53 @@ export default function ReviewForm({ workerId, onReviewCreated }: ReviewFormProp
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3" aria-busy={loading}>
       {/* Star picker */}
-      <div className="flex items-center gap-1">
-        {[1, 2, 3, 4, 5].map((star) => (
-          <button
-            key={star}
-            type="button"
-            onClick={() => setRating(star)}
-            onMouseEnter={() => setHovered(star)}
-            onMouseLeave={() => setHovered(0)}
-            aria-label={`Rate ${star} star${star > 1 ? "s" : ""}`}
-          >
-            <Star
-              size={22}
-              className={(hovered || rating) >= star ? "text-yellow-400" : "text-gray-200"}
-              fill={(hovered || rating) >= star ? "currentColor" : "none"}
-            />
-          </button>
-        ))}
+      <span id={groupId} className="sr-only">
+        Rating
+      </span>
+      <div
+        role="radiogroup"
+        aria-labelledby={groupId}
+        aria-required="true"
+        aria-describedby={error ? errorId : undefined}
+        className="flex items-center gap-1"
+      >
+        {STARS.map((star) => {
+          const filled = (hovered || rating) >= star;
+          return (
+            <button
+              key={star}
+              ref={(el) => {
+                starRefs.current[star - 1] = el;
+              }}
+              type="button"
+              role="radio"
+              aria-checked={rating === star}
+              tabIndex={star === focusableStar ? 0 : -1}
+              onClick={() => selectStar(star)}
+              onKeyDown={(e) => handleStarKeyDown(e, star)}
+              onMouseEnter={() => setHovered(star)}
+              onMouseLeave={() => setHovered(0)}
+              className="rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              aria-label={`Rate ${star} star${star > 1 ? "s" : ""}`}
+            >
+              <Star
+                size={22}
+                aria-hidden="true"
+                className={filled ? "text-yellow-400" : "text-gray-200"}
+                fill={filled ? "currentColor" : "none"}
+              />
+            </button>
+          );
+        })}
       </div>
 
+      <label htmlFor={commentId} className="sr-only">
+        Your review (optional)
+      </label>
       <textarea
+        id={commentId}
         value={comment}
         onChange={(e) => setComment(e.target.value)}
         placeholder="Share your experience (optional)"
@@ -68,15 +134,19 @@ export default function ReviewForm({ workerId, onReviewCreated }: ReviewFormProp
         className="w-full rounded-lg border px-3 py-2 text-sm text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
       />
 
-      {error && <p className="text-xs text-red-500">{error}</p>}
+      {error && (
+        <p id={errorId} role="alert" className="text-xs text-red-500">
+          {error}
+        </p>
+      )}
 
       <button
         type="submit"
         disabled={loading}
         className="flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60 transition-colors"
       >
-        {loading && <Loader2 size={14} className="animate-spin" />}
-        Submit Review
+        {loading && <Loader2 size={14} className="animate-spin" aria-hidden="true" />}
+        {loading ? "Submitting Review…" : "Submit Review"}
       </button>
     </form>
   );

--- a/packages/app/src/components/ReviewHelpfulButton.tsx
+++ b/packages/app/src/components/ReviewHelpfulButton.tsx
@@ -35,18 +35,22 @@ export default function ReviewHelpfulButton({
 
   return (
     <button
+      type="button"
       onClick={handleToggle}
       disabled={loading}
+      aria-busy={loading}
+      aria-pressed={helpful}
       className={cn(
         "flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium transition-colors",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
         helpful
           ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
           : "text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
       )}
-      aria-label={helpful ? "Remove helpful vote" : "Mark as helpful"}
+      aria-label={`${helpful ? "Remove helpful vote" : "Mark as helpful"} (${count} so far)`}
     >
-      <ThumbsUp size={13} fill={helpful ? "currentColor" : "none"} />
-      <span>{count}</span>
+      <ThumbsUp size={13} fill={helpful ? "currentColor" : "none"} aria-hidden="true" />
+      <span aria-hidden="true">{count}</span>
     </button>
   );
 }

--- a/packages/app/src/components/ReviewSortFilter.tsx
+++ b/packages/app/src/components/ReviewSortFilter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import { ArrowUpDown } from "lucide-react";
 
 export type SortOption = "newest" | "oldest" | "highest" | "lowest";
@@ -17,10 +18,17 @@ const OPTIONS: { value: SortOption; label: string }[] = [
 ];
 
 export default function ReviewSortFilter({ sort, onSortChange }: Props) {
+  const selectId = useId();
+
   return (
     <div className="flex items-center gap-2">
-      <ArrowUpDown size={14} className="text-gray-400" />
+      <ArrowUpDown size={14} className="text-gray-400" aria-hidden="true" />
+      {/* The icon gives the select no accessible name, so label it explicitly. */}
+      <label htmlFor={selectId} className="sr-only">
+        Sort reviews
+      </label>
       <select
+        id={selectId}
         value={sort}
         onChange={(e) => onSortChange(e.target.value as SortOption)}
         className="rounded-lg border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400"

--- a/packages/app/src/components/ReviewsSection.tsx
+++ b/packages/app/src/components/ReviewsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import ReviewCard from "./ReviewCard";
 import ReviewForm from "./ReviewForm";
 import RatingBreakdown from "./RatingBreakdown";
@@ -11,6 +11,13 @@ import { getWorkerReviews } from "@/lib/api";
 import { useAuth } from "@/context/AuthContext";
 
 const PAGE_SIZE = 5;
+
+const SORT_LABELS: Record<SortOption, string> = {
+  newest: "newest first",
+  oldest: "oldest first",
+  highest: "highest rated first",
+  lowest: "lowest rated first",
+};
 
 interface Props {
   workerId: string;
@@ -34,6 +41,13 @@ export default function ReviewsSection({
   const [filterLoading, setFilterLoading] = useState(false);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [sort, setSort] = useState<SortOption>("newest");
+  /** Announced politely when the list changes under the user without a page move. */
+  const [announcement, setAnnouncement] = useState("");
+
+  const headingId = useId();
+  const listRef = useRef<HTMLUListElement>(null);
+  /** Index of the first item revealed by "Load more", so focus can land on it. */
+  const focusIndexRef = useRef<number | null>(null);
 
   const hasReviewed = !!user && reviews.some((r) => r.authorId === user.id);
 
@@ -41,12 +55,35 @@ export default function ReviewsSection({
     setReviews((prev) => [review, ...prev]);
     setCount((c) => c + 1);
     setVisibleCount((v) => v + 1);
+    setAnnouncement("Your review was posted.");
   };
+
+  const handleSortChange = (next: SortOption) => {
+    setSort(next);
+    setAnnouncement(`Reviews sorted by ${SORT_LABELS[next]}.`);
+  };
+
+  const handleLoadMore = () => {
+    // Revealing items below the button leaves keyboard and screen reader users
+    // at the bottom of the list with no indication anything appeared, so move
+    // focus to the first new review once it renders.
+    focusIndexRef.current = visibleCount;
+    setVisibleCount((v) => v + PAGE_SIZE);
+  };
+
+  useEffect(() => {
+    const index = focusIndexRef.current;
+    if (index === null) return;
+    focusIndexRef.current = null;
+    const target = listRef.current?.children[index] as HTMLElement | undefined;
+    target?.focus();
+  }, [visibleCount]);
 
   const handleFilterChange = async (rating: number | null) => {
     if (rating === null) {
       setFilteredReviews(null);
       setVisibleCount(PAGE_SIZE);
+      setAnnouncement("Rating filter cleared. Showing all reviews.");
       return;
     }
     setFilterLoading(true);
@@ -54,8 +91,12 @@ export default function ReviewsSection({
       const res = await getWorkerReviews(workerId, { rating: String(rating), limit: "50" });
       setFilteredReviews(res.data);
       setVisibleCount(PAGE_SIZE);
+      setAnnouncement(
+        `Showing ${res.data.length} ${rating}-star review${res.data.length !== 1 ? "s" : ""}.`,
+      );
     } catch {
       setFilteredReviews(null);
+      setAnnouncement("Could not load filtered reviews. Showing all reviews.");
     } finally {
       setFilterLoading(false);
     }
@@ -83,13 +124,22 @@ export default function ReviewsSection({
   const hasMore = visibleCount < sorted.length;
 
   return (
-    <div className="mt-8 border-t pt-6 dark:border-gray-800">
+    <section
+      aria-labelledby={headingId}
+      className="mt-8 border-t pt-6 dark:border-gray-800"
+    >
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+        <h2 id={headingId} className="text-base font-semibold text-gray-900 dark:text-gray-100">
           Reviews {count > 0 && `(${count})`}
         </h2>
-        {count > 0 && <ReviewSortFilter sort={sort} onSortChange={setSort} />}
+        {count > 0 && <ReviewSortFilter sort={sort} onSortChange={handleSortChange} />}
       </div>
+
+      {/* Sorting, filtering and loading all mutate the list in place; without a
+          live region a screen reader user gets no feedback that anything moved. */}
+      <p aria-live="polite" aria-atomic="true" className="sr-only">
+        {announcement}
+      </p>
 
       {count > 0 && (
         <RatingBreakdown
@@ -104,24 +154,36 @@ export default function ReviewsSection({
         {hasReviewed ? (
           <p className="text-sm text-gray-500 italic dark:text-gray-400">You have already reviewed this worker.</p>
         ) : (
-          <>
+          // EmptyState's "Write a Review" CTA links here; the id must exist for
+          // that skip target to work.
+          <div id="review-form">
             <p className="text-sm font-medium text-gray-700 mb-3 dark:text-gray-300">Leave a review</p>
             <ReviewForm workerId={workerId} onReviewCreated={handleReviewCreated} />
-          </>
+          </div>
         )}
       </div>
 
       {filterLoading ? (
-        <div className="py-6 text-center text-sm text-gray-400">Loading...</div>
+        <div role="status" className="py-6 text-center text-sm text-gray-400">
+          Loading reviews…
+        </div>
       ) : displayed.length > 0 ? (
         <div>
-          {displayed.map((review) => (
-            <ReviewCard key={review.id} review={review} />
-          ))}
+          <ul ref={listRef} className="list-none p-0 m-0">
+            {displayed.map((review) => (
+              // tabIndex={-1} makes each item a programmatic focus target for
+              // the "Load more" handler without adding it to the tab order.
+              <li key={review.id} tabIndex={-1} className="focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded">
+                <ReviewCard review={review} />
+              </li>
+            ))}
+          </ul>
           {hasMore && (
             <button
-              onClick={() => setVisibleCount((v) => v + PAGE_SIZE)}
-              className="mt-4 w-full rounded-lg border py-2 text-sm text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 transition-colors"
+              type="button"
+              onClick={handleLoadMore}
+              aria-label={`Load more reviews, ${sorted.length - visibleCount} remaining`}
+              className="mt-4 w-full rounded-lg border py-2 text-sm text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
               Load more ({sorted.length - visibleCount} remaining)
             </button>
@@ -130,6 +192,6 @@ export default function ReviewsSection({
       ) : (
         <EmptyState variant="no-reviews" ctaHref="#review-form" />
       )}
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
Closes #963

## Component naming

The issue names `ReviewsPanel`, which does not exist in this repo. The reviews panel is `src/components/ReviewsSection.tsx`, so this PR targets that and the components it renders — `ReviewSortFilter`, `RatingBreakdown`, `ReviewForm`, `ReviewCard`, `ReviewHelpfulButton`. Happy to rename the component to `ReviewsPanel` in a follow-up if maintainers prefer the issue's name.

## Audit

Ran `axe-core` (WCAG 2.1 AA + best-practice) against the rendered panel, matching the config already used in `src/__tests__/accessibility.test.tsx`.

**Before:** 1 critical violation — `select-name`, the sort dropdown had no accessible name.
**After:** 0 violations across four states (with reviews, empty, rating-filtered, form showing a validation error).

axe only checks static markup, so the rest of the audit was manual keyboard walkthrough. That found the more serious problems — none of which axe flags.

## Fixes

**ARIA labels and roles**
- `ReviewSortFilter` — the `<select>`'s only sibling was a decorative icon, so it had no accessible name at all. Added a visually hidden `<label>` and `aria-hidden` on the icon.
- `ReviewsSection` — now a `<section>` labelled by its `<h2>`, so it appears as a navigable region.
- Reviews render as a real `<ul>`/`<li>` list, so assistive tech announces "list, 5 items" instead of an undifferentiated run of text.
- `ReviewCard` — `<article>` labelled `Review by {author}`; date is now a `<time dateTime=…>`; the initials avatar fallback is `aria-hidden` since it duplicates the author name rendered beside it.
- `RatingBreakdown` — the distribution buttons are wrapped in a labelled `role="group"`, and each label now carries its numbers (`"Filter by 5 stars: 4 reviews, 67%"`) rather than just `"Filter by 5 stars"`. The average-rating cluster was three separate fragments (a numeral, five icons, a count) read as disconnected noise; it is now one `role="img"` with a single label, with the visual pieces hidden.
- `ReviewHelpfulButton` — added `aria-pressed` so toggle state is exposed, and folded the count into the label.

**Keyboard navigability and focus order**
- The star picker was five separately tabbable buttons, forcing keyboard users through the whole rating scale to reach the comment field. It now implements the ARIA **radiogroup** pattern with a roving tabindex: one tab stop, `←`/`→`/`↑`/`↓` to move (wrapping at both ends), `Home`/`End` to jump. `aria-checked` reflects the selection and `aria-required` marks it mandatory.
- The comment textarea had no label — only a placeholder, which is not an accessible name. Added a visually hidden `<label>`.
- Added visible `focus-visible` rings to the rating filters, star picker, clear-filter and load-more controls.

**Focus management**
- **Load more** appended reviews below the button and left focus where it was, so keyboard and screen reader users got no indication anything happened. Focus now moves to the first newly revealed review.
- Submitting without a rating now returns focus to the star picker alongside the error, instead of stranding it on the submit button.
- Clicking a star keeps focus on that star.

**Announcements** — sorting, filtering and loading all mutate the list in place with no page navigation, so a screen reader user previously had no feedback at all:
- Added a polite live region announcing sort changes, filter results (`"Showing 2 5-star reviews."`), filter clearing, and successful review submission.
- Filter loading is now `role="status"` with real text instead of a bare `Loading...` div.
- Filter request failures were swallowed silently; they now announce and fall back to all reviews.
- Validation errors are `role="alert"` and wired to the radiogroup via `aria-describedby`.

**Bug found during the audit** — `EmptyState`'s "Write a Review" CTA links to `#review-form`, but no element in the tree had that id, so the empty-state CTA was a dead link. Added the target element and a test asserting both halves stay in sync.

## Testing

New `src/__tests__/ReviewsSection.a11y.test.tsx` — **30 tests**:

| Group | Covers |
|---|---|
| axe (WCAG 2.1 AA) | 4 states: populated, empty, filtered, form error |
| ARIA roles and labels | region/heading association, list semantics, article labels, combobox name, filter group and labels, `aria-pressed`, average-rating label, `<time>`, `#review-form` target |
| Keyboard navigation | tab order through sort → filters → picker, single tab stop, arrow wrap both directions, Home/End, single-selection invariant, Enter on filters |
| Focus management | focus lands on first new review after Load more, returns to picker on validation error, stays on clicked star |
| Live announcements | filter result count, filter cleared, sort change, filter failure, review posted, loading status |

```
✓ src/__tests__/ReviewsSection.a11y.test.tsx  (30 tests)
✓ src/__tests__/accessibility.test.tsx        (14 tests)   ← existing suite, still green
Test Files  2 passed (2)
     Tests  44 passed (44)
```

`tsc --noEmit` reports no errors in any file this PR touches, and `next lint` on the changed components is clean apart from a pre-existing `no-img-element` warning in `ReviewCard`.

## Note on the full suite

`pnpm test` in `packages/app` fails 21 of 28 files **on `upstream/main` before this branch** — mostly components that call `useTranslations` without a `next-intl` provider mock. This PR does not change that count: 21 failed before and after, while passing tests go from 65 to 95. I left those pre-existing failures alone rather than widen this PR; happy to open a separate issue for them.

## Acceptance criteria

- [x] Audit ReviewsPanel with axe-core or Lighthouse
- [x] Add ARIA labels and roles
- [x] Ensure keyboard navigability and focus order
- [x] Add regression test for a11y violations
- [x] Tested (unit/integration as applicable)
- [ ] Code review passed
- [x] Related tests passing