### PR TITLE
feat: Add integration tests for search, jobs, contracts and refactor wallet controller

### DIFF
--- a/packages/api/src/__tests__/integration/contracts.integration.test.ts
+++ b/packages/api/src/__tests__/integration/contracts.integration.test.ts
@@ -1,0 +1,687 @@
+/**
+ * Integration tests for contracts endpoints (#1003)
+ *
+ * Covers:
+ *  Escrow:
+ *    - GET    /api/escrow
+ *    - GET    /api/escrow/:id
+ *    - POST   /api/escrow
+ *    - PATCH  /api/escrow/:id/activate
+ *    - PATCH  /api/escrow/:id/release
+ *    - PATCH  /api/escrow/:id/cancel
+ *    - POST   /api/escrow/:id/disputes
+ *    - PATCH  /api/escrow/:id/disputes/:disputeId (admin only)
+ *
+ *  Disputes:
+ *    - POST   /api/disputes
+ *    - GET    /api/disputes
+ *    - GET    /api/disputes/:id
+ *    - PATCH  /api/disputes/:id/resolve (admin only)
+ *
+ * All DB / Redis / external deps are mocked; the full HTTP cycle is
+ * exercised via supertest against the real Express app.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+// ─── Environment ─────────────────────────────────────────────────────────────
+process.env.JWT_SECRET = 'test-integration-secret'
+process.env.DATABASE_URL = 'postgresql://localhost:5432/test'
+process.env.REDIS_URL = 'redis://localhost:6379'
+process.env.APP_URL = 'http://localhost:3000'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+vi.mock('../../db.js', () => ({
+  db: {
+    escrowRecord: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+    dispute: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+    notification: { create: vi.fn() },
+    user: { findUnique: vi.fn() },
+    $queryRaw: vi.fn(),
+    $transaction: vi.fn(),
+  },
+}))
+
+vi.mock('../../config/redis.js', () => ({
+  redis: { connect: vi.fn().mockResolvedValue(undefined), ping: vi.fn().mockResolvedValue('PONG') },
+  cacheMetrics: { hits: 0, misses: 0 },
+}))
+
+vi.mock('../../config/env.js', () => ({
+  env: {
+    DATABASE_URL: 'postgresql://localhost:5432/test',
+    JWT_SECRET: 'test-integration-secret',
+    PORT: 3000,
+    GOOGLE_CLIENT_ID: 'test',
+    GOOGLE_CLIENT_SECRET: 'test',
+    MAIL_HOST: 'smtp.test.local',
+    MAIL_PORT: 587,
+    MAIL_USER: 'test',
+    MAIL_PASS: 'test',
+    APP_URL: 'http://localhost:3000',
+  },
+}))
+
+vi.mock('../../openapi/docs.js', () => {
+  const fn = (_: any, __: any, next: any) => next()
+  fn.use = fn; fn.get = fn; fn.handle = fn
+  return { default: fn }
+})
+
+vi.mock('../../config/passport.js', () => ({
+  default: {
+    initialize: () => (_: any, __: any, next: any) => next(),
+    authenticate: () => (_: any, __: any, next: any) => next(),
+  },
+}))
+
+vi.mock('../../middleware/requestLogger.js', () => ({
+  requestLogger: (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../events/index.js', () => ({ registerEventHandlers: vi.fn() }))
+
+vi.mock('../../config/rateLimiter.js', () => ({
+  moderateAuthRateLimiter: (_: any, __: any, next: any) => next(),
+  strictAuthRateLimiter: (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../middleware/versionRateLimit.js', () => ({
+  versionRateLimit: () => (_: any, __: any, next: any) => next(),
+  getRateLimitStatus: (_: any, res: any) => res.json({ status: 'ok' }),
+}))
+
+vi.mock('../../middleware/userRateLimit.js', () => ({
+  contactRateLimit: (_: any, __: any, next: any) => next(),
+  generalRateLimit: (_: any, __: any, next: any) => next(),
+  userRateLimit: () => (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../mailer/transport.js', () => ({
+  transporter: { sendMail: vi.fn().mockResolvedValue({ messageId: 'test-msg' }) },
+}))
+
+// Mock contracts service
+vi.mock('../../services/contracts.service.js', () => ({
+  createEscrowRecord: vi.fn(),
+  activateEscrowRecord: vi.fn(),
+  fileEscrowDispute: vi.fn(),
+  resolveEscrowDispute: vi.fn(),
+  fileWorkerDispute: vi.fn(),
+  escrow: {
+    listEscrows: vi.fn(),
+    getEscrow: vi.fn(),
+    releaseEscrow: vi.fn(),
+    cancelEscrow: vi.fn(),
+  },
+  dispute: {
+    listDisputes: vi.fn(),
+    getDispute: vi.fn(),
+    resolveDispute: vi.fn(),
+  },
+}))
+
+import app from '../../app.js'
+import * as contractsService from '../../services/contracts.service.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function makeToken(role = 'user', id = 'user-1') {
+  return jwt.sign({ id, email: 'user@example.com', role }, 'test-integration-secret', { expiresIn: '1h' })
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+const fakeEscrow = {
+  id: 'escrow-1',
+  jobId: 'job-1',
+  payerId: 'user-1',
+  payeeId: 'user-2',
+  amountXlm: 100,
+  status: 'pending',
+  expiresAt: new Date(Date.now() + 86400000 * 7),
+  txId: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const fakeDispute = {
+  id: 'dispute-1',
+  escrowId: 'escrow-1',
+  workerId: 'worker-1',
+  filedById: 'user-1',
+  reason: 'Payment not received',
+  evidence: 'Transaction hash: abc123',
+  status: 'pending',
+  resolution: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+// ═══ ESCROW TESTS ════════════════════════════════════════════════════════════
+
+describe('GET /api/escrow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.escrow.listEscrows).mockResolvedValue({
+      data: [fakeEscrow] as any,
+      meta: { total: 1, page: 1, limit: 20, pages: 1 },
+    })
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/escrow')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with escrow list for authenticated user', async () => {
+    const token = makeToken('user')
+    const res = await request(app).get('/api/escrow').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+    expect(res.body.data).toHaveLength(1)
+  })
+
+  it('calls service with correct user id and role', async () => {
+    const token = makeToken('user', 'user-42')
+    await request(app).get('/api/escrow').set('Authorization', `Bearer ${token}`)
+    expect(vi.mocked(contractsService.escrow.listEscrows)).toHaveBeenCalledWith('user-42', 'user', 1, 20)
+  })
+
+  it('passes pagination params to service', async () => {
+    const token = makeToken('user')
+    await request(app).get('/api/escrow?page=2&limit=10').set('Authorization', `Bearer ${token}`)
+    expect(vi.mocked(contractsService.escrow.listEscrows)).toHaveBeenCalledWith('user-1', 'user', 2, 10)
+  })
+})
+
+describe('GET /api/escrow/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.escrow.getEscrow).mockResolvedValue(fakeEscrow as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/escrow/escrow-1')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with escrow details', async () => {
+    const token = makeToken('user')
+    const res = await request(app).get('/api/escrow/escrow-1').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.id).toBe('escrow-1')
+  })
+
+  it('returns 404 when escrow not found', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.escrow.getEscrow).mockRejectedValue(
+      new AppError('Escrow not found', 404, true, ErrorCode.NOT_FOUND),
+    )
+    const token = makeToken('user')
+    const res = await request(app).get('/api/escrow/nonexistent').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when user not authorized to view escrow', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.escrow.getEscrow).mockRejectedValue(
+      new AppError('Forbidden', 403, true, ErrorCode.FORBIDDEN),
+    )
+    const token = makeToken('user', 'other-user')
+    const res = await request(app).get('/api/escrow/escrow-1').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('POST /api/escrow', () => {
+  const validBody = {
+    payeeId: 'user-2',
+    amountXlm: 100,
+    expiresAt: new Date(Date.now() + 86400000 * 7).toISOString(),
+    jobId: 'job-1',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.createEscrowRecord).mockResolvedValue(fakeEscrow as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/escrow').send(validBody)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 201 when escrow is created', async () => {
+    const token = makeToken('user')
+    const res = await request(app).post('/api/escrow').set('Authorization', `Bearer ${token}`).send(validBody)
+    expect(res.status).toBe(201)
+    expect(res.body.status).toBe('success')
+    expect(res.body.data.id).toBe('escrow-1')
+  })
+
+  it('calls service with correct payer id', async () => {
+    const token = makeToken('user', 'payer-99')
+    await request(app).post('/api/escrow').set('Authorization', `Bearer ${token}`).send(validBody)
+    expect(vi.mocked(contractsService.createEscrowRecord)).toHaveBeenCalledWith(
+      'payer-99',
+      expect.objectContaining({ payeeId: 'user-2', amountXlm: 100 }),
+    )
+  })
+
+  it('returns 400 when payeeId is missing', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.createEscrowRecord).mockRejectedValue(
+      new AppError('payeeId, amountXlm and expiresAt are required', 400, true, ErrorCode.VALIDATION_ERROR),
+    )
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/escrow')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...validBody, payeeId: undefined })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when amountXlm is missing', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.createEscrowRecord).mockRejectedValue(
+      new AppError('payeeId, amountXlm and expiresAt are required', 400, true, ErrorCode.VALIDATION_ERROR),
+    )
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/escrow')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...validBody, amountXlm: undefined })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('PATCH /api/escrow/:id/activate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.activateEscrowRecord).mockResolvedValue({
+      ...fakeEscrow,
+      status: 'active',
+      txId: 'tx-abc123',
+    } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/escrow/escrow-1/activate').send({ txId: 'tx-abc123' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 when activation succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .patch('/api/escrow/escrow-1/activate')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ txId: 'tx-abc123' })
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('active')
+  })
+
+  it('returns 400 when txId is missing', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.activateEscrowRecord).mockRejectedValue(
+      new AppError('txId is required', 400, true, ErrorCode.VALIDATION_ERROR),
+    )
+    const token = makeToken('user')
+    const res = await request(app)
+      .patch('/api/escrow/escrow-1/activate')
+      .set('Authorization', `Bearer ${token}`)
+      .send({})
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('PATCH /api/escrow/:id/release', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.escrow.releaseEscrow).mockResolvedValue({
+      ...fakeEscrow,
+      status: 'released',
+    } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/escrow/escrow-1/release')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 when release succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .patch('/api/escrow/escrow-1/release')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('released')
+  })
+})
+
+describe('PATCH /api/escrow/:id/cancel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.escrow.cancelEscrow).mockResolvedValue({
+      ...fakeEscrow,
+      status: 'cancelled',
+    } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/escrow/escrow-1/cancel')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 when cancellation succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .patch('/api/escrow/escrow-1/cancel')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('cancelled')
+  })
+})
+
+describe('POST /api/escrow/:id/disputes', () => {
+  const validBody = {
+    reason: 'Payment not received after 7 days',
+    evidence: 'Transaction ID: tx-abc123, no confirmation received',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.fileEscrowDispute).mockResolvedValue(fakeDispute as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/escrow/escrow-1/disputes').send(validBody)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 201 when dispute is filed', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/escrow/escrow-1/disputes')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(201)
+    expect(res.body.status).toBe('success')
+  })
+
+  it('returns 400 when reason is missing', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.fileEscrowDispute).mockRejectedValue(
+      new AppError('reason is required', 400, true, ErrorCode.VALIDATION_ERROR),
+    )
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/escrow/escrow-1/disputes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ evidence: 'Some evidence' })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('PATCH /api/escrow/:id/disputes/:disputeId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.resolveEscrowDispute).mockResolvedValue({
+      ...fakeDispute,
+      status: 'resolved',
+      resolution: 'Refund issued to payer',
+    } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app)
+      .patch('/api/escrow/escrow-1/disputes/dispute-1')
+      .send({ status: 'resolved', resolution: 'Refund issued' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for non-admin user', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .patch('/api/escrow/escrow-1/disputes/dispute-1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'resolved', resolution: 'Refund issued' })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 200 for admin user when resolution succeeds', async () => {
+    const token = makeToken('admin')
+    const res = await request(app)
+      .patch('/api/escrow/escrow-1/disputes/dispute-1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'resolved', resolution: 'Refund issued to payer' })
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('resolved')
+  })
+})
+
+// ═══ DISPUTES TESTS ══════════════════════════════════════════════════════════
+
+describe('POST /api/disputes', () => {
+  const validBody = {
+    workerId: 'worker-1',
+    reason: 'Worker did not complete the job as agreed',
+    evidence: 'Photos and messages proving incomplete work',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.fileWorkerDispute).mockResolvedValue(fakeDispute as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/disputes').send(validBody)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 201 when dispute is filed successfully', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/disputes')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(201)
+    expect(res.body.status).toBe('success')
+  })
+
+  it('calls service with correct args', async () => {
+    const token = makeToken('user', 'filer-99')
+    await request(app)
+      .post('/api/disputes')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(vi.mocked(contractsService.fileWorkerDispute)).toHaveBeenCalledWith(
+      'worker-1',
+      'filer-99',
+      validBody.reason,
+      validBody.evidence,
+    )
+  })
+
+  it('returns 400 when workerId is missing', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.fileWorkerDispute).mockRejectedValue(
+      new AppError('workerId and reason are required', 400, true, ErrorCode.VALIDATION_ERROR),
+    )
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/disputes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ reason: validBody.reason })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when reason is missing', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.fileWorkerDispute).mockRejectedValue(
+      new AppError('workerId and reason are required', 400, true, ErrorCode.VALIDATION_ERROR),
+    )
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/disputes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workerId: 'worker-1' })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /api/disputes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.dispute.listDisputes).mockResolvedValue({
+      data: [fakeDispute] as any,
+      meta: { total: 1, page: 1, limit: 20, pages: 1 },
+    })
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/disputes')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with dispute list for authenticated user', async () => {
+    const token = makeToken('user')
+    const res = await request(app).get('/api/disputes').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+    expect(res.body.data).toHaveLength(1)
+  })
+
+  it('calls service with user id and role', async () => {
+    const token = makeToken('user', 'user-77')
+    await request(app).get('/api/disputes').set('Authorization', `Bearer ${token}`)
+    expect(vi.mocked(contractsService.dispute.listDisputes)).toHaveBeenCalledWith('user-77', 'user', 1, 20)
+  })
+
+  it('admin can list all disputes', async () => {
+    vi.mocked(contractsService.dispute.listDisputes).mockResolvedValue({
+      data: [fakeDispute, { ...fakeDispute, id: 'dispute-2' }] as any,
+      meta: { total: 2, page: 1, limit: 20, pages: 1 },
+    })
+    const token = makeToken('admin')
+    const res = await request(app).get('/api/disputes').set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(2)
+  })
+
+  it('passes pagination params to service', async () => {
+    const token = makeToken('user')
+    await request(app).get('/api/disputes?page=2&limit=5').set('Authorization', `Bearer ${token}`)
+    expect(vi.mocked(contractsService.dispute.listDisputes)).toHaveBeenCalledWith('user-1', 'user', 2, 5)
+  })
+})
+
+describe('GET /api/disputes/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.dispute.getDispute).mockResolvedValue(fakeDispute as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/disputes/dispute-1')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with dispute details', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .get('/api/disputes/dispute-1')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.id).toBe('dispute-1')
+    expect(res.body.data.reason).toBe('Payment not received')
+  })
+
+  it('returns 404 when dispute not found', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.dispute.getDispute).mockRejectedValue(
+      new AppError('Dispute not found', 404, true, ErrorCode.NOT_FOUND),
+    )
+    const token = makeToken('user')
+    const res = await request(app)
+      .get('/api/disputes/nonexistent')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when user is not authorized to view the dispute', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.dispute.getDispute).mockRejectedValue(
+      new AppError('Forbidden', 403, true, ErrorCode.FORBIDDEN),
+    )
+    const token = makeToken('user', 'other-user')
+    const res = await request(app)
+      .get('/api/disputes/dispute-1')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('PATCH /api/disputes/:id/resolve', () => {
+  const validBody = { status: 'resolved', resolution: 'Worker issued a full refund' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(contractsService.dispute.resolveDispute).mockResolvedValue({
+      ...fakeDispute,
+      status: 'resolved',
+      resolution: 'Worker issued a full refund',
+    } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/disputes/dispute-1/resolve').send(validBody)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for non-admin user', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .patch('/api/disputes/dispute-1/resolve')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 200 for admin user', async () => {
+    const token = makeToken('admin')
+    const res = await request(app)
+      .patch('/api/disputes/dispute-1/resolve')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('resolved')
+    expect(res.body.data.resolution).toBe('Worker issued a full refund')
+  })
+
+  it('calls service with correct args', async () => {
+    const token = makeToken('admin', 'admin-1')
+    await request(app)
+      .patch('/api/disputes/dispute-1/resolve')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(vi.mocked(contractsService.dispute.resolveDispute)).toHaveBeenCalledWith(
+      'dispute-1',
+      'admin-1',
+      'resolved',
+      'Worker issued a full refund',
+    )
+  })
+
+  it('returns 400 for invalid status', async () => {
+    const { AppError, ErrorCode } = await import('../../utils/AppError.js')
+    vi.mocked(contractsService.dispute.resolveDispute).mockRejectedValue(
+      new AppError('status must be under_review, resolved, or dismissed', 400, true, ErrorCode.VALIDATION_ERROR),
+    )
+    const token = makeToken('admin')
+    const res = await request(app)
+      .patch('/api/disputes/dispute-1/resolve')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'bad-status' })
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/api/src/__tests__/integration/jobs.integration.test.ts
+++ b/packages/api/src/__tests__/integration/jobs.integration.test.ts
@@ -1,0 +1,740 @@
+/**
+ * Integration tests for jobs endpoints (#1002)
+ *
+ * Covers:
+ *  - GET    /api/jobs
+ *  - GET    /api/jobs/:id
+ *  - POST   /api/jobs
+ *  - PUT    /api/jobs/:id
+ *  - DELETE /api/jobs/:id
+ *  - POST   /api/jobs/:id/renew
+ *  - GET    /api/jobs/me/posted
+ *  - GET    /api/jobs/me/applications
+ *  - POST   /api/jobs/:id/apply
+ *  - GET    /api/jobs/:id/applications
+ *  - PATCH  /api/jobs/:id/applications/:applicationId
+ *  - DELETE /api/jobs/:id/apply
+ *  - POST   /api/jobs/:id/messages
+ *  - GET    /api/jobs/:id/messages
+ *
+ * All DB / Redis / external deps are mocked; the full HTTP cycle is
+ * exercised via supertest against the real Express app.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+// ─── Environment ─────────────────────────────────────────────────────────────
+process.env.JWT_SECRET = 'test-integration-secret'
+process.env.DATABASE_URL = 'postgresql://localhost:5432/test'
+process.env.REDIS_URL = 'redis://localhost:6379'
+process.env.APP_URL = 'http://localhost:3000'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+vi.mock('../../db.js', () => ({
+  db: {
+    worker: { findMany: vi.fn(), findUnique: vi.fn(), count: vi.fn(), findFirst: vi.fn() },
+    category: { findUnique: vi.fn(), findMany: vi.fn() },
+    review: { aggregate: vi.fn(), groupBy: vi.fn() },
+    notification: { create: vi.fn() },
+    user: { findUnique: vi.fn() },
+    location: { findMany: vi.fn() },
+    $queryRaw: vi.fn(),
+    $transaction: vi.fn(),
+  },
+}))
+
+vi.mock('../../config/redis.js', () => ({
+  redis: { connect: vi.fn().mockResolvedValue(undefined), ping: vi.fn().mockResolvedValue('PONG') },
+  cacheMetrics: { hits: 0, misses: 0 },
+}))
+
+vi.mock('../../config/env.js', () => ({
+  env: {
+    DATABASE_URL: 'postgresql://localhost:5432/test',
+    JWT_SECRET: 'test-integration-secret',
+    PORT: 3000,
+    GOOGLE_CLIENT_ID: 'test',
+    GOOGLE_CLIENT_SECRET: 'test',
+    MAIL_HOST: 'smtp.test.local',
+    MAIL_PORT: 587,
+    MAIL_USER: 'test',
+    MAIL_PASS: 'test',
+    APP_URL: 'http://localhost:3000',
+  },
+}))
+
+vi.mock('../../openapi/docs.js', () => {
+  const fn = (_: any, __: any, next: any) => next()
+  fn.use = fn; fn.get = fn; fn.handle = fn
+  return { default: fn }
+})
+
+vi.mock('../../config/passport.js', () => ({
+  default: {
+    initialize: () => (_: any, __: any, next: any) => next(),
+    authenticate: () => (_: any, __: any, next: any) => next(),
+  },
+}))
+
+vi.mock('../../middleware/requestLogger.js', () => ({
+  requestLogger: (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../events/index.js', () => ({ registerEventHandlers: vi.fn() }))
+
+vi.mock('../../config/rateLimiter.js', () => ({
+  moderateAuthRateLimiter: (_: any, __: any, next: any) => next(),
+  strictAuthRateLimiter: (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../middleware/versionRateLimit.js', () => ({
+  versionRateLimit: () => (_: any, __: any, next: any) => next(),
+  getRateLimitStatus: (_: any, res: any) => res.json({ status: 'ok' }),
+}))
+
+vi.mock('../../middleware/userRateLimit.js', () => ({
+  contactRateLimit: (_: any, __: any, next: any) => next(),
+  generalRateLimit: (_: any, __: any, next: any) => next(),
+  userRateLimit: () => (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../mailer/transport.js', () => ({
+  transporter: { sendMail: vi.fn().mockResolvedValue({ messageId: 'test-msg' }) },
+}))
+
+// Mock the job service so we control responses
+vi.mock('../../services/job.service.js', () => ({
+  listJobs: vi.fn(),
+  getJob: vi.fn(),
+  createJob: vi.fn(),
+  updateJob: vi.fn(),
+  deleteJob: vi.fn(),
+  renewJob: vi.fn(),
+  recommendedJobs: vi.fn(),
+  myPostedJobs: vi.fn(),
+  myApplications: vi.fn(),
+  applyToJob: vi.fn(),
+  listApplications: vi.fn(),
+  updateApplicationStatus: vi.fn(),
+  withdrawApplication: vi.fn(),
+  sendMessage: vi.fn(),
+  listMessages: vi.fn(),
+}))
+
+import app from '../../app.js'
+import * as jobService from '../../services/job.service.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function makeToken(role = 'user', id = 'user-1') {
+  return jwt.sign({ id, email: 'user@example.com', role }, 'test-integration-secret', { expiresIn: '1h' })
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+const fakeJob = {
+  id: 'job-1',
+  title: 'Fix kitchen sink',
+  description: 'Need a plumber to fix leaking kitchen sink pipes',
+  budget: 150,
+  skills: ['plumbing'],
+  urgency: 'normal',
+  status: 'open',
+  categoryId: 'cat-1',
+  postedById: 'user-1',
+  locationId: null,
+  expiresAt: new Date(Date.now() + 86400000 * 30),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  renewedAt: null,
+  escrowAmount: null,
+  category: { id: 'cat-1', name: 'Plumbing' },
+  location: null,
+  postedBy: { id: 'user-1', firstName: 'Jane', lastName: 'Doe', avatar: null },
+  _count: { applications: 0, messages: 0 },
+}
+
+const fakeApplication = {
+  id: 'app-1',
+  jobId: 'job-1',
+  workerId: 'worker-1',
+  coverLetter: 'I have 10 years experience with plumbing',
+  proposedRate: 120,
+  status: 'pending',
+  createdAt: new Date(),
+  job: { id: 'job-1', title: 'Fix kitchen sink', postedById: 'user-1' },
+  worker: { id: 'worker-1', name: 'Bob Plumber', avatar: null, email: 'bob@example.com', category: null },
+}
+
+const fakeMessage = {
+  id: 'msg-1',
+  jobId: 'job-1',
+  senderId: 'user-1',
+  recipientId: 'worker-1',
+  body: 'Are you available this weekend?',
+  createdAt: new Date(),
+}
+
+// ─── GET /api/jobs ────────────────────────────────────────────────────────────
+describe('GET /api/jobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.listJobs).mockResolvedValue({
+      data: [fakeJob] as any,
+      meta: { total: 1, page: 1, limit: 20, pages: 1 },
+    })
+  })
+
+  it('returns 200 with job list (public endpoint)', async () => {
+    const res = await request(app).get('/api/jobs')
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].title).toBe('Fix kitchen sink')
+  })
+
+  it('returns paginated meta', async () => {
+    const res = await request(app).get('/api/jobs')
+    expect(res.body).toHaveProperty('meta')
+    expect(res.body.meta.total).toBe(1)
+  })
+
+  it('passes categoryId filter to service', async () => {
+    await request(app).get('/api/jobs?categoryId=cat-1')
+    expect(vi.mocked(jobService.listJobs)).toHaveBeenCalledWith(
+      expect.objectContaining({ categoryId: 'cat-1' }),
+    )
+  })
+
+  it('passes status filter to service', async () => {
+    await request(app).get('/api/jobs?status=closed')
+    expect(vi.mocked(jobService.listJobs)).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'closed' }),
+    )
+  })
+
+  it('passes search text to service', async () => {
+    await request(app).get('/api/jobs?search=sink')
+    expect(vi.mocked(jobService.listJobs)).toHaveBeenCalledWith(
+      expect.objectContaining({ search: 'sink' }),
+    )
+  })
+
+  it('passes urgency filter to service', async () => {
+    await request(app).get('/api/jobs?urgency=urgent')
+    expect(vi.mocked(jobService.listJobs)).toHaveBeenCalledWith(
+      expect.objectContaining({ urgency: 'urgent' }),
+    )
+  })
+
+  it('passes budget range to service', async () => {
+    await request(app).get('/api/jobs?minBudget=100&maxBudget=500')
+    expect(vi.mocked(jobService.listJobs)).toHaveBeenCalledWith(
+      expect.objectContaining({ minBudget: 100, maxBudget: 500 }),
+    )
+  })
+
+  it('passes skills filter to service', async () => {
+    await request(app).get('/api/jobs?skills=plumbing,welding')
+    expect(vi.mocked(jobService.listJobs)).toHaveBeenCalledWith(
+      expect.objectContaining({ skills: ['plumbing', 'welding'] }),
+    )
+  })
+
+  it('passes pagination params to service', async () => {
+    await request(app).get('/api/jobs?page=2&limit=5')
+    expect(vi.mocked(jobService.listJobs)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2, limit: 5 }),
+    )
+  })
+
+  it('returns empty array when no jobs exist', async () => {
+    vi.mocked(jobService.listJobs).mockResolvedValue({ data: [], meta: { total: 0, page: 1, limit: 20, pages: 0 } })
+    const res = await request(app).get('/api/jobs')
+    expect(res.status).toBe(200)
+    expect(res.body.data).toEqual([])
+  })
+})
+
+// ─── GET /api/jobs/:id ────────────────────────────────────────────────────────
+describe('GET /api/jobs/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.getJob).mockResolvedValue(fakeJob as any)
+  })
+
+  it('returns 200 with the job (public endpoint)', async () => {
+    const res = await request(app).get('/api/jobs/job-1')
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+    expect(res.body.data.id).toBe('job-1')
+  })
+
+  it('returns 404 when job does not exist', async () => {
+    const { AppError } = await import('../../utils/AppError.js')
+    vi.mocked(jobService.getJob).mockRejectedValue(new AppError('Job not found', 404))
+    const res = await request(app).get('/api/jobs/nonexistent')
+    expect(res.status).toBe(404)
+  })
+})
+
+// ─── POST /api/jobs ───────────────────────────────────────────────────────────
+describe('POST /api/jobs', () => {
+  const validBody = {
+    title: 'Fix bathroom tiles',
+    description: 'Need a tiler to fix cracked bathroom tiles in main bathroom',
+    budget: 200,
+    skills: ['tiling'],
+    urgency: 'normal',
+    categoryId: 'cat-1',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.createJob).mockResolvedValue({ ...fakeJob, ...validBody } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/jobs').send(validBody)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 201 with valid body and auth', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(201)
+    expect(res.body.status).toBe('success')
+  })
+
+  it('returns 400 when title is missing', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...validBody, title: undefined })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when description is too short', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...validBody, description: 'Short' })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when categoryId is missing', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...validBody, categoryId: undefined })
+    expect(res.status).toBe(400)
+  })
+
+  it('calls service with correct data and user id', async () => {
+    const token = makeToken('user', 'user-42')
+    await request(app)
+      .post('/api/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(vi.mocked(jobService.createJob)).toHaveBeenCalledWith(
+      expect.objectContaining({ title: validBody.title }),
+      'user-42',
+    )
+  })
+})
+
+// ─── PUT /api/jobs/:id ────────────────────────────────────────────────────────
+describe('PUT /api/jobs/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.updateJob).mockResolvedValue({ ...fakeJob, title: 'Updated title' } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).put('/api/jobs/job-1').send({ title: 'New title' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 when update succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .put('/api/jobs/job-1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Updated job title with more text' })
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+  })
+
+  it('returns 404 when job does not exist', async () => {
+    const { AppError } = await import('../../utils/AppError.js')
+    vi.mocked(jobService.updateJob).mockRejectedValue(new AppError('Job not found', 404))
+    const token = makeToken('user')
+    const res = await request(app)
+      .put('/api/jobs/bad-id')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Updated title that is long enough' })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when user does not own the job', async () => {
+    const { AppError } = await import('../../utils/AppError.js')
+    vi.mocked(jobService.updateJob).mockRejectedValue(new AppError('Forbidden', 403))
+    const token = makeToken('user', 'other-user')
+    const res = await request(app)
+      .put('/api/jobs/job-1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Trying to update someone elses job' })
+    expect(res.status).toBe(403)
+  })
+})
+
+// ─── DELETE /api/jobs/:id ─────────────────────────────────────────────────────
+describe('DELETE /api/jobs/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.deleteJob).mockResolvedValue(undefined)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).delete('/api/jobs/job-1')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 204 when delete succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .delete('/api/jobs/job-1')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(204)
+  })
+
+  it('returns 404 when job does not exist', async () => {
+    const { AppError } = await import('../../utils/AppError.js')
+    vi.mocked(jobService.deleteJob).mockRejectedValue(new AppError('Job not found', 404))
+    const token = makeToken('user')
+    const res = await request(app)
+      .delete('/api/jobs/nonexistent')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when user does not own the job', async () => {
+    const { AppError } = await import('../../utils/AppError.js')
+    vi.mocked(jobService.deleteJob).mockRejectedValue(new AppError('Forbidden', 403))
+    const token = makeToken('user', 'other-user')
+    const res = await request(app)
+      .delete('/api/jobs/job-1')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(403)
+  })
+})
+
+// ─── POST /api/jobs/:id/renew ─────────────────────────────────────────────────
+describe('POST /api/jobs/:id/renew', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.renewJob).mockResolvedValue({ ...fakeJob, status: 'open' } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/jobs/job-1/renew')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 when renewal succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs/job-1/renew')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ days: 30 })
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+  })
+
+  it('uses default days when not provided', async () => {
+    const token = makeToken('user')
+    await request(app)
+      .post('/api/jobs/job-1/renew')
+      .set('Authorization', `Bearer ${token}`)
+      .send({})
+    expect(vi.mocked(jobService.renewJob)).toHaveBeenCalledWith('job-1', 'user-1', 30)
+  })
+})
+
+// ─── GET /api/jobs/me/posted ──────────────────────────────────────────────────
+describe('GET /api/jobs/me/posted', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.myPostedJobs).mockResolvedValue({
+      data: [fakeJob] as any,
+      meta: { total: 1, page: 1, limit: 20, pages: 1 },
+    })
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/jobs/me/posted')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with user\'s posted jobs', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .get('/api/jobs/me/posted')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+    expect(res.body.data).toHaveLength(1)
+  })
+
+  it('calls service with the authenticated user id', async () => {
+    const token = makeToken('user', 'user-99')
+    await request(app)
+      .get('/api/jobs/me/posted')
+      .set('Authorization', `Bearer ${token}`)
+    expect(vi.mocked(jobService.myPostedJobs)).toHaveBeenCalledWith('user-99', 1, 20)
+  })
+})
+
+// ─── GET /api/jobs/me/applications ───────────────────────────────────────────
+describe('GET /api/jobs/me/applications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.myApplications).mockResolvedValue({
+      data: [fakeApplication] as any,
+      meta: { total: 1, page: 1, limit: 20, pages: 1 },
+    })
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/jobs/me/applications?workerId=worker-1')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with applications when workerId provided', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .get('/api/jobs/me/applications?workerId=worker-1')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(1)
+  })
+
+  it('returns 400 when workerId is missing', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .get('/api/jobs/me/applications')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── POST /api/jobs/:id/apply ─────────────────────────────────────────────────
+describe('POST /api/jobs/:id/apply', () => {
+  const validBody = {
+    workerId: 'worker-1',
+    coverLetter: 'I am an experienced plumber with 10 years of experience',
+    proposedRate: 120,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.applyToJob).mockResolvedValue(fakeApplication as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/jobs/job-1/apply').send(validBody)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 201 when application succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs/job-1/apply')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(201)
+    expect(res.body.status).toBe('success')
+  })
+
+  it('returns 400 when workerId is missing', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs/job-1/apply')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ coverLetter: 'I have experience but missing workerId', proposedRate: 100 })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when job does not exist', async () => {
+    const { AppError } = await import('../../utils/AppError.js')
+    vi.mocked(jobService.applyToJob).mockRejectedValue(new AppError('Job not found', 404))
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs/bad-id/apply')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 when job is not open', async () => {
+    const { AppError } = await import('../../utils/AppError.js')
+    vi.mocked(jobService.applyToJob).mockRejectedValue(
+      new AppError('Job is not accepting applications', 400),
+    )
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs/job-1/apply')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── GET /api/jobs/:id/applications ──────────────────────────────────────────
+describe('GET /api/jobs/:id/applications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.listApplications).mockResolvedValue([fakeApplication] as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/jobs/job-1/applications')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with application list', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .get('/api/jobs/job-1/applications')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(1)
+  })
+})
+
+// ─── PATCH /api/jobs/:id/applications/:appId ─────────────────────────────────
+describe('PATCH /api/jobs/:id/applications/:appId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.updateApplicationStatus).mockResolvedValue({
+      ...fakeApplication, status: 'accepted',
+    } as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/jobs/job-1/applications/app-1').send({ status: 'accepted' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 when status update succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .patch('/api/jobs/job-1/applications/app-1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'accepted' })
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('accepted')
+  })
+
+  it('returns 400 for invalid status value', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .patch('/api/jobs/job-1/applications/app-1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'invalid-status' })
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── DELETE /api/jobs/:id/apply (withdraw) ────────────────────────────────────
+describe('DELETE /api/jobs/:id/apply', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.withdrawApplication).mockResolvedValue(fakeApplication as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).delete('/api/jobs/job-1/apply').send({ workerId: 'worker-1' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 when withdrawal succeeds', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .delete('/api/jobs/job-1/apply')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ workerId: 'worker-1' })
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 400 when workerId is missing', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .delete('/api/jobs/job-1/apply')
+      .set('Authorization', `Bearer ${token}`)
+      .send({})
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── POST /api/jobs/:id/messages ──────────────────────────────────────────────
+describe('POST /api/jobs/:id/messages', () => {
+  const validBody = { recipientId: 'worker-1', body: 'Are you available this weekend?' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.sendMessage).mockResolvedValue(fakeMessage as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/jobs/job-1/messages').send(validBody)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 201 when message is sent', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs/job-1/messages')
+      .set('Authorization', `Bearer ${token}`)
+      .send(validBody)
+    expect(res.status).toBe(201)
+    expect(res.body.status).toBe('success')
+  })
+
+  it('returns 400 when body is missing', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .post('/api/jobs/job-1/messages')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ recipientId: 'worker-1' })
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── GET /api/jobs/:id/messages ───────────────────────────────────────────────
+describe('GET /api/jobs/:id/messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jobService.listMessages).mockResolvedValue([fakeMessage] as any)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/jobs/job-1/messages')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with messages list', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .get('/api/jobs/job-1/messages')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].body).toBe('Are you available this weekend?')
+  })
+})

--- a/packages/api/src/__tests__/integration/search.integration.test.ts
+++ b/packages/api/src/__tests__/integration/search.integration.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Integration tests for search endpoints (#1001)
+ *
+ * Covers:
+ *  - GET /api/workers/search      (searchWorkersHandler)
+ *  - GET /api/workers/search/advanced (advancedSearch)
+ *
+ * All DB / Redis / external deps are mocked; the full HTTP cycle is exercised
+ * via supertest against the real Express app.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+// ─── Environment ─────────────────────────────────────────────────────────────
+process.env.JWT_SECRET = 'test-integration-secret'
+process.env.DATABASE_URL = 'postgresql://localhost:5432/test'
+process.env.REDIS_URL = 'redis://localhost:6379'
+process.env.APP_URL = 'http://localhost:3000'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+vi.mock('../../db.js', () => ({
+  db: {
+    worker: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    category: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    review: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      count: vi.fn(),
+      groupBy: vi.fn(),
+      aggregate: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    searchAnalytics: {
+      create: vi.fn(),
+    },
+    notification: { create: vi.fn() },
+    user: { findUnique: vi.fn() },
+    location: { findMany: vi.fn() },
+    workerAnalytics: { findUnique: vi.fn(), upsert: vi.fn() },
+    $queryRaw: vi.fn(),
+    $queryRawUnsafe: vi.fn(),
+    $transaction: vi.fn(),
+  },
+}))
+
+vi.mock('../../config/redis.js', () => ({
+  redis: {
+    connect: vi.fn().mockResolvedValue(undefined),
+    ping: vi.fn().mockResolvedValue('PONG'),
+  },
+  cacheMetrics: { hits: 0, misses: 0 },
+}))
+
+vi.mock('../../config/env.js', () => ({
+  env: {
+    DATABASE_URL: 'postgresql://localhost:5432/test',
+    JWT_SECRET: 'test-integration-secret',
+    PORT: 3000,
+    GOOGLE_CLIENT_ID: 'test',
+    GOOGLE_CLIENT_SECRET: 'test',
+    MAIL_HOST: 'smtp.test.local',
+    MAIL_PORT: 587,
+    MAIL_USER: 'test',
+    MAIL_PASS: 'test',
+    APP_URL: 'http://localhost:3000',
+  },
+}))
+
+vi.mock('../../openapi/docs.js', () => {
+  const fn = (_: any, __: any, next: any) => next()
+  fn.use = fn
+  fn.get = fn
+  fn.handle = fn
+  return { default: fn }
+})
+
+vi.mock('../../config/passport.js', () => ({
+  default: {
+    initialize: () => (_: any, __: any, next: any) => next(),
+    authenticate: () => (_: any, __: any, next: any) => next(),
+  },
+}))
+
+vi.mock('../../middleware/requestLogger.js', () => ({
+  requestLogger: (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../events/index.js', () => ({ registerEventHandlers: vi.fn() }))
+
+vi.mock('../../config/rateLimiter.js', () => ({
+  moderateAuthRateLimiter: (_: any, __: any, next: any) => next(),
+  strictAuthRateLimiter: (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../middleware/versionRateLimit.js', () => ({
+  versionRateLimit: () => (_: any, __: any, next: any) => next(),
+  getRateLimitStatus: (_: any, res: any) => res.json({ status: 'ok' }),
+}))
+
+vi.mock('../../middleware/userRateLimit.js', () => ({
+  contactRateLimit: (_: any, __: any, next: any) => next(),
+  generalRateLimit: (_: any, __: any, next: any) => next(),
+  userRateLimit: () => (_: any, __: any, next: any) => next(),
+}))
+
+vi.mock('../../mailer/transport.js', () => ({
+  transporter: { sendMail: vi.fn().mockResolvedValue({ messageId: 'test-msg' }) },
+}))
+
+// Mock search service to isolate controller under test
+vi.mock('../../services/search.service.js', () => ({
+  searchWorkers: vi.fn(),
+  performAdvancedSearch: vi.fn(),
+}))
+
+// Mock worker service (used by advancedSearch path)
+vi.mock('../../services/worker.service.js', () => ({
+  listWorkers: vi.fn(),
+  listWorkersCursor: vi.fn(),
+  listWorkersGeo: vi.fn(),
+  getWorkerWithPortfolio: vi.fn(),
+  createWorkerWithMedia: vi.fn(),
+  updateWorkerWithMedia: vi.fn(),
+  deleteWorkerWithMedia: vi.fn(),
+  toggleWorker: vi.fn(),
+  listMyWorkers: vi.fn(),
+  advancedSearch: vi.fn(),
+  trackSearchAnalytics: vi.fn(),
+  getWorkerReputation: vi.fn(),
+}))
+
+import app from '../../app.js'
+import * as searchService from '../../services/search.service.js'
+import { db } from '../../db.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeToken(role = 'user', id = 'user-1') {
+  return jwt.sign(
+    { id, email: 'user@example.com', role },
+    'test-integration-secret',
+    { expiresIn: '1h' },
+  )
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const fakeSearchResult = {
+  data: [
+    {
+      id: 'worker-1',
+      name: 'Alice Plumber',
+      bio: 'Expert plumber with 10 years experience',
+      isActive: true,
+      isVerified: true,
+      categoryId: 'cat-1',
+      rank: 0.85,
+      highlight: { name: 'Alice <mark>Plumber</mark>', bio: 'Expert <mark>plumber</mark>' },
+    },
+  ],
+  meta: { total: 1, page: 1, limit: 20, pages: 1 },
+}
+
+const fakeAdvancedResult = {
+  data: [
+    {
+      id: 'worker-2',
+      name: 'Bob Electrician',
+      bio: 'Certified electrician',
+      isActive: true,
+      isVerified: true,
+      categoryId: 'cat-2',
+    },
+  ],
+  meta: { total: 1, page: 1, limit: 20, hasMore: false, pages: 1 },
+}
+
+// ─── GET /api/workers/search ──────────────────────────────────────────────────
+
+describe('GET /api/workers/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(searchService.searchWorkers).mockResolvedValue(fakeSearchResult as any)
+  })
+
+  it('returns 200 with search results on a basic query', async () => {
+    const res = await request(app).get('/api/workers/search?q=plumber')
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].name).toBe('Alice Plumber')
+  })
+
+  it('returns 200 even without a query param (browse mode)', async () => {
+    vi.mocked(searchService.searchWorkers).mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 20, pages: 0 },
+    })
+    const res = await request(app).get('/api/workers/search')
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+    expect(Array.isArray(res.body.data)).toBe(true)
+  })
+
+  it('passes the q param to the search service', async () => {
+    await request(app).get('/api/workers/search?q=electrician')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'electrician' }),
+      expect.anything(),
+    )
+  })
+
+  it('accepts query alias for q param', async () => {
+    await request(app).get('/api/workers/search?query=welder')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'welder' }),
+      expect.anything(),
+    )
+  })
+
+  it('passes geo params (lat, lng, radius) to the service', async () => {
+    await request(app).get('/api/workers/search?q=plumber&lat=6.5244&lng=3.3792&radius=15')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ lat: 6.5244, lng: 3.3792, radius: 15 }),
+      expect.anything(),
+    )
+  })
+
+  it('passes category filter to the service', async () => {
+    await request(app).get('/api/workers/search?q=plumber&categories=cat-1,cat-2')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ categories: ['cat-1', 'cat-2'] }),
+      expect.anything(),
+    )
+  })
+
+  it('passes isVerified filter to the service', async () => {
+    await request(app).get('/api/workers/search?isVerified=true')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ isVerified: true }),
+      expect.anything(),
+    )
+  })
+
+  it('passes rating filters to the service', async () => {
+    await request(app).get('/api/workers/search?minRating=3&maxRating=5')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ minRating: 3, maxRating: 5 }),
+      expect.anything(),
+    )
+  })
+
+  it('passes sortBy=rating param to the service', async () => {
+    await request(app).get('/api/workers/search?sortBy=rating')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ sortBy: 'rating' }),
+      expect.anything(),
+    )
+  })
+
+  it('passes pagination params to the service', async () => {
+    await request(app).get('/api/workers/search?page=2&limit=10')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2, limit: 10 }),
+      expect.anything(),
+    )
+  })
+
+  it('caps limit at 100', async () => {
+    await request(app).get('/api/workers/search?limit=500')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 100 }),
+      expect.anything(),
+    )
+  })
+
+  it('includes meta in the response', async () => {
+    const res = await request(app).get('/api/workers/search?q=plumber')
+    expect(res.body).toHaveProperty('meta')
+    expect(res.body.meta).toMatchObject({ total: 1, page: 1, limit: 20, pages: 1 })
+  })
+
+  it('returns 500 when search service throws an unexpected error', async () => {
+    vi.mocked(searchService.searchWorkers).mockRejectedValue(new Error('DB connection lost'))
+    const res = await request(app).get('/api/workers/search?q=plumber')
+    expect(res.status).toBeGreaterThanOrEqual(500)
+  })
+
+  it('is accessible without authentication', async () => {
+    // No Authorization header
+    const res = await request(app).get('/api/workers/search?q=plumber')
+    expect(res.status).toBe(200)
+  })
+
+  it('works with an authenticated user token as well', async () => {
+    const token = makeToken('user')
+    const res = await request(app)
+      .get('/api/workers/search?q=plumber')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+  })
+
+  it('returns empty data array when no results found', async () => {
+    vi.mocked(searchService.searchWorkers).mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 20, pages: 0 },
+    })
+    const res = await request(app).get('/api/workers/search?q=nonexistentskill123')
+    expect(res.status).toBe(200)
+    expect(res.body.data).toEqual([])
+    expect(res.body.meta.total).toBe(0)
+  })
+
+  it('passes dayOfWeek filter to the service', async () => {
+    await request(app).get('/api/workers/search?dayOfWeek=1')
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalledWith(
+      expect.objectContaining({ dayOfWeek: 1 }),
+      expect.anything(),
+    )
+  })
+})
+
+// ─── GET /api/workers/search/advanced ────────────────────────────────────────
+
+describe('GET /api/workers/search/advanced', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(searchService.performAdvancedSearch).mockResolvedValue(fakeAdvancedResult as any)
+  })
+
+  it('returns 200 with results on a basic query', async () => {
+    const res = await request(app).get('/api/workers/search/advanced?query=electrician')
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('success')
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].name).toBe('Bob Electrician')
+  })
+
+  it('returns 200 with no query (browse mode)', async () => {
+    vi.mocked(searchService.performAdvancedSearch).mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 20, hasMore: false, pages: 0 },
+    })
+    const res = await request(app).get('/api/workers/search/advanced')
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body.data)).toBe(true)
+  })
+
+  it('passes text query to the service', async () => {
+    await request(app).get('/api/workers/search/advanced?query=carpenter')
+    expect(vi.mocked(searchService.performAdvancedSearch)).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'carpenter' }),
+      expect.anything(),
+    )
+  })
+
+  it('passes geo params to the service', async () => {
+    await request(app).get('/api/workers/search/advanced?lat=9.0765&lng=7.3986&radius=20')
+    expect(vi.mocked(searchService.performAdvancedSearch)).toHaveBeenCalledWith(
+      expect.objectContaining({ lat: 9.0765, lng: 7.3986, radius: 20 }),
+      expect.anything(),
+    )
+  })
+
+  it('passes category filter to the service', async () => {
+    await request(app).get('/api/workers/search/advanced?categories=cat-1,cat-3')
+    expect(vi.mocked(searchService.performAdvancedSearch)).toHaveBeenCalledWith(
+      expect.objectContaining({ categories: ['cat-1', 'cat-3'] }),
+      expect.anything(),
+    )
+  })
+
+  it('passes rating filters to the service', async () => {
+    await request(app).get('/api/workers/search/advanced?minRating=4&maxRating=5')
+    expect(vi.mocked(searchService.performAdvancedSearch)).toHaveBeenCalledWith(
+      expect.objectContaining({ minRating: 4, maxRating: 5 }),
+      expect.anything(),
+    )
+  })
+
+  it('passes availability time window to the service', async () => {
+    await request(app).get('/api/workers/search/advanced?startTime=09:00&endTime=17:00')
+    expect(vi.mocked(searchService.performAdvancedSearch)).toHaveBeenCalledWith(
+      expect.objectContaining({ startTime: '09:00', endTime: '17:00' }),
+      expect.anything(),
+    )
+  })
+
+  it('passes isVerified filter to the service', async () => {
+    await request(app).get('/api/workers/search/advanced?isVerified=true')
+    expect(vi.mocked(searchService.performAdvancedSearch)).toHaveBeenCalledWith(
+      expect.objectContaining({ isVerified: true }),
+      expect.anything(),
+    )
+  })
+
+  it('passes sortBy param to the service', async () => {
+    await request(app).get('/api/workers/search/advanced?sortBy=distance')
+    expect(vi.mocked(searchService.performAdvancedSearch)).toHaveBeenCalledWith(
+      expect.objectContaining({ sortBy: 'distance' }),
+      expect.anything(),
+    )
+  })
+
+  it('passes pagination params to the service', async () => {
+    await request(app).get('/api/workers/search/advanced?page=3&limit=5')
+    expect(vi.mocked(searchService.performAdvancedSearch)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 3, limit: 5 }),
+      expect.anything(),
+    )
+  })
+
+  it('includes hasMore in meta', async () => {
+    vi.mocked(searchService.performAdvancedSearch).mockResolvedValue({
+      data: [],
+      meta: { total: 100, page: 1, limit: 20, hasMore: true, pages: 5 },
+    })
+    const res = await request(app).get('/api/workers/search/advanced?query=plumber')
+    expect(res.body.meta).toMatchObject({ hasMore: true })
+  })
+
+  it('is publicly accessible without a token', async () => {
+    const res = await request(app).get('/api/workers/search/advanced?query=welder')
+    expect(res.status).toBe(200)
+  })
+
+  it('works with an authenticated token as well', async () => {
+    const token = makeToken('curator')
+    const res = await request(app)
+      .get('/api/workers/search/advanced?query=painter')
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 500 when the service throws', async () => {
+    vi.mocked(searchService.performAdvancedSearch).mockRejectedValue(new Error('Service error'))
+    const res = await request(app).get('/api/workers/search/advanced?query=test')
+    expect(res.status).toBeGreaterThanOrEqual(500)
+  })
+
+  it('returns empty data when no workers match', async () => {
+    vi.mocked(searchService.performAdvancedSearch).mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 20, hasMore: false, pages: 0 },
+    })
+    const res = await request(app).get('/api/workers/search/advanced?query=nonexistent')
+    expect(res.status).toBe(200)
+    expect(res.body.data).toEqual([])
+    expect(res.body.meta.total).toBe(0)
+  })
+})
+
+// ─── Auth & validation failure cases ─────────────────────────────────────────
+
+describe('Search endpoints – auth and validation edge cases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(searchService.searchWorkers).mockResolvedValue(fakeSearchResult as any)
+    vi.mocked(searchService.performAdvancedSearch).mockResolvedValue(fakeAdvancedResult as any)
+  })
+
+  it('rejects an invalid Bearer token with 401', async () => {
+    const res = await request(app)
+      .get('/api/workers/search?q=test')
+      .set('Authorization', 'Bearer not-a-real-token')
+    // search is public so invalid token is ignored (route has no auth guard)
+    // the app should still respond with 200 for public endpoints
+    expect([200, 401]).toContain(res.status)
+  })
+
+  it('handles malformed limit gracefully (defaults to capped value)', async () => {
+    const res = await request(app).get('/api/workers/search?limit=abc')
+    expect(res.status).toBe(200)
+  })
+
+  it('handles malformed page gracefully', async () => {
+    const res = await request(app).get('/api/workers/search?page=foo')
+    expect(res.status).toBe(200)
+  })
+
+  it('handles XSS attempt in query string safely', async () => {
+    const res = await request(app).get(
+      '/api/workers/search?q=%3Cscript%3Ealert(1)%3C%2Fscript%3E',
+    )
+    expect(res.status).toBe(200)
+    // Verify it called the service with the sanitised/raw string — no crash
+    expect(vi.mocked(searchService.searchWorkers)).toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/controllers/wallet.test.ts
+++ b/packages/api/src/controllers/wallet.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for the wallet controller (#1004)
+ *
+ * The controller is exercised in complete isolation by injecting a stubbed
+ * WalletService via `createWalletController()`. No real DB, network, or
+ * external deps are touched.
+ *
+ * Note: `catchAsync` wraps handlers so the returned function is synchronous;
+ * the internal promise resolves in the microtask queue. We use `flushPromises`
+ * to await all pending microtasks after each handler call.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { Request, Response } from 'express'
+import { createWalletController, type WalletService } from './wallet.js'
+import { AppError, ErrorCode } from '../utils/AppError.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+const flushPromises = () => new Promise<void>(resolve => setImmediate(resolve))
+
+function makeService(overrides: Partial<WalletService> = {}): WalletService {
+  return {
+    getUserBalance: vi.fn(),
+    getAccountInfo: vi.fn(),
+    linkStellarAccount: vi.fn(),
+    buildUnsignedTx: vi.fn(),
+    broadcastTransaction: vi.fn(),
+    pollTransactionStatus: vi.fn(),
+    fundTestnetAccount: vi.fn(),
+    getAccountTransactions: vi.fn(),
+    syncStellarAccount: vi.fn(),
+    ...overrides,
+  } as unknown as WalletService
+}
+
+function makeRes() {
+  const res = { status: vi.fn(), json: vi.fn() }
+  res.status.mockReturnValue(res)
+  return res as unknown as Response
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    user: { id: 'user-1', role: 'user', email: 'user@example.com' },
+    params: {},
+    query: {},
+    body: {},
+    ...overrides,
+  } as unknown as Request
+}
+
+// ─── getBalance ───────────────────────────────────────────────────────────────
+describe('walletController.getBalance', () => {
+  it('returns balance data', async () => {
+    const balanceData = { publicKey: 'GAABC123', balance: 500.0, lastSyncedAt: new Date() }
+    const service = makeService({ getUserBalance: vi.fn().mockResolvedValue(balanceData) })
+    const { getBalance } = createWalletController(service)
+    const req = makeReq()
+    const res = makeRes()
+    const next = vi.fn()
+
+    getBalance(req, res, next)
+    await flushPromises()
+
+    expect(service.getUserBalance).toHaveBeenCalledWith('user-1')
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'success', code: 200, data: balanceData }))
+  })
+
+  it('calls next with 401 when not authenticated', async () => {
+    const service = makeService()
+    const { getBalance } = createWalletController(service)
+    const req = makeReq({ user: undefined })
+    const res = makeRes()
+    const next = vi.fn()
+
+    getBalance(req, res, next)
+    await flushPromises()
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }))
+    expect(service.getUserBalance).not.toHaveBeenCalled()
+  })
+})
+
+// ─── getAccountInfo ───────────────────────────────────────────────────────────
+describe('walletController.getAccountInfo', () => {
+  it('returns account info', async () => {
+    const accountData = { publicKey: 'GAABC123', balance: 100.0, sequence: BigInt(12345) }
+    const service = makeService({ getAccountInfo: vi.fn().mockResolvedValue(accountData) })
+    const { getAccountInfo } = createWalletController(service)
+    const req = makeReq({ params: { publicKey: 'GAABC123' } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    getAccountInfo(req, res, next)
+    await flushPromises()
+
+    expect(service.getAccountInfo).toHaveBeenCalledWith('GAABC123')
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'success', code: 200 }))
+  })
+})
+
+// ─── linkWallet ───────────────────────────────────────────────────────────────
+describe('walletController.linkWallet', () => {
+  const validKey = 'G'.padEnd(56, 'A')
+
+  it('returns 201 when wallet is linked', async () => {
+    const account = { publicKey: validKey, userId: 'user-1', balance: 0 }
+    const service = makeService({ linkStellarAccount: vi.fn().mockResolvedValue(account) })
+    const { linkWallet } = createWalletController(service)
+    const req = makeReq({ body: { publicKey: validKey } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    linkWallet(req, res, next)
+    await flushPromises()
+
+    expect(service.linkStellarAccount).toHaveBeenCalledWith('user-1', validKey)
+    expect(res.status).toHaveBeenCalledWith(201)
+  })
+
+  it('calls next with 400 when publicKey is too short', async () => {
+    const service = makeService()
+    const { linkWallet } = createWalletController(service)
+    const req = makeReq({ body: { publicKey: 'SHORT' } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    linkWallet(req, res, next)
+    await flushPromises()
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }))
+  })
+})
+
+// ─── buildTransaction ─────────────────────────────────────────────────────────
+describe('walletController.buildTransaction', () => {
+  it('returns tx params', async () => {
+    const txData = { sourcePublicKey: 'GSOURCE', destinationPublicKey: 'GDEST', amount: '50', sequence: '100' }
+    const service = makeService({ buildUnsignedTx: vi.fn().mockResolvedValue(txData) })
+    const { buildTransaction } = createWalletController(service)
+    const req = makeReq({ body: { sourcePublicKey: 'GSOURCE', destinationPublicKey: 'GDEST', amount: '50' } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    buildTransaction(req, res, next)
+    await flushPromises()
+
+    expect(service.buildUnsignedTx).toHaveBeenCalled()
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'success', code: 200 }))
+  })
+
+  it('calls next with 400 when amount is missing', async () => {
+    const service = makeService()
+    const { buildTransaction } = createWalletController(service)
+    const req = makeReq({ body: { sourcePublicKey: 'GSRC', destinationPublicKey: 'GDEST' } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    buildTransaction(req, res, next)
+    await flushPromises()
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }))
+  })
+})
+
+// ─── broadcastTx ──────────────────────────────────────────────────────────────
+describe('walletController.broadcastTx', () => {
+  it('returns tx hash on success', async () => {
+    const result = { txHash: 'abc123', txId: 'id-456' }
+    const service = makeService({ broadcastTransaction: vi.fn().mockResolvedValue(result) })
+    const { broadcastTx } = createWalletController(service)
+    const req = makeReq({ body: { signedXdr: 'AAAAAA==' } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    broadcastTx(req, res, next)
+    await flushPromises()
+
+    expect(service.broadcastTransaction).toHaveBeenCalledWith('AAAAAA==')
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: result }))
+  })
+
+  it('calls next with 400 when signedXdr is missing', async () => {
+    const service = makeService()
+    const { broadcastTx } = createWalletController(service)
+    const req = makeReq({ body: {} })
+    const res = makeRes()
+    const next = vi.fn()
+
+    broadcastTx(req, res, next)
+    await flushPromises()
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }))
+  })
+})
+
+// ─── getTxStatus ──────────────────────────────────────────────────────────────
+describe('walletController.getTxStatus', () => {
+  it('returns status', async () => {
+    const statusData = { status: 'confirmed', resultCode: 'SUCCESS' }
+    const service = makeService({ pollTransactionStatus: vi.fn().mockResolvedValue(statusData) })
+    const { getTxStatus } = createWalletController(service)
+    const req = makeReq({ params: { txHash: 'abc123' } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    getTxStatus(req, res, next)
+    await flushPromises()
+
+    expect(service.pollTransactionStatus).toHaveBeenCalledWith('abc123')
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: statusData }))
+  })
+})
+
+// ─── fundTestnet ──────────────────────────────────────────────────────────────
+describe('walletController.fundTestnet', () => {
+  it('returns success when funding succeeds', async () => {
+    const fundResult = { txHash: 'fundtxhash', message: 'Account funded successfully' }
+    const service = makeService({ fundTestnetAccount: vi.fn().mockResolvedValue(fundResult) })
+    const { fundTestnet } = createWalletController(service)
+    const req = makeReq({ body: { publicKey: 'GPUBKEY123' } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    fundTestnet(req, res, next)
+    await flushPromises()
+
+    expect(service.fundTestnetAccount).toHaveBeenCalledWith('GPUBKEY123')
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: fundResult }))
+  })
+
+  it('calls next with 400 when publicKey is missing', async () => {
+    const service = makeService()
+    const { fundTestnet } = createWalletController(service)
+    const req = makeReq({ body: {} })
+    const res = makeRes()
+    const next = vi.fn()
+
+    fundTestnet(req, res, next)
+    await flushPromises()
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }))
+  })
+})
+
+// ─── getTransactions ──────────────────────────────────────────────────────────
+describe('walletController.getTransactions', () => {
+  it('returns transaction list', async () => {
+    const txList = [{ hash: 'tx1', created_at: '2026-01-01T00:00:00Z' }]
+    const service = makeService({ getAccountTransactions: vi.fn().mockResolvedValue(txList) })
+    const { getTransactions } = createWalletController(service)
+    const req = makeReq({ params: { publicKey: 'GPUBKEY123' }, query: {} })
+    const res = makeRes()
+    const next = vi.fn()
+
+    getTransactions(req, res, next)
+    await flushPromises()
+
+    expect(service.getAccountTransactions).toHaveBeenCalledWith('GPUBKEY123', 50, 'desc')
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: txList }))
+  })
+
+  it('passes limit and order query params', async () => {
+    const service = makeService({ getAccountTransactions: vi.fn().mockResolvedValue([]) })
+    const { getTransactions } = createWalletController(service)
+    const req = makeReq({ params: { publicKey: 'GPUBKEY123' }, query: { limit: '10', order: 'asc' } })
+    const res = makeRes()
+    const next = vi.fn()
+
+    getTransactions(req, res, next)
+    await flushPromises()
+
+    expect(service.getAccountTransactions).toHaveBeenCalledWith('GPUBKEY123', 10, 'asc')
+  })
+})

--- a/packages/api/src/controllers/wallet.ts
+++ b/packages/api/src/controllers/wallet.ts
@@ -1,176 +1,162 @@
-import { Request, Response } from 'express'
+import type { Request, Response } from 'express'
 import * as walletService from '../services/wallet.service.js'
 import { catchAsync } from '../utils/catchAsync.js'
 import { AppError, ErrorCode } from '../utils/AppError.js'
 import { z } from 'zod'
 
-// Validation schemas
+// ── Validation schemas ────────────────────────────────────────────────────────
+
 const linkWalletSchema = z.object({
   publicKey: z.string().min(56).max(56),
 })
 
-const pollTxSchema = z.object({
-  txHash: z.string(),
+const buildTxSchema = z.object({
+  sourcePublicKey: z.string().min(1),
+  destinationPublicKey: z.string().min(1),
+  amount: z.string().min(1),
+  memo: z.string().optional(),
 })
 
+const broadcastSchema = z.object({
+  signedXdr: z.string().min(1),
+})
+
+const fundTestnetSchema = z.object({
+  publicKey: z.string().min(1),
+})
+
+// ── Service type ──────────────────────────────────────────────────────────────
+
+export type WalletService = typeof walletService
+
 /**
- * GET /api/wallet/balance
- * Get current balance for authenticated user's Stellar account
+ * Builds the wallet route handlers on top of an injected wallet service.
+ * Defaults to the real `wallet.service.js` module so route wiring is
+ * unchanged; tests can pass a stub service to exercise handlers without
+ * hitting the network or the database.
  */
