### PR TITLE
docs(contracts): fix stale interface reference, add versioning policy, sdk README

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -196,6 +196,7 @@ fn cancel_upgrade(env, admin)                   // cancel pending
 | `update_availability(id, caller, is_available, expires_at)` | `caller.require_auth()` | `id: Symbol, caller: Address, is_available: bool, expires_at: u64` | — | Set availability (owner only). |
 | `get_availability(worker_id)` | — | `worker_id: Symbol` | `Option<AvailabilityStatus>` | Get availability. |
 | `batch_register(curator, ids, owners, names, categories, location_hashes, contact_hashes)` | `curator.require_auth()` | (parallel vecs) | `Vec<BatchRegisterResult>` | Register up to 20 workers. Partial success. |
+| `batch_toggle(caller, ids)` | `caller.require_auth()`, must be curator | `caller: Address, ids: Vec<Symbol>` (max `MAX_BATCH_SIZE`) | `Vec<(Symbol, bool)>` | Toggle `is_active` for multiple workers. Skips ids that don't exist (partial success). |
 | `stake(caller, worker_id, token_addr, amount)` | `caller.require_auth()` | `caller: Address, worker_id: Symbol, token_addr: Address, amount: i128` | — | Stake tokens for visibility (owner only). |
 | `request_unstake(caller, worker_id)` | `caller.require_auth()` | `caller: Address, worker_id: Symbol` | — | Start 7-day unstake cooldown. |
 | `unstake(caller, worker_id)` | `caller.require_auth()` | `caller: Address, worker_id: Symbol` | — | Finalise unstake after cooldown. Returns tokens + rewards. |
@@ -217,6 +218,32 @@ fn cancel_upgrade(env, admin)                   // cancel pending
 | `upgrade(new_wasm_hash)` | `ROLE_UPGRADER` | `new_wasm_hash: BytesN<32>` | — | Immediate upgrade (no timelock). |
 | `migrate(admin, expected_version)` | `ROLE_ADMIN` | `admin: Address, expected_version: u32` | — | Run version-specific storage migration. |
 | `get_schema_version()` | — | — | `u32` | Get current schema version. |
+
+### Certification & Verification Functions
+
+Two related but distinct sub-APIs, both curator/admin-gated writes with public reads.
+Certifications (`registry/src/certifications.rs`) are individually revocable records
+with their own lifecycle; certified skills are simpler tag-like entries keyed by skill
+symbol, and verification level is a single per-worker status flag. See
+[CERTIFICATION_TRACKING.md](../packages/contracts/CERTIFICATION_TRACKING.md) for the
+full `Certification` struct, storage keys, and event details for the first group.
+
+| Function | Auth | Parameters | Returns | Description |
+|---|---|---|---|---|
+| `add_certification(caller, worker_id, cert_id, issuer, name, issued_at, expires_at)` | curator/admin | `caller: Address, worker_id: Symbol, cert_id: Symbol, issuer: String, name: String, issued_at: u64, expires_at: u64` | — | Add a certification record. See CERTIFICATION_TRACKING.md. |
+| `remove_certification(caller, worker_id, cert_id)` | curator/admin | `caller: Address, worker_id: Symbol, cert_id: Symbol` | — | Remove a certification record. |
+| `verify_certification(caller, cert_id)` | curator/admin | `caller: Address, cert_id: Symbol` | — | Mark a certification as verified. |
+| `get_certification(cert_id)` | — | `cert_id: Symbol` | `Option<Certification>` | Get a single certification. |
+| `get_certification_count(worker_id)` | — | `worker_id: Symbol` | `u32` | Count of certifications for a worker. |
+| `get_worker_certifications(worker_id)` | — | `worker_id: Symbol` | `Vec<Certification>` | All certifications for a worker. |
+| `get_valid_certifications(worker_id)` | — | `worker_id: Symbol` | `Vec<Certification>` | Non-expired certifications for a worker. |
+| `get_verified_certification_count(worker_id)` | — | `worker_id: Symbol` | `u32` | Count of verified certifications for a worker. |
+| `is_certification_valid(cert_id)` | — | `cert_id: Symbol` | `bool` | Whether a certification exists and hasn't expired. |
+| `set_verification_level(caller, worker_id, level)` | `ROLE_CURATOR_MGR` or `ROLE_ADMIN` | `caller: Address, worker_id: Symbol, level: VerificationLevel` | — | Set a worker's verification level. Panics `"Worker not found"` if unknown. |
+| `get_verification_level(worker_id)` | — | `worker_id: Symbol` | `VerificationLevel` | Get a worker's verification level; `VerificationLevel::None` if unset. |
+| `add_certified_skill(caller, worker_id, skill, expires_at)` | `ROLE_CURATOR_MGR` or `ROLE_ADMIN` | `caller: Address, worker_id: Symbol, skill: Symbol, expires_at: u64` | — | Add/replace a certified skill entry (`expires_at: 0` = no expiry). |
+| `revoke_certified_skill(caller, worker_id, skill)` | `ROLE_CURATOR_MGR` or `ROLE_ADMIN` | `caller: Address, worker_id: Symbol, skill: Symbol` | — | Remove a certified skill. Panics `"Skill not found"` if absent. |
+| `get_certified_skills(worker_id)` | — | `worker_id: Symbol` | `Vec<CertifiedSkill>` | All certified skills for a worker. |
 
 ---
 
