### PR TITLE
feat(app): improve accessibility of the navigation header

### DIFF
--- a/packages/app/src/__tests__/Navbar.a11y.test.tsx
+++ b/packages/app/src/__tests__/Navbar.a11y.test.tsx
@@ -1,0 +1,332 @@
+/**
+ * Accessibility regression tests for the navigation header (Navbar).
+ *
+ * axe covers the static markup in both the desktop bar and the open mobile
+ * drawer; the rest covers what axe cannot see — the drawer's modal semantics,
+ * its focus trap, focus restoration, Escape handling, and current-page state.
+ */
+
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axe from 'axe-core'
+import React from 'react'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const mockPush = vi.fn()
+const mockPathname = vi.fn(() => '/workers')
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+// Return the key, with interpolated params appended, so tests can assert on
+// the dynamic half of a label without hard-coding English copy.
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key} ${Object.values(params).join(' ')}` : key,
+  useMessages: () => ({}),
+}))
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light', setTheme: vi.fn() }),
+}))
+
+const mockUser = vi.fn(() => null as { id: string; firstName: string; role: string } | null)
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: mockUser(), logout: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useWallet', () => ({
+  useWallet: () => ({
+    publicKey: null,
+    network: null,
+    isConnecting: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
+}))
+
+vi.mock('@/context/NotificationContext', () => ({
+  useNotifications: () => ({
+    notifications: [],
+    unreadCount: 0,
+    markRead: vi.fn(),
+    markAllRead: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}))
+
+import Navbar from '@/components/Navbar'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function runAxe(container: Element) {
+  const results = await axe.run(container, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'],
+    },
+  })
+  return results.violations
+}
+
+function formatViolations(violations: axe.Result[]): string {
+  return violations
+    .map((v) => `[${v.impact}] ${v.id}: ${v.help}\n  ${v.nodes.map((n) => n.html).join('\n  ')}`)
+    .join('\n')
+}
+
+const menuButton = () => screen.getByRole('button', { name: 'openMenu' })
+const drawer = () => screen.getByRole('dialog', { name: 'mobileMenu' })
+
+/** Open the mobile drawer and return it. */
+async function openDrawer(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(menuButton())
+  return drawer()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUser.mockReturnValue(null)
+  mockPathname.mockReturnValue('/workers')
+})
+
+// ─── axe ──────────────────────────────────────────────────────────────────────
+
+describe('Navbar — axe (WCAG 2.1 AA)', () => {
+  it('has no violations when logged out', async () => {
+    const { container } = render(<Navbar />)
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
+  })
+
+  it('has no violations when logged in', async () => {
+    mockUser.mockReturnValue({ id: 'u1', firstName: 'Ada', role: 'admin' })
+    const { container } = render(<Navbar />)
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
+  })
+
+  it('has no violations with the mobile drawer open', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<Navbar />)
+    await openDrawer(user)
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
+  })
+})
+
+// ─── Landmarks, roles and labels ──────────────────────────────────────────────
+
+describe('Navbar — ARIA roles and labels', () => {
+  it('labels the nav landmark, so it is distinguishable from BottomNav', () => {
+    render(<Navbar />)
+    expect(screen.getByRole('navigation', { name: 'primaryNavigation' })).toBeInTheDocument()
+  })
+
+  it('exposes the primary links as a list', () => {
+    render(<Navbar />)
+    const nav = screen.getByRole('navigation', { name: 'primaryNavigation' })
+    // Desktop bar; the drawer list only exists while the drawer is open.
+    expect(within(nav).getAllByRole('listitem')).toHaveLength(3)
+  })
+
+  it('marks the active link with aria-current="page"', () => {
+    mockPathname.mockReturnValue('/workers')
+    render(<Navbar />)
+    expect(screen.getByRole('link', { name: 'workers' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: 'home' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('does not mark any link current on an unrelated route', () => {
+    mockPathname.mockReturnValue('/settings')
+    render(<Navbar />)
+    for (const name of ['home', 'workers', 'about']) {
+      expect(screen.getByRole('link', { name })).not.toHaveAttribute('aria-current')
+    }
+  })
+
+  it('names the language trigger with the current language', () => {
+    render(<Navbar />)
+    expect(
+      screen.getByRole('button', { name: 'changeLanguage English' }),
+    ).toBeInTheDocument()
+  })
+
+  it('names the account trigger with the signed-in user', () => {
+    mockUser.mockReturnValue({ id: 'u1', firstName: 'Ada', role: 'user' })
+    render(<Navbar />)
+    expect(screen.getByRole('button', { name: 'accountMenu Ada' })).toBeInTheDocument()
+  })
+
+  it('describes the menu button as a collapsed dialog trigger', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+
+    expect(menuButton()).toHaveAttribute('aria-expanded', 'false')
+    expect(menuButton()).toHaveAttribute('aria-haspopup', 'dialog')
+
+    await openDrawer(user)
+    expect(menuButton()).toHaveAttribute('aria-expanded', 'true')
+    // aria-controls must point at the element that actually exists.
+    const controls = menuButton().getAttribute('aria-controls')
+    expect(controls).toBeTruthy()
+    expect(document.getElementById(controls!)).toBe(drawer())
+  })
+})
+
+// ─── Mobile drawer: modal semantics ───────────────────────────────────────────
+
+describe('Navbar — mobile drawer semantics', () => {
+  it('exposes the drawer as a labelled modal dialog', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+    const panel = await openDrawer(user)
+    expect(panel).toHaveAttribute('aria-modal', 'true')
+    expect(panel).toHaveAttribute('aria-label', 'mobileMenu')
+  })
+
+  it('hides the click-to-dismiss backdrop from assistive tech', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<Navbar />)
+    await openDrawer(user)
+    // The backdrop is mouse-only; Escape and the close button serve keyboard
+    // users, so it must not appear as a phantom element in the a11y tree.
+    const backdrop = container.querySelector('.fixed.inset-0')
+    expect(backdrop).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('marks the active link current inside the drawer too', async () => {
+    const user = userEvent.setup()
+    mockPathname.mockReturnValue('/workers')
+    render(<Navbar />)
+    const panel = await openDrawer(user)
+    expect(within(panel).getByRole('link', { name: 'workers' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+  })
+
+  it('groups the drawer language switcher and marks the current locale', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+    const panel = await openDrawer(user)
+
+    const group = within(panel).getByRole('group', { name: 'language' })
+    expect(within(group).getByRole('button', { name: 'English' })).toHaveAttribute(
+      'aria-current',
+      'true',
+    )
+    expect(within(group).getByRole('button', { name: 'Français' })).not.toHaveAttribute(
+      'aria-current',
+    )
+  })
+})
+
+// ─── Mobile drawer: keyboard and focus ────────────────────────────────────────
+
+describe('Navbar — drawer keyboard navigation and focus management', () => {
+  it('does not steal focus on mount', () => {
+    // Focus restoration must be scoped to closing the drawer; if it runs on
+    // mount it hijacks the page's initial focus and breaks the tab order.
+    render(<Navbar />)
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it('moves focus into the drawer when it opens', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+    await openDrawer(user)
+    expect(screen.getByRole('button', { name: 'closeMenu' })).toHaveFocus()
+  })
+
+  it('closes on Escape and restores focus to the menu button', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+    await openDrawer(user)
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(menuButton()).toHaveFocus()
+  })
+
+  it('closes via the close button and restores focus to the menu button', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+    await openDrawer(user)
+
+    await user.click(screen.getByRole('button', { name: 'closeMenu' }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    // Focus must not be left on a button that no longer exists.
+    expect(menuButton()).toHaveFocus()
+  })
+
+  it('traps Tab inside the drawer, wrapping from the last element to the first', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+    const panel = await openDrawer(user)
+
+    const focusable = Array.from(
+      panel.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    )
+    expect(focusable.length).toBeGreaterThan(1)
+
+    const last = focusable[focusable.length - 1]!
+    last.focus()
+    await user.tab()
+
+    expect(focusable[0]!).toHaveFocus()
+  })
+
+  it('traps Shift+Tab, wrapping from the first element to the last', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+    const panel = await openDrawer(user)
+
+    const focusable = Array.from(
+      panel.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    )
+    const first = focusable[0]!
+    const last = focusable[focusable.length - 1]!
+
+    first.focus()
+    await user.tab({ shift: true })
+
+    expect(last).toHaveFocus()
+  })
+
+  it('keeps focus inside the drawer across a full Tab cycle', async () => {
+    const user = userEvent.setup()
+    render(<Navbar />)
+    const panel = await openDrawer(user)
+
+    const count = panel.querySelectorAll(
+      'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    ).length
+
+    // One extra Tab past the end proves the trap wraps rather than escaping
+    // into the page content behind the overlay.
+    for (let i = 0; i <= count; i++) {
+      await user.tab()
+      expect(panel.contains(document.activeElement)).toBe(true)
+    }
+  })
+})

--- a/packages/app/src/__tests__/Navbar.test.tsx
+++ b/packages/app/src/__tests__/Navbar.test.tsx
@@ -23,18 +23,45 @@ vi.mock('@/hooks/useAuth', () => ({
 }))
 
 vi.mock('@/hooks/useWallet', () => ({
-  useWallet: () => ({ address: null, connecting: false, connect: mockConnect }),
+  useWallet: () => ({
+    publicKey: null,
+    network: null,
+    isConnecting: false,
+    connect: mockConnect,
+    disconnect: vi.fn(),
+  }),
 }))
 
-// lucide-react stubs
-vi.mock('lucide-react', () => ({
-  Menu: () => <span />,
-  Wallet: () => <span />,
-  ChevronDown: () => <span />,
-  User: () => <span />,
-  Sun: () => <span data-testid="sun-icon" />,
-  Moon: () => <span data-testid="moon-icon" />,
+// Return the key, with any interpolated params appended, so assertions can
+// match on the dynamic part of a label (e.g. the user's name).
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key} ${Object.values(params).join(' ')}` : key,
+  useMessages: () => ({}),
 }))