-export const getBalance = catchAsync(async (req: Request, res: Response) => {
-  const userId = req.user?.id
-  if (!userId) {
-    throw new AppError('Unauthorized', 401, true, ErrorCode.UNAUTHORIZED)
+export function createWalletController(service: WalletService = walletService) {
+  return {
+    /**
+     * GET /api/wallet/balance
+     * Get cached balance for the authenticated user's Stellar account.
+     */
+    getBalance: catchAsync(async (req: Request, res: Response) => {
+      const userId = req.user?.id
+      if (!userId) {
+        throw new AppError('Unauthorized', 401, true, ErrorCode.UNAUTHORIZED)
+      }
+      const data = await service.getUserBalance(userId)
+      res.json({ status: 'success', code: 200, data })
+    }),
+
+    /**
+     * GET /api/wallet/account/:publicKey
+     * Get account info (balance, sequence) from Horizon.
+     */
+    getAccountInfo: catchAsync(async (req: Request, res: Response) => {
+      const { publicKey } = req.params
+      const data = await service.getAccountInfo(publicKey)
+      res.json({ status: 'success', code: 200, data })
+    }),
+
+    /**
+     * POST /api/wallet/link
+     * Link a Stellar wallet to the authenticated user.
+     */
+    linkWallet: catchAsync(async (req: Request, res: Response) => {
+      const userId = req.user?.id
+      if (!userId) {
+        throw new AppError('Unauthorized', 401, true, ErrorCode.UNAUTHORIZED)
+      }
+      const parsed = linkWalletSchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new AppError('Invalid public key', 400, true, ErrorCode.VALIDATION_ERROR)
+      }
+      const account = await service.linkStellarAccount(userId, parsed.data.publicKey)
+      res.status(201).json({
+        status: 'success',
+        code: 201,
+        message: 'Wallet linked successfully',
+        data: account,
+      })
+    }),
+
+    /**
+     * POST /api/wallet/build-tx
+     * Build an unsigned transaction XDR for tip/escrow.
+     */
+    buildTransaction: catchAsync(async (req: Request, res: Response) => {
+      const parsed = buildTxSchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new AppError('Missing required fields', 400, true, ErrorCode.VALIDATION_ERROR)
+      }
+      const { sourcePublicKey, destinationPublicKey, amount, memo } = parsed.data
+      const tx = await service.buildUnsignedTx(sourcePublicKey, destinationPublicKey, amount, memo)
+      res.json({ status: 'success', code: 200, data: tx })
+    }),
+
+    /**
+     * POST /api/wallet/broadcast
+     * Broadcast a signed transaction to the Stellar network.
+     */
+    broadcastTx: catchAsync(async (req: Request, res: Response) => {
+      const parsed = broadcastSchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new AppError('signedXdr is required', 400, true, ErrorCode.VALIDATION_ERROR)
+      }
+      const result = await service.broadcastTransaction(parsed.data.signedXdr)
+      res.json({ status: 'success', code: 200, data: result })
+    }),
+
+    /**
+     * GET /api/wallet/tx-status/:txHash
+     * Poll transaction status from Horizon.
+     */
+    getTxStatus: catchAsync(async (req: Request, res: Response) => {
+      const { txHash } = req.params
+      const status = await service.pollTransactionStatus(txHash)
+      res.json({ status: 'success', code: 200, data: status })
+    }),
+
+    /**
+     * POST /api/wallet/testnet-fund
+     * Fund a testnet account via friendbot.
+     */
+    fundTestnet: catchAsync(async (req: Request, res: Response) => {
+      const parsed = fundTestnetSchema.safeParse(req.body)
+      if (!parsed.success) {
+        throw new AppError('publicKey is required', 400, true, ErrorCode.VALIDATION_ERROR)
+      }
+      const result = await service.fundTestnetAccount(parsed.data.publicKey)
+      res.json({ status: 'success', code: 200, data: result })
+    }),
+
+    /**
+     * GET /api/wallet/transactions/:publicKey
+     * Get account transaction history from Horizon.
+     */
+    getTransactions: catchAsync(async (req: Request, res: Response) => {
+      const { publicKey } = req.params
+      const limit = parseInt((req.query.limit as string) || '50', 10)
+      const order = ((req.query.order as string) || 'desc') as 'asc' | 'desc'
+      const transactions = await service.getAccountTransactions(publicKey, limit, order)
+      res.json({ status: 'success', code: 200, data: transactions })
+    }),
   }
+}
 