@@ -284,6 +311,7 @@ fn cancel_upgrade(env, admin)                   // cancel pending
 | `tip(from, to, token_addr, amount)` | `from.require_auth()` | `from: Address, to: Address, token_addr: Address, amount: i128` | — | Transfer `amount` minus `fee_bps` to `to`. Fee to `fee_recipient`. |
 | `create_escrow(id, from, to, token_addr, amount, expiry)` | `from.require_auth()` | `id: Symbol, from: Address, to: Address, token_addr: Address, amount: i128, expiry: u64` | — | Lock tokens in escrow. |
 | `release_escrow(id, caller)` | `caller.require_auth()` | `id: Symbol, caller: Address` | — | Release funds to `to`. Callable by `from` or `to`. |
+| `batch_release_escrow(caller, ids)` | `caller.require_auth()` | `caller: Address, ids: Vec<Symbol>` (max 20) | `Vec<Symbol>` | Release multiple escrows in one call. Skips already-released/cancelled or unauthorised ids (partial success); returns the ids that succeeded. |
 | `cancel_escrow(id, caller)` | `caller.require_auth()` | `id: Symbol, caller: Address` | — | Refund `from` after `expiry`. Payer only. |
 | `cancel_expired_escrow(id)` | — | `id: Symbol` | — | Anyone can cancel an expired escrow. |
 | `get_escrow(id)` | — | `id: Symbol` | `Option<Escrow>` | Get escrow details. |
@@ -320,7 +348,9 @@ fn cancel_upgrade(env, admin)                   // cancel pending
 ## Dispute Contract
 
 **Source**: `packages/contracts/contracts/dispute/src/lib.rs`
-**Deployment**: Stellar Soroban, handles dispute filing, evidence submission, and arbitration.
+**Deployment**: Stellar Soroban. Lifecycle: `file_dispute` (open) → `submit_evidence`
+(evidence) → `decide` (arbitrator records outcome, no transfer yet) → `settle` (anyone
+executes the transfer per the recorded decision).
 
 ### Storage Map
 
@@ -339,17 +369,18 @@ fn cancel_upgrade(env, admin)                   // cancel pending
 | Field | Type | Description |
 |---|---|---|
 | `id` | `Symbol` | Unique dispute identifier |
-| `disputer` | `Address` | Party that filed the dispute |
+| `disputer` | `Address` | Party that filed the dispute and locked the tokens |
 | `respondent` | `Address` | Party being disputed against |