+
+vi.mock('@/context/NotificationContext', () => ({
+  useNotifications: () => ({
+    notifications: [],
+    unreadCount: 0,
+    markRead: vi.fn(),
+    markAllRead: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}))
+
+// Stub every lucide icon as a decorative span via a Proxy, so the list of
+// icons Navbar imports can change without breaking this file.
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const Icon = () => <span aria-hidden="true" />
+  const mock: Record<string, unknown> = {}
+  for (const key of Object.keys(actual)) {
+    mock[key] = typeof (actual as any)[key] === 'function' ? Icon : (actual as any)[key]
+  }
+  return mock
+})
 
 vi.mock('next-themes', () => ({
   useTheme: () => ({ resolvedTheme: 'light', setTheme: vi.fn() }),
@@ -76,7 +103,7 @@ describe('Navbar', () => {
     setUser({ id: '1', firstName: 'Alice', lastName: 'Smith', email: 'a@b.com', role: 'user' })
     render(<Navbar />)
     await user.click(screen.getByRole('button', { name: /alice/i }))
-    expect(await screen.findByText('Logout')).toBeInTheDocument()
+    expect(await screen.findByText('logout')).toBeInTheDocument()
   })
 
   it('shows Dashboard for curator role', async () => {
@@ -84,7 +111,7 @@ describe('Navbar', () => {
     setUser({ id: '2', firstName: 'Bob', lastName: 'Jones', email: 'b@c.com', role: 'curator' })
     render(<Navbar />)
     await user.click(screen.getByRole('button', { name: /bob/i }))
-    expect(await screen.findByText('Dashboard')).toBeInTheDocument()
+    expect(await screen.findByText('dashboard')).toBeInTheDocument()
   })
 
   it('does not show Dashboard for plain user role', async () => {
@@ -92,7 +119,7 @@ describe('Navbar', () => {
     setUser({ id: '3', firstName: 'Carol', lastName: 'Lee', email: 'c@d.com', role: 'user' })
     render(<Navbar />)
     await user.click(screen.getByRole('button', { name: /carol/i }))
-    await screen.findByText('Logout') // wait for dropdown to open
-    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+    await screen.findByText('logout') // wait for dropdown to open
+    expect(screen.queryByText('dashboard')).not.toBeInTheDocument()
   })
 })

--- a/packages/app/src/components/Navbar.tsx
+++ b/packages/app/src/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { Menu, Wallet, ChevronDown, User, Sun, Moon, Globe, X, MessageSquare } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { useTheme } from "next-themes";
@@ -18,15 +18,27 @@ const LANGUAGES = [
   { code: "es", label: "Español" },
 ];
 
+/** Selectors for everything focusable inside the mobile drawer. */
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+function isPathActive(pathname: string, href: string) {
+  return pathname === href || (href !== "/" && pathname.startsWith(href));
+}
+
 function NavLink({ href, label, onClick }: { href: string; label: string; onClick?: () => void }) {
   const pathname = usePathname();
-  const isActive = pathname === href || (href !== "/" && pathname.startsWith(href));
+  const isActive = isPathActive(pathname, href);
   return (
     <Link
       href={href}
       onClick={onClick}
+      // Colour and an underline alone don't convey "current page" to assistive
+      // tech — aria-current does.
+      aria-current={isActive ? "page" : undefined}
       className={cn(
-        "relative text-sm font-medium transition-colors hover:text-blue-600",
+        "relative rounded text-sm font-medium transition-colors hover:text-blue-600",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2",
         isActive
           ? "text-blue-600 font-semibold"
           : "text-gray-600 dark:text-gray-300"
@@ -34,7 +46,10 @@ function NavLink({ href, label, onClick }: { href: string; label: string; onClic
     >
       {label}
       {isActive && (
-        <span className="absolute -bottom-0.5 left-0 h-0.5 w-full rounded-full bg-blue-600" />
+        <span
+          aria-hidden="true"
+          className="absolute -bottom-0.5 left-0 h-0.5 w-full rounded-full bg-blue-600"
+        />
       )}
     </Link>
   );
@@ -45,14 +60,20 @@ function ThemeToggle({ className }: { className?: string }) {
   const t = useTranslations("nav");
   return (
     <button
+      type="button"
       onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
       className={cn(
         "rounded-md p-2 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800 min-w-[40px] min-h-[40px] flex items-center justify-center",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
         className
       )}
       aria-label={t("theme")}
     >
-      {resolvedTheme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+      {resolvedTheme === "dark" ? (
+        <Sun size={18} aria-hidden="true" />
+      ) : (
+        <Moon size={18} aria-hidden="true" />
+      )}
     </button>
   );
 }
@@ -66,7 +87,61 @@ export default function Navbar() {
   const t = useTranslations("nav");
   const [mobileOpen, setMobileOpen] = useState(false);
 
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const drawerLabelId = useId();
+
   useEffect(() => { setMobileOpen(false); }, [pathname]);
+
+  // Move focus into the drawer when it opens, and restore it to the trigger
+  // when it closes — otherwise focus is left behind on a hidden button.
+  // Guarded on a previous-open flag so mounting the navbar never steals focus.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (mobileOpen) {
+      closeButtonRef.current?.focus();
+    } else if (wasOpenRef.current && document.activeElement === document.body) {
+      menuButtonRef.current?.focus();
+    }
+    wasOpenRef.current = mobileOpen;
+  }, [mobileOpen]);
+
+  // The drawer is modal: Escape closes it and Tab cycles within it, so keyboard
+  // users can't wander into the inert content behind the overlay.
+  useEffect(() => {
+    if (!mobileOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setMobileOpen(false);
+        menuButtonRef.current?.focus();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const focusable = Array.from(
+        drawerRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [],
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !drawerRef.current?.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [mobileOpen]);
 
   const touchStartX = useRef<number | null>(null);
   const handleTouchStart = (e: React.TouchEvent) => {
@@ -92,17 +167,30 @@ export default function Navbar() {
     { href: "/about", label: t("about") },
   ];
 
+  const currentLanguageLabel =
+    LANGUAGES.find((l) => l.code === locale)?.label ?? locale.toUpperCase();
+
   return (
     <>
-      <nav className="sticky top-0 z-50 w-full border-b bg-white/90 backdrop-blur dark:bg-gray-900/90 dark:border-gray-800">
+      <nav
+        aria-label={t("primaryNavigation")}
+        className="sticky top-0 z-50 w-full border-b bg-white/90 backdrop-blur dark:bg-gray-900/90 dark:border-gray-800"
+      >
         <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
-          <Link href="/" className="text-xl font-bold text-blue-600">
+          <Link
+            href="/"
+            className="rounded text-xl font-bold text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
             BlueCollar
           </Link>
 
-          <div className="hidden items-center gap-6 md:flex">
-            {NAV_LINKS.map((l) => <NavLink key={l.href} {...l} />)}
-          </div>
+          <ul className="hidden list-none items-center gap-6 md:flex">
+            {NAV_LINKS.map((l) => (
+              <li key={l.href}>
+                <NavLink {...l} />
+              </li>
+            ))}
+          </ul>
 
           <div className="hidden items-center gap-3 md:flex">
             <ThemeToggle />
@@ -110,15 +198,24 @@ export default function Navbar() {
 
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
-                <button className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200">
-                  <Globe size={15} />
+                <button
+                  type="button"
+                  aria-label={t("changeLanguage", { language: currentLanguageLabel })}
+                  className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                >
+                  <Globe size={15} aria-hidden="true" />
                   {locale.toUpperCase()}
                 </button>
               </DropdownMenu.Trigger>
               <DropdownMenu.Portal>
                 <DropdownMenu.Content align="end" sideOffset={6} className="z-50 min-w-[120px] rounded-md border bg-white p-1 shadow-md text-sm dark:bg-gray-900 dark:border-gray-700">
                   {LANGUAGES.map((lang) => (
-                    <DropdownMenu.Item key={lang.code} onSelect={() => handleLanguageChange(lang.code)} className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none dark:hover:bg-gray-800 dark:text-gray-200">
+                    <DropdownMenu.Item
+                      key={lang.code}
+                      onSelect={() => handleLanguageChange(lang.code)}
+                      aria-current={lang.code === locale ? "true" : undefined}
+                      className="cursor-pointer rounded px-3 py-2 hover:bg-gray-100 outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-gray-800 dark:text-gray-200"
+                    >
                       {lang.label}
                     </DropdownMenu.Item>
                   ))}
@@ -129,8 +226,12 @@ export default function Navbar() {
             {publicKey ? (
               <DropdownMenu.Root>
                 <DropdownMenu.Trigger asChild>
-                  <button className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200">
-                    <Wallet size={15} />
+                  <button
+                    type="button"
+                    aria-label={t("walletMenu")}
+                    className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  >
+                    <Wallet size={15} aria-hidden="true" />
                     {shortAddress}
                     {network && (
                       <span className={cn(
@@ -142,7 +243,7 @@ export default function Navbar() {
                         {network.toLowerCase().includes("test") ? t("testnet") : t("mainnet")}
                       </span>
                     )}
-                    <ChevronDown size={13} />
+                    <ChevronDown size={13} aria-hidden="true" />
                   </button>
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Portal>
@@ -156,8 +257,14 @@ export default function Navbar() {
                 </DropdownMenu.Portal>
               </DropdownMenu.Root>
             ) : (
-              <button onClick={connect} disabled={isConnecting} className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200">
-                <Wallet size={15} />
+              <button
+                type="button"
+                onClick={connect}
+                disabled={isConnecting}
+                aria-busy={isConnecting}
+                className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              >
+                <Wallet size={15} aria-hidden="true" />
                 {isConnecting ? t("connecting") : t("connectWallet")}
               </button>
             )}
@@ -165,10 +272,14 @@ export default function Navbar() {
             {user ? (
               <DropdownMenu.Root>
                 <DropdownMenu.Trigger asChild>
-                  <button className="flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200">
-                    <User size={15} />
+                  <button
+                    type="button"
+                    aria-label={t("accountMenu", { name: user.firstName })}
+                    className="flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  >
+                    <User size={15} aria-hidden="true" />
                     {user.firstName}
-                    <ChevronDown size={13} />
+                    <ChevronDown size={13} aria-hidden="true" />
                   </button>
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Portal>
@@ -194,22 +305,35 @@ export default function Navbar() {
           </div>
 
           <button
-            className="md:hidden flex items-center justify-center rounded-md p-2 min-w-[44px] min-h-[44px] hover:bg-gray-100 dark:hover:bg-gray-800"
+            ref={menuButtonRef}
+            type="button"
+            className="md:hidden flex items-center justify-center rounded-md p-2 min-w-[44px] min-h-[44px] hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             onClick={() => setMobileOpen(true)}
             aria-label={t("openMenu")}
+            aria-expanded={mobileOpen}
+            aria-haspopup="dialog"
+            aria-controls={mobileOpen ? drawerLabelId : undefined}
           >
-            <Menu size={22} />
+            <Menu size={22} aria-hidden="true" />
           </button>
         </div>
       </nav>
 
       {mobileOpen && (
         <div className="md:hidden">
+          {/* Click-to-dismiss backdrop. Escape and the close button cover the
+              same action for keyboard users, so it is hidden from a11y tree. */}
           <div
+            aria-hidden="true"
             className="fixed inset-0 z-40 bg-black/40 animate-fade-in"
             onClick={() => setMobileOpen(false)}
           />
           <div
+            ref={drawerRef}
+            id={drawerLabelId}
+            role="dialog"
+            aria-modal="true"
+            aria-label={t("mobileMenu")}
             className="fixed right-0 top-0 z-50 h-full w-72 bg-white dark:bg-gray-900 shadow-xl flex flex-col animate-slide-in-right"
             onTouchStart={handleTouchStart}
             onTouchEnd={handleTouchEnd}
@@ -219,61 +343,88 @@ export default function Navbar() {
               <div className="flex items-center gap-1">
                 <ThemeToggle />
                 <button
+                  ref={closeButtonRef}
+                  type="button"
                   onClick={() => setMobileOpen(false)}
-                  className="flex items-center justify-center rounded-md p-2 min-w-[44px] min-h-[44px] text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  className="flex items-center justify-center rounded-md p-2 min-w-[44px] min-h-[44px] text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   aria-label={t("closeMenu")}
                 >
-                  <X size={20} />
+                  <X size={20} aria-hidden="true" />
                 </button>
               </div>
             </div>
 
             <div className="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-1">
-              {NAV_LINKS.map(({ href, label }) => {
-                const isActive = pathname === href || (href !== "/" && pathname.startsWith(href));
-                return (
-                  <Link
-                    key={href}
-                    href={href}
-                    onClick={() => setMobileOpen(false)}
+              <ul className="list-none m-0 p-0 flex flex-col gap-1">
+                {NAV_LINKS.map(({ href, label }) => {
+                  const isActive = isPathActive(pathname, href);
+                  return (
+                    <li key={href}>
+                      <Link
+                        href={href}
+                        onClick={() => setMobileOpen(false)}
+                        aria-current={isActive ? "page" : undefined}
+                        className={cn(
+                          "flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition-colors min-h-[48px]",
+                          "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                          isActive
+                            ? "bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-400"
+                            : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                        )}
+                      >
+                        {isActive && (
+                          <span
+                            aria-hidden="true"
+                            className="h-1.5 w-1.5 rounded-full bg-blue-600 dark:bg-blue-400 shrink-0"
+                          />
+                        )}
+                        {label}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" aria-hidden="true" />
+
+              <p
+                id={`${drawerLabelId}-lang`}
+                className="px-4 py-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500"
+              >
+                {t("language")}
+              </p>
+              <div role="group" aria-labelledby={`${drawerLabelId}-lang`} className="flex flex-col gap-1">
+                {LANGUAGES.map((lang) => (
+                  <button
+                    key={lang.code}
+                    type="button"
+                    onClick={() => handleLanguageChange(lang.code)}
+                    aria-current={locale === lang.code ? "true" : undefined}
                     className={cn(
-                      "flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition-colors min-h-[48px]",
-                      isActive
+                      "flex items-center gap-3 rounded-lg px-4 py-3 text-sm text-left min-h-[48px] w-full transition-colors",
+                      "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                      locale === lang.code
                         ? "bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-400"
                         : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
                     )}
                   >
-                    {isActive && <span className="h-1.5 w-1.5 rounded-full bg-blue-600 dark:bg-blue-400 shrink-0" />}
-                    {label}
-                  </Link>
-                );
-              })}
+                    {locale === lang.code && (
+                      <span
+                        aria-hidden="true"
+                        className="h-1.5 w-1.5 rounded-full bg-blue-600 dark:bg-blue-400 shrink-0"
+                      />
+                    )}
+                    {lang.label}
+                  </button>
+                ))}
+              </div>
 
-              <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" />
-
-              <p className="px-4 py-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">{t("language")}</p>
-              {LANGUAGES.map((lang) => (
-                <button
-                  key={lang.code}
-                  onClick={() => handleLanguageChange(lang.code)}
-                  className={cn(
-                    "flex items-center gap-3 rounded-lg px-4 py-3 text-sm text-left min-h-[48px] w-full transition-colors",
-                    locale === lang.code
-                      ? "bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-400"
-                      : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
-                  )}
-                >
-                  {locale === lang.code && <span className="h-1.5 w-1.5 rounded-full bg-blue-600 dark:bg-blue-400 shrink-0" />}
-                  {lang.label}
-                </button>
-              ))}
-
-              <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" />
+              <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" aria-hidden="true" />
 
               {publicKey ? (
                 <>
                   <div className="flex items-center gap-3 rounded-lg border px-4 py-3 text-sm min-h-[48px] dark:border-gray-700 dark:text-gray-200">
-                    <Wallet size={16} />
+                    <Wallet size={16} aria-hidden="true" />
                     <span className="flex-1 font-mono text-xs truncate">{shortAddress}</span>
                     {network && (
                       <span className={cn(
@@ -287,33 +438,36 @@ export default function Navbar() {
                     )}
                   </div>
                   <button
+                    type="button"
                     onClick={() => { disconnect(); setMobileOpen(false); }}
-                    className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors w-full text-left"
+                    className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   >
                     {t("disconnectWallet")}
                   </button>
                 </>
               ) : (
                 <button
+                  type="button"
                   onClick={() => { connect(); setMobileOpen(false); }}
                   disabled={isConnecting}
-                  className="flex items-center gap-3 rounded-lg border px-4 py-3 text-sm font-medium min-h-[48px] hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors"
+                  aria-busy={isConnecting}
+                  className="flex items-center gap-3 rounded-lg border px-4 py-3 text-sm font-medium min-h-[48px] hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
-                  <Wallet size={16} />
+                  <Wallet size={16} aria-hidden="true" />
                   {isConnecting ? t("connecting") : t("connectWallet")}
                 </button>
               )}
 
-              <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" />
+              <div className="my-2 h-px bg-gray-100 dark:bg-gray-800" aria-hidden="true" />
 
               {user ? (
                 <>
                   <Link href="/profile" onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
-                    <User size={16} className="text-gray-400" />
+                    <User size={16} className="text-gray-400" aria-hidden="true" />
                     {t("profile")}
                   </Link>
                   <Link href="/messages" onClick={() => setMobileOpen(false)} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-200 transition-colors">
-                    <MessageSquare size={16} className="text-gray-400" />
+                    <MessageSquare size={16} className="text-gray-400" aria-hidden="true" />
                     Messages
                   </Link>
                   {(user.role === "curator" || user.role === "admin") && (
@@ -326,7 +480,7 @@ export default function Navbar() {
                       {t("adminAnalytics")}
                     </Link>
                   )}
-                  <button onClick={() => { logout(); setMobileOpen(false); }} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors w-full text-left">
+                  <button type="button" onClick={() => { logout(); setMobileOpen(false); }} className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm min-h-[48px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
                     {t("logout")}
                   </button>
                 </>

--- a/packages/app/src/messages/en.json
+++ b/packages/app/src/messages/en.json
@@ -35,7 +35,12 @@
     "connecting": "Connecting…",
     "disconnectWallet": "Disconnect Wallet",
     "testnet": "testnet",
-    "mainnet": "mainnet"
+    "mainnet": "mainnet",
+    "primaryNavigation": "Main navigation",
+    "mobileMenu": "Main menu",
+    "changeLanguage": "Change language, current language {language}",
+    "accountMenu": "Account menu for {name}",
+    "walletMenu": "Wallet menu"
   },
   "hero": {
     "title": "Find Skilled Workers Near You",

--- a/packages/app/src/messages/es.json
+++ b/packages/app/src/messages/es.json
@@ -35,7 +35,12 @@
     "connecting": "Conectando…",
     "disconnectWallet": "Desconectar billetera",
     "testnet": "testnet",
-    "mainnet": "mainnet"
+    "mainnet": "mainnet",
+    "primaryNavigation": "Navegación principal",
+    "mobileMenu": "Menú principal",
+    "changeLanguage": "Cambiar idioma, idioma actual {language}",
+    "accountMenu": "Menú de cuenta de {name}",
+    "walletMenu": "Menú de billetera"
   },
   "hero": {
     "title": "Encuentra trabajadores calificados cerca de ti",

--- a/packages/app/src/messages/fr.json
+++ b/packages/app/src/messages/fr.json
@@ -35,7 +35,12 @@
     "connecting": "Connexion…",
     "disconnectWallet": "Déconnecter le portefeuille",
     "testnet": "testnet",
-    "mainnet": "mainnet"
+    "mainnet": "mainnet",
+    "primaryNavigation": "Navigation principale",
+    "mobileMenu": "Menu principal",
+    "changeLanguage": "Changer de langue, langue actuelle {language}",
+    "accountMenu": "Menu du compte de {name}",
+    "walletMenu": "Menu du portefeuille"
   },
   "hero": {
     "title": "Trouvez des travailleurs qualifiés près de chez vous",

--- a/packages/app/src/messages/pt.json
+++ b/packages/app/src/messages/pt.json
@@ -35,7 +35,12 @@
     "connecting": "Conectando…",
     "disconnectWallet": "Desconectar carteira",
     "testnet": "testnet",
-    "mainnet": "mainnet"
+    "mainnet": "mainnet",
+    "primaryNavigation": "Navegação principal",
+    "mobileMenu": "Menu principal",
+    "changeLanguage": "Alterar idioma, idioma atual {language}",
+    "accountMenu": "Menu da conta de {name}",
+    "walletMenu": "Menu da carteira"
   },
   "hero": {
     "title": "Encontre Trabalhadores Qualificados Perto de Você",


### PR DESCRIPTION
Closes #964

## Component naming

The issue names `NavigationHeader`, which does not exist in this repo. The navigation header is `src/components/Navbar.tsx`, so this PR targets that. Happy to rename it to `NavigationHeader` in a follow-up if maintainers prefer the issue's name.

## Audit

Ran `axe-core` (WCAG 2.1 AA + best-practice) against three states, using the same config as the existing `src/__tests__/accessibility.test.tsx`.

| State | Before | After |
|---|---|---|
| Desktop, logged out / logged in | 0 | 0 |
| Mobile drawer open | 1 moderate (`region` — drawer content outside any landmark) | 0 |

The desktop bar was already close to clean, so **axe was not where the real problems were**. The manual keyboard walkthrough found them: the mobile drawer was not a dialog in any sense that assistive tech or a keyboard could tell.

## Fixes

### Mobile drawer

Before this PR the drawer was two plain `<div>`s. Consequences, all fixed here:

- **Not announced as a dialog** → now `role="dialog"` + `aria-modal="true"` + `aria-label`, and the menu button carries `aria-expanded`, `aria-haspopup="dialog"` and `aria-controls`.
- **No focus trap** — Tab walked straight out of the drawer into the page content sitting behind an opaque overlay, with no visual indication of where focus had gone. Tab and Shift+Tab now cycle within the drawer.
- **Escape did nothing** — the drawer could only be dismissed by clicking the backdrop or the close button, so a keyboard-only user who opened it had no way out. Escape now closes it.
- **Focus was never moved or restored** — opening left focus on the (now visually hidden) hamburger; closing left it on a button that had been removed from the DOM, dumping focus to `<body>`. Focus now moves to the close button on open and returns to the menu button on close.
- **Backdrop was a phantom element** — a click-only `<div>` exposed to the a11y tree. It is `aria-hidden` now; Escape and the close button cover the same action for keyboard users.

### Navigation semantics

- The `<nav>` had no accessible name, while `BottomNav` already had `aria-label="Mobile navigation"`. With two nav landmarks on the page, a screen reader user got "navigation" twice with no way to tell them apart. Added `aria-label`.
- Primary links were loose `<a>` elements in a flex div; they are a real `<ul>`/`<li>` list now.
- **Current page was conveyed by colour and an underline only** — a WCAG 1.4.1 problem and invisible to assistive tech. Added `aria-current="page"` in both the desktop bar and the drawer, matching what `BottomNav` already does.
- The language trigger announced only "EN"; it is now named with the current language. The account trigger is named with the signed-in user. The drawer's language switcher is a labelled `role="group"` with `aria-current` on the active locale.
- Decorative icons, dividers, and the active-link underline are `aria-hidden`; every interactive control got a visible `focus-visible` ring and an explicit `type="button"`.

### i18n

Five new keys under `nav` (`primaryNavigation`, `mobileMenu`, `changeLanguage`, `accountMenu`, `walletMenu`), translated into all four locales — `en`, `es`, `fr`, `pt`. The diffs are purely additive.

## A bug this work caught

The first version of the focus-restore effect ran on mount, not just on close, so simply rendering the navbar stole focus to the hamburger button and broke the page's initial tab order. The **existing** `accessibility.test.tsx` keyboard test caught it. Fixed by gating restoration on a previously-open flag, and `does not steal focus on mount` is now a test so it can't come back.

## Testing

New `src/__tests__/Navbar.a11y.test.tsx` — **21 tests**:

| Group | Covers |
|---|---|
| axe (WCAG 2.1 AA) | logged out, logged in, drawer open |
| Roles and labels | named nav landmark, list semantics, `aria-current` on active link (and absent on unrelated routes), language/account trigger names, `aria-expanded`/`aria-controls` pointing at a real element |
| Drawer semantics | modal dialog attributes, hidden backdrop, drawer `aria-current`, language group |
| Keyboard and focus | no focus theft on mount, focus in on open, Escape closes + restores, close button restores, Tab wrap, Shift+Tab wrap, focus stays inside across a full cycle |

I verified the trap tests actually bite: temporarily removing the trap logic fails exactly the 3 trap tests and nothing else.

**Also repaired `src/__tests__/Navbar.test.tsx`**, which fails **5/5 on `upstream/main` today** — its `useWallet` mock returns `address`/`connecting` while the hook exposes `publicKey`/`isConnecting`, and it has no `next-intl` or notification-context mocks. It now passes 5/5. Since this PR touches Navbar, leaving its own test suite red would have made "related tests passing" meaningless.

```
✓ src/__tests__/Navbar.a11y.test.tsx    (21 tests)
✓ src/__tests__/Navbar.test.tsx         ( 5 tests)   ← was 0/5 on main
✓ src/__tests__/accessibility.test.tsx  (14 tests)   ← existing suite, still green
Test Files  3 passed (3)
     Tests  40 passed (40)
```

`tsc --noEmit` is clean for every file touched, and `next lint` on `Navbar.tsx` reports no warnings or errors.

## Note on the full suite

`pnpm test` in `packages/app` fails 21 of 27 files **on `upstream/main` before this branch**, mostly components calling `useTranslations` without a provider mock. This PR **improves** that: 21 → 20 failing files and 21 → 16 failing tests, with passing tests going 65 → 91. The remaining failures are pre-existing and unrelated; I left them alone rather than widen this PR, and I'm happy to open a separate issue for them.

## Acceptance criteria

- [x] Audit NavigationHeader with axe-core or Lighthouse
- [x] Add ARIA labels and roles
- [x] Ensure keyboard navigability and focus order
- [x] Add regression test for a11y violations
- [x] Tested (unit/integration as applicable)
- [ ] Code review passed
- [x] Related tests passing