-  const data = await walletService.getUserBalance(userId)
+// ── Default singleton (keeps existing route wiring intact) ────────────────────
 
-  res.json({
-    status: 'success',
-    code: 200,
-    data,
-  })
-})
+const defaultWalletController = createWalletController()
 
-/**
- * GET /api/wallet/account/:publicKey
- * Get account info (balance, sequence) from Horizon
- */
-export const getAccountInfo = catchAsync(async (req: Request, res: Response) => {
-  const { publicKey } = req.params
-
-  const data = await walletService.getAccountInfo(publicKey)
-
-  res.json({
-    status: 'success',
-    code: 200,
-    data,
-  })
-})
-
-/**
- * POST /api/wallet/link
- * Link a Stellar wallet to the authenticated user
- */
-export const linkWallet = catchAsync(async (req: Request, res: Response) => {
-  const userId = req.user?.id
-  if (!userId) {
-    throw new AppError('Unauthorized', 401, true, ErrorCode.UNAUTHORIZED)
-  }
-
-  const parsed = linkWalletSchema.safeParse(req.body)
-  if (!parsed.success) {
-    throw new AppError('Invalid public key', 400, true, ErrorCode.VALIDATION_ERROR)
-  }
-
-  const account = await walletService.linkStellarAccount(userId, parsed.data.publicKey)
-
-  res.status(201).json({
-    status: 'success',
-    code: 201,
-    message: 'Wallet linked successfully',
-    data: account,
-  })
-})
-
-/**
- * POST /api/wallet/build-tx
- * Build unsigned transaction for tip/escrow
- */
-export const buildTransaction = catchAsync(async (req: Request, res: Response) => {
-  const { sourcePublicKey, destinationPublicKey, amount, memo } = req.body
-
-  if (!sourcePublicKey || !destinationPublicKey || !amount) {
-    throw new AppError('Missing required fields', 400, true, ErrorCode.VALIDATION_ERROR)
-  }
-
-  const tx = await walletService.buildUnsignedTx(
-    sourcePublicKey,
-    destinationPublicKey,
-    amount,
-    memo,
-  )
-
-  res.json({
-    status: 'success',
-    code: 200,
-    data: tx,
-  })
-})
-
-/**
- * POST /api/wallet/broadcast
- * Broadcast a signed transaction to Stellar network
- */
-export const broadcastTx = catchAsync(async (req: Request, res: Response) => {
-  const { signedXdr } = req.body
-
-  if (!signedXdr) {
-    throw new AppError('signedXdr is required', 400, true, ErrorCode.VALIDATION_ERROR)
-  }
-
-  const result = await walletService.broadcastTransaction(signedXdr)
-
-  res.json({
-    status: 'success',
-    code: 200,
-    data: result,
-  })
-})
-
-/**
- * GET /api/wallet/tx-status/:txHash
- * Poll transaction status
- */
-export const getTxStatus = catchAsync(async (req: Request, res: Response) => {
-  const { txHash } = req.params
-
-  const status = await walletService.pollTransactionStatus(txHash)
-
-  res.json({
-    status: 'success',
-    code: 200,
-    data: status,
-  })
-})
-
-/**
- * POST /api/wallet/testnet-fund
- * Fund testnet account via friendbot
- */
-export const fundTestnet = catchAsync(async (req: Request, res: Response) => {
-  const { publicKey } = req.body
-
-  if (!publicKey) {
-    throw new AppError('publicKey is required', 400, true, ErrorCode.VALIDATION_ERROR)
-  }
-
-  const result = await walletService.fundTestnetAccount(publicKey)
-
-  res.json({
-    status: 'success',
-    code: 200,
-    data: result,
-  })
-})
-
-/**
- * GET /api/wallet/transactions/:publicKey
- * Get account transactions from Horizon
- */
-export const getTransactions = catchAsync(async (req: Request, res: Response) => {
-  const { publicKey } = req.params
-  const { limit = '50', order = 'desc' } = req.query
-
-  const transactions = await walletService.getAccountTransactions(
-    publicKey,
-    parseInt(limit as string),
-    (order as 'asc' | 'desc') || 'desc',
-  )
-
-  res.json({
-    status: 'success',
-    code: 200,
-    data: transactions,
-  })
-})
+export const {
+  getBalance,
+  getAccountInfo,
+  linkWallet,
+  buildTransaction,
+  broadcastTx,
+  getTxStatus,
+  fundTestnet,
+  getTransactions,
+} = defaultWalletController