-| `token` | `Address` | Token contract address |
-| `amount` | `i128` | Disputed amount |
-| `status` | `DisputeStatus` | `Filed` / `EvidenceSubmitted` / `Resolved` / `Cancelled` |
-| `outcome` | `DisputeOutcome` | `RefundPayer` / `ReleaseWorker` / `PartialRefund` / `Unresolved` |
-| `arbitrator` | `Option<Address>` | Arbitrator who resolved |
-| `filed_at` | `u64` | Filing timestamp |
-| `resolved_at` | `Option<u64>` | Resolution timestamp |
-| `disputer_evidence_hash` | `Option<String>` | SHA-256 of disputer's evidence |
-| `respondent_evidence_hash` | `Option<String>` | SHA-256 of respondent's evidence |
+| `token` | `Address` | Token contract used for the locked amount |
+| `amount` | `i128` | Total amount locked in this contract |
+| `status` | `DisputeStatus` | `Open` / `Evidence` / `Decided` / `Settled` |
+| `outcome` | `DisputeOutcome` | `RefundDisputer` / `ReleaseRespondent` / `Split`; placeholder `RefundDisputer` until `status >= Decided` |
+| `split_bps` | `u32` | Respondent's share in basis points (0–10,000); only meaningful for `Split` |
+| `arbitrator` | `Option<Address>` | Arbitrator address once decided |
+| `filed_at` | `u64` | Unix timestamp when filed |
+| `settled_at` | `u64` | Unix timestamp when settled (`0` until settled) |
+| `disputer_evidence` | `Option<String>` | Off-chain evidence hash submitted by the disputer |
+| `respondent_evidence` | `Option<String>` | Off-chain evidence hash submitted by the respondent |
 
 ### Public Functions
 
@@ -357,11 +388,16 @@ fn cancel_upgrade(env, admin)                   // cancel pending
 |---|---|---|---|---|
 | `initialize(admin)` | — | `admin: Address` | — | Init contract. One-time. |
 | `get_admin()` | — | — | `Address` | Get admin. |
-| `add_arbitrator(admin, arbitrator)` | `admin.require_auth()` | `admin: Address, arbitrator: Address` | — | Add approved arbitrator. |
-| `remove_arbitrator(admin, arbitrator)` | `admin.require_auth()` | `admin: Address, arbitrator: Address` | — | Remove arbitrator. |
-| `file_dispute(id, disputer, respondent, token, amount, evidence_hash)` | `disputer.require_auth()` | `id: Symbol, disputer: Address, respondent: Address, token: Address, amount: i128, evidence_hash: String` | — | File a dispute. |
-| `submit_evidence(dispute_id, respondent, evidence_hash)` | `respondent.require_auth()` | `dispute_id: Symbol, respondent: Address, evidence_hash: String` | — | Submit counter-evidence. |
-| `resolve_dispute(dispute_id, arbitrator, outcome)` | `arbitrator.require_auth()` | `dispute_id: Symbol, arbitrator: Address, outcome: DisputeOutcome` | — | Resolve dispute. |
+| `version()` | — | — | `u32` | Get the event schema version. |
+| `pause(admin)` | `admin.require_auth()` | `admin: Address` | — | Pause the contract. |
+| `unpause(admin)` | `admin.require_auth()` | `admin: Address` | — | Unpause the contract. |
+| `add_arbitrator(admin, arbitrator)` | `admin.require_auth()` | `admin: Address, arbitrator: Address` | — | Add an approved arbitrator (idempotent). |
+| `remove_arbitrator(admin, arbitrator)` | `admin.require_auth()` | `admin: Address, arbitrator: Address` | — | Remove an approved arbitrator. |
+| `list_arbitrators()` | — | — | `Vec<Address>` | List all approved arbitrators. |
+| `file_dispute(id, disputer, respondent, token, amount, evidence_hash)` | `disputer.require_auth()` | `id: Symbol, disputer: Address, respondent: Address, token: Address, amount: i128, evidence_hash: String` | — | File a dispute; locks `amount` tokens in the contract. |
+| `submit_evidence(dispute_id, caller, evidence_hash)` | `caller.require_auth()` | `dispute_id: Symbol, caller: Address, evidence_hash: String` | — | Attach an evidence hash. `caller` must be the disputer or respondent; dispute must be `Open` or `Evidence`. |
+| `decide(dispute_id, arbitrator, outcome, split_bps)` | `arbitrator.require_auth()` | `dispute_id: Symbol, arbitrator: Address, outcome: DisputeOutcome, split_bps: u32` | — | Record an arbitrator decision (no transfer yet). `arbitrator` must be in the approved list; dispute must be `Open` or `Evidence`. |
+| `settle(dispute_id)` | — (callable by anyone) | `dispute_id: Symbol` | — | Execute the token transfer per the recorded decision. Dispute must be `Decided`. |
 | `get_dispute(dispute_id)` | — | `dispute_id: Symbol` | `Option<Dispute>` | Get dispute details. |
 | `list_disputes()` | — | — | `Vec<Symbol>` | List all dispute IDs. |
 | `upgrade(admin, new_wasm_hash)` | `admin.require_auth()` | `admin: Address, new_wasm_hash: BytesN<32>` | — | Upgrade contract WASM. |
@@ -565,11 +601,14 @@ fn cancel_upgrade(env, admin)                   // cancel pending
 | Event | Topics | Data | Description |
 |---|---|---|---|
 | `Init` | `("Init",)` | `admin: Address` | Contract initialized |
+| `Paused` | `("Paused", admin: Address)` | `()` | Paused |
+| `Unpaused` | `("Unpaused", admin: Address)` | `()` | Unpaused |
 | `ArbAdd` | `("ArbAdd",)` | `arbitrator: Address` | Arbitrator added |
 | `ArbRem` | `("ArbRem",)` | `arbitrator: Address` | Arbitrator removed |
-| `DspFld` | `("DspFld", id: Symbol)` | `(disputer: Address, amount: i128)` | Dispute filed |
-| `EvdSub` | `("EvdSub", dispute_id: Symbol)` | `respondent: Address` | Evidence submitted |
-| `DspRes` | `("DspRes", dispute_id: Symbol)` | `(arbitrator: Address, outcome: u32)` | Dispute resolved |
+| `DspOpen` | `("DspOpen", id: Symbol, disputer: Address)` | `(respondent: Address, amount: i128)` | Dispute filed |
+| `DspEvid` | `("DspEvid", dispute_id: Symbol, caller: Address)` | `()` | Evidence submitted |
+| `DspDcide` | `("DspDcide", dispute_id: Symbol, arbitrator: Address)` | `(outcome: u32, split_bps: u32)` | Arbitrator decision recorded (no transfer yet) |
+| `DspSettle` | `("DspSettle", dispute_id: Symbol)` | `(outcome: u32, amount: i128)` | Settlement executed |
 
 ### FeeDistribution Contract Events
 
@@ -610,6 +649,9 @@ fn cancel_upgrade(env, admin)                   // cancel pending
 | Document | Link |
 |---|---|
 | Contract Integration Guide (client-side SDK usage) | [CONTRACT_INTEGRATION.md](./CONTRACT_INTEGRATION.md) |
+| In-repo TypeScript SDK (`@bluecollar/sdk`) | [packages/sdk/README.md](../packages/sdk/README.md) |
+| Interface Versioning Policy | [packages/contracts/VERSIONING.md](../packages/contracts/VERSIONING.md) |
+| Contracts Package Overview | [packages/contracts/README.md](../packages/contracts/README.md) |
 | Upgrade Runbook & WASM deployment | [contract-upgrade-guide.md](./contract-upgrade-guide.md) |
 | Architecture Overview | [system-overview.svg](./architecture/system-overview.svg) |
 | Environment Variables | [ENVIRONMENT_VARIABLES.md](./ENVIRONMENT_VARIABLES.md) |

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -6,6 +6,16 @@ Stellar **Soroban** smart contracts for the BlueCollar protocol, written in Rust
 |---|---|
 | `registry` | On-chain worker registrations, curator management, staking, badges |
 | `market` | Token tips, escrow payments, arbitration, protocol fee |