### PR DESCRIPTION
## Summary
closes #1001 
closes #1002 
closes #1003 
closes #1004 
Implements four GitHub issues:

### #1001 — Integration tests for search endpoints
- `GET /api/workers/search` — full-text search with all filters (q, lat/lng/radius, categories, rating, isVerified, sortBy, pagination)
- `GET /api/workers/search/advanced` — advanced search with time window and geo filters
- Public access tests (no auth required) and auth edge cases
- 30+ test cases

### #1002 — Integration tests for jobs endpoints
- Full CRUD: list, show, create, update, delete
- Job renewal (`POST /api/jobs/:id/renew`)
- My posted jobs + my applications
- Applications: apply, list, update status, withdraw
- Messaging: send message, list messages
- Auth (401), authorization (403), and validation (400) failure cases for every endpoint
- 50+ test cases

### #1003 — Integration tests for contracts endpoints
- **Escrow** (`/api/escrow`): list, get, create, activate, release, cancel
- **Escrow disputes**: file (`POST /api/escrow/:id/disputes`), resolve (admin only)
- **Worker disputes** (`/api/disputes`): create, list, get, resolve (admin only)
- 401/403 auth guards verified on every route; admin-only endpoints return 403 for plain users
- Validation (400) failure cases
- 35+ test cases

### #1004 — Refactor wallet controller to use service layer + unit tests
- Introduced `createWalletController(service)` DI factory (matches the jobs controller pattern)
- Replaced ad-hoc inline validation with Zod schemas (consistent with rest of codebase)
- Named exports preserved — **zero breaking changes** to route wiring
- 14 focused unit tests covering every handler, validation path, and error scenario

## Testing

All new tests use the existing mock-based integration test pattern (no live DB required):

```
pnpm vitest run src/controllers/wallet.test.ts       # 14 tests pass
pnpm vitest run src/__tests__/integration/search*    # runs in CI
pnpm vitest run src/__tests__/integration/jobs*
pnpm vitest run src/__tests__/integration/contracts*
```

## Closes
- Fixes #1001
- Fixes #1002
- Fixes #1003
- Fixes #1004