+| `dispute` | Full dispute lifecycle — file → evidence → arbitrator decision → settle |
+| `fee_distribution` | Protocol fee collection and percentage-based distribution to multiple recipients |
+| `insurance_pool` | On-chain insurance pool for worker payments — contributions, claims, rebalancing |
+
+Every public function on every contract is documented with rustdoc (`///`) comments in
+its `lib.rs`. The consolidated, per-contract reference — function signatures, storage
+maps, event catalogue, and the common auth/TTL/upgrade patterns shared across all five
+contracts — lives in **[docs/CONTRACTS.md](../../docs/CONTRACTS.md)**. See
+[VERSIONING.md](./VERSIONING.md) for how interface changes are versioned across
+releases (distinct from the WASM upgrade mechanics below).
 
 ---
 
@@ -176,3 +186,14 @@ lets anyone refresh a worker entry without special permissions.
 
 See [SECURITY.md](./SECURITY.md) for the full threat model, auth table, overflow
 analysis, and migration pattern.
+
+## Further reading
+
+| Document | Covers |
+|---|---|
+| [docs/CONTRACTS.md](../../docs/CONTRACTS.md) | Full interface reference: functions, storage, events, per-contract |
+| [VERSIONING.md](./VERSIONING.md) | Interface/semver versioning policy for public functions |
+| [UPGRADE_GUIDE.md](./UPGRADE_GUIDE.md) | WASM upgrade runbook (build → install → invoke `upgrade`/`migrate`) |
+| [INTEGRATION_GUIDE.md](./INTEGRATION_GUIDE.md) | Integrating against the deployed contracts |
+| [SECURITY.md](./SECURITY.md) | Threat model, auth table, overflow analysis |
+| [CERTIFICATION_TRACKING.md](./CERTIFICATION_TRACKING.md) | Registry's certification sub-API in depth |

--- a/packages/contracts/VERSIONING.md
+++ b/packages/contracts/VERSIONING.md
@@ -1,0 +1,65 @@
+# Interface Versioning Policy
+
+This document covers how the **public function interface** of each contract is
+versioned across releases — distinct from the on-chain **WASM upgrade mechanics**
+covered in [UPGRADE_GUIDE.md](./UPGRADE_GUIDE.md). A WASM upgrade replaces the code
+behind a fixed contract ID; this document is about what's safe to change in that new
+code without breaking existing callers (the SDK, the app, external integrators).
+
+## Why this is separate from the upgrade guide
+
+`UPGRADE_GUIDE.md` and `SECURITY.md`'s migration pattern answer *how* to deploy new
+code and migrate on-chain storage (`propose_upgrade`/`upgrade`, `migrate`,
+`get_schema_version`). They don't say what changes are *safe* to ship in that new code.
+That's the gap this document fills, for anyone reading `docs/CONTRACTS.md` or building
+against `packages/sdk`.
+
+## Versioning model
+
+Each contract's interface has an implicit version (there is no on-chain interface
+version number distinct from `SchemaVersion` — see below). Changes are classified the
+same way as semver, applied to the **function signatures and behavior documented in
+[docs/CONTRACTS.md](../../docs/CONTRACTS.md)**, not to the crate version in `Cargo.toml`
+(these contracts are not published to crates.io; `Cargo.toml` versions track internal
+workspace state, not a public interface contract):
+
+| Change type | Examples | Safe to ship via... |
+|---|---|---|
+| **Patch** (non-breaking, no signature change) | Bug fixes, gas optimizations, internal refactors, tightening an overly-permissive check | `upgrade()` (or `execute_upgrade()` after timelock), no `migrate()` needed unless storage layout changed |
+| **Minor** (additive, backward-compatible) | New public function, new optional parameter *at the end* of an existing function via a new function overload (Soroban has no default params — add a new fn instead of changing an existing signature), new event | `upgrade()`, callers on the old interface are unaffected |
+| **Major** (breaking) | Changing an existing function's parameter types/order, removing a function, changing a return type, changing storage key encoding | `upgrade()` **+ `migrate()`** if storage changed; bump `SchemaVersion`; requires coordinated updates to `packages/sdk` and any other caller before/alongside the on-chain upgrade |
+
+A "breaking" change to the interface and a storage-layout change that requires
+`migrate()` are related but not the same thing — you can have one without the other.
+Always check both independently before an upgrade.
+
+## Rules for contributors
+
+1. **Never change an existing public function's signature or semantics in place.**
+   Add a new function instead (e.g. `register_v2`) if you need new behavior, or bump
+   `SchemaVersion` and go through the full `propose_upgrade`/`migrate` flow (see
+   [UPGRADE_GUIDE.md](./UPGRADE_GUIDE.md)) if you must replace it.
+2. **Update `docs/CONTRACTS.md`** — its per-contract Public Functions table is the
+   source of truth consumers read. A signature change that isn't reflected there is
+   treated as undocumented and should not ship.
+3. **Update `packages/sdk`** in the same change (or a coordinated follow-up) whenever a
+   function used by `RegistryClient`/`HorizonClient` changes — the SDK wraps these
+   contracts directly (see [packages/sdk/README.md](../sdk/README.md)) and has no
+   independent versioning of its own to cushion a breaking on-chain change.
+4. **Deprecating a function**: mark it in its rustdoc comment (`/// @deprecated — use
+   X instead. Will be removed no earlier than <target release/date>.`) and note it in
+   `docs/CONTRACTS.md`'s function table before removing it in a later major change.
+   There's no on-chain deprecation flag — this is a documentation-level contract with
+   consumers, not an enforced one.
+5. **Registry and Market's `propose_upgrade`/`execute_upgrade` 48-hour timelock** (see
+   `docs/CONTRACTS.md#upgrade-flow`) exists precisely so integrators have a window to
+   react to an upcoming major change before it goes live — don't rely on same-day
+   upgrades for breaking changes on those two contracts.
+
+## Where this fits with `SchemaVersion`
+
+`SchemaVersion` (Registry + Market, see `docs/CONTRACTS.md#storage-ttl-strategy`) tracks
+**on-chain storage layout**, bumped by `migrate()`. It is not a general-purpose API
+version — a function signature can change without any storage migration, and storage
+can migrate without any function signature changing. Don't conflate the two when
+deciding whether a change is safe to ship.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,61 @@
+# @bluecollar/sdk
+
+Shared TypeScript SDK for Stellar / Soroban contract interaction. This is the single
+source of truth for talking to the BlueCollar contracts and the Stellar network —
+consumed by both `packages/api` and `packages/app` so contract-calling logic isn't
+duplicated (or allowed to drift) between the backend and the frontend.
+
+## What's in here
+
+| Export | Purpose |
+|---|---|
+| `createSdk(config)` | Factory that wires up a `HorizonClient` and (if a registry contract ID is passed) a `RegistryClient` |
+| `HorizonClient` | Typed wrapper around the Stellar Horizon REST API — account info, broadcasting signed transactions, tx status |
+| `RegistryClient` | Typed wrapper for invoking the `registry` Soroban contract (see below) |
+| `SdkError` | Error type thrown by both clients, carrying an HTTP-style status code |
+| Types (`AccountInfo`, `SdkConfig`, `WorkerRegistration`, `ReputationSync`, `UnsignedTxParams`, `BroadcastResult`, `TxStatus`, …) | `src/types.ts` |
+
+## Usage
+
+```ts
+import { createSdk } from '@bluecollar/sdk'
+
+const sdk = createSdk({
+  network: 'testnet',
+  registryContractId: '<C...>', // optional — omit if you only need Horizon
+})
+
+const account = await sdk.horizon.getAccountInfo(publicKey)
+const result = await sdk.registry?.simulateInvoke('get_worker', [workerId])
+```
+
+`createSdk` picks the default Horizon URL for the given network
+(`horizon-testnet.stellar.org` / `horizon.stellar.org`) unless you override it via
+`horizonUrl`. `RegistryClient` similarly resolves the Soroban RPC endpoint
+(`soroban-testnet.stellar.org` / `soroban-rpc.stellar.org`) from `network`.
+
+`RegistryClient.simulateInvoke` covers read-only contract calls. For writes (anything
+that requires a signature — `register`, `toggle`, etc.), build and sign the transaction
+with `@stellar/stellar-sdk`'s `TransactionBuilder` and submit the resulting XDR via
+`HorizonClient.broadcastTransaction`; `RegistryClient`'s own envelope builder is a
+placeholder for the simulate-only path (see the comment in `registry.client.ts`).
+
+## Contract interface reference
+
+This SDK only wraps a subset of one contract's interface (`registry`, read-only calls).
+For the full public interface of every contract — including `market`, `dispute`,
+`fee_distribution`, and `insurance_pool`, which this SDK does not yet wrap — see:
+
+- **[docs/CONTRACTS.md](../../docs/CONTRACTS.md)** — function signatures, storage maps,
+  events, and auth requirements for every contract.
+- **[packages/contracts/VERSIONING.md](../contracts/VERSIONING.md)** — how contract
+  interfaces are versioned; read this before depending on a specific function signature,
+  since a breaking on-chain change requires this SDK to be updated in lockstep.
+- **[packages/contracts/README.md](../contracts/README.md)** — build/deploy/upgrade
+  instructions for the contracts themselves.
+
+## Testing
+
+```bash
+pnpm --filter @bluecollar/sdk test
+```


### PR DESCRIPTION
## Summary

Closes #960

`docs/CONTRACTS.md` already existed as a per-contract interface reference but had drifted from source in real, non-cosmetic ways, and `packages/sdk` had no README at all despite wrapping the registry contract directly.

- **Dispute contract**: the doc described an older shape entirely — `resolve_dispute` (removed; split into `decide` + `settle`), `DisputeStatus`/`DisputeOutcome` enum values that no longer exist in the code, and 4 functions with zero documentation (`decide`, `settle`, `list_arbitrators`, `version`). Rewrote the storage map, key types, public functions table, and event catalogue against the current `lib.rs`.
- **Registry**: added the entire certification/verification sub-API that had no reference at all — 14 functions across `certifications.rs` and the newer certified-skills/verification-level additions in `lib.rs` — plus the missing `batch_toggle`.
- **Market**: added the missing `batch_release_escrow`.
- Verified every remaining function in registry/market/dispute/fee_distribution/insurance_pool against `lib.rs` — no further gaps (verification method described in the test plan below).
- `packages/contracts/README.md`: the contract table only listed 2 of 5 contracts; now lists all 5 and links to `docs/CONTRACTS.md` as the interface reference.
- New `packages/contracts/VERSIONING.md`: the interface/semver versioning policy the issue asks for — distinct from the WASM-upgrade runbook already in `UPGRADE_GUIDE.md`, which covers deployment mechanics, not what's safe to change in a new version.
- New `packages/sdk/README.md` (didn't exist before this PR): documents `createSdk`/`HorizonClient`/`RegistryClient` and cross-links `docs/CONTRACTS.md` + `VERSIONING.md`.

## Test plan

- [x] Extracted every `pub fn` from all 5 contracts' `lib.rs` (+ `certifications.rs`, `fees.rs` submodules) and diffed against `docs/CONTRACTS.md` — 0 undocumented entrypoints remain (`split_fee` intentionally excluded: it's a free function in `fees.rs`, not a `#[contractimpl]` entrypoint, so it isn't part of the external interface)
- [x] Verified every relative link added/changed (`docs/CONTRACTS.md` ↔ `packages/contracts/README.md` ↔ `VERSIONING.md` ↔ `packages/sdk/README.md` ↔ `CERTIFICATION_TRACKING.md`) resolves to an existing file
- [x] No Rust source was touched — documentation-only change