### PR TITLE
feat(api): refactor payments/auth/jobs — service layer, DI, error handling

### DIFF
--- a/packages/api/src/__tests__/auth.test.ts
+++ b/packages/api/src/__tests__/auth.test.ts
@@ -1,6 +1,12 @@
 /**
  * Unit tests for the auth controller (src/controllers/auth.ts).
+ *
  * All external dependencies (auth service, db, nodemailer) are mocked.
+ *
+ * Error-handling contract: handlers now use `catchAsync`, so errors are
+ * forwarded to `next(err)` rather than handled inline.  Error-case tests
+ * assert that `next` was called with an AppError carrying the expected
+ * status code and message.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -17,6 +23,9 @@ vi.mock("../services/auth.service.js", () => ({
   requestPasswordReset: vi.fn(),
   resetPassword: vi.fn(),
   verifyAccount: vi.fn(),
+  revokeAllRefreshTokens: vi.fn(),
+  rotateRefreshToken: vi.fn(),
+  resendVerificationEmail: vi.fn(),
 }));
 
 vi.mock("../db.js", () => ({
@@ -24,6 +33,7 @@ vi.mock("../db.js", () => ({
     user: { findUnique: vi.fn() },
   },
 }));
+
 vi.mock("../config/env.js", () => ({
   env: {
     DATABASE_URL: "postgresql://localhost:5432/test",
@@ -56,8 +66,11 @@ import {
   logout,
   forgotPassword,
   resetPassword,
+  refresh,
+  me,
+  resendVerification,
 } from "../controllers/auth.js";
-import { AppError } from "../services/AppError.js";
+import { AppError } from "../utils/AppError.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -69,8 +82,19 @@ function makeRes() {
   return res;
 }
 
-function makeReq(body: Record<string, any> = {}, user?: any): any {
-  return { body, user };
+function makeReq(body: Record<string, any> = {}, user?: any, query: Record<string, any> = {}): any {
+  return { body, user, query, get: () => undefined };
+}
+
+/** Call a catchAsync handler and capture what was passed to next. */
+async function callHandler(
+  handler: (req: any, res: any, next: any) => any,
+  req: any,
+  res: any,
+): Promise<{ nextError: unknown }> {
+  let nextError: unknown = undefined;
+  await handler(req, res, (err: unknown) => { nextError = err });
+  return { nextError };
 }
 
 const mockUser = {
@@ -91,6 +115,7 @@ const mockUser = {
   resetTokenExpiry: null,
   verificationToken: null,
   verificationTokenExpiry: null,
+  unsubscribedReminders: false,
   createdAt: new Date(),
   updatedAt: new Date(),
 };
@@ -102,16 +127,12 @@ describe("register", () => {
 
   it("returns 201 with user data on success", async () => {
     (authService.registerUser as any).mockResolvedValue(mockUser);
-    const req = makeReq({
-      email: "alice@example.com",
-      password: "secret",
-      firstName: "Alice",
-      lastName: "Smith",
-    });
+    const req = makeReq({ email: "alice@example.com", password: "secret", firstName: "Alice", lastName: "Smith" });
     const res = makeRes();
 
-    await register(req, res);
+    const { nextError } = await callHandler(register, req, res);
 
+    expect(nextError).toBeUndefined();
     expect(res.status).toHaveBeenCalledWith(201);
     const body = res.json.mock.calls[0][0];
     expect(body.status).toBe("success");
@@ -120,43 +141,31 @@ describe("register", () => {
     expect(body.data).toBeDefined();
   });
 
-  it("returns 409 when the email is already registered", async () => {
+  it("forwards AppError 409 when the email is already registered", async () => {
     (authService.registerUser as any).mockRejectedValue(
       new AppError("Email already in use", 409),
     );
-    const req = makeReq({
-      email: "alice@example.com",
-      password: "secret",
-      firstName: "Alice",
-      lastName: "Smith",
-    });
+    const req = makeReq({ email: "alice@example.com", password: "secret", firstName: "Alice", lastName: "Smith" });
     const res = makeRes();
 
-    await register(req, res);
+    const { nextError } = await callHandler(register, req, res);
 
-    expect(res.status).toHaveBeenCalledWith(409);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "error",
-        message: "Email already in use",
-        code: 409,
-      }),
-    );
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(409);
+    expect((nextError as AppError).message).toBe("Email already in use");
   });
 
-  it("returns 422 when required fields are missing", async () => {
+  it("forwards AppError 422 when required fields are missing", async () => {
     (authService.registerUser as any).mockRejectedValue(
       new AppError("Validation failed", 422),
     );
     const req = makeReq({});
     const res = makeRes();
 
-    await register(req, res);
+    const { nextError } = await callHandler(register, req, res);
 
-    expect(res.status).toHaveBeenCalledWith(422);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ status: "error", code: 422 }),
-    );
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(422);
   });
 });
 
@@ -169,12 +178,15 @@ describe("login", () => {
     (authService.loginUser as any).mockResolvedValue({
       data: mockUser,
       token: "signed-jwt",
+      refreshToken: "refresh-token",
+      deviceId: "device-1",
     });
     const req = makeReq({ email: "alice@example.com", password: "secret" });
     const res = makeRes();
 
-    await login(req, res);
+    const { nextError } = await callHandler(login, req, res);
 
+    expect(nextError).toBeUndefined();
     expect(res.status).toHaveBeenCalledWith(202);
     const body = res.json.mock.calls[0][0];
     expect(body.status).toBe("success");
@@ -182,37 +194,33 @@ describe("login", () => {
     expect(body.code).toBe(202);
   });
 
-  it("returns 401 for a wrong password", async () => {
+  it("forwards AppError 401 for wrong password", async () => {
     (authService.loginUser as any).mockRejectedValue(
       new AppError("Invalid credentials", 401),
     );
-    const req = makeReq({
-      email: "alice@example.com",
-      password: "wrong-password",
-    });
+    const req = makeReq({ email: "alice@example.com", password: "wrong-password" });
     const res = makeRes();
 
-    await login(req, res);
+    const { nextError } = await callHandler(login, req, res);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ status: "error", code: 401 }),
-    );
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(401);
   });
 
-  it("returns 401 for a non-existent user", async () => {
+  it("forwards AppError 401 for non-existent user", async () => {
     (authService.loginUser as any).mockRejectedValue(
       new AppError("Invalid credentials", 401),
     );
     const req = makeReq({ email: "ghost@example.com", password: "secret" });
     const res = makeRes();
 
-    await login(req, res);
+    const { nextError } = await callHandler(login, req, res);
 
-    expect(res.status).toHaveBeenCalledWith(401);
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(401);
   });
 
-  it("returns 403 for an unverified account", async () => {
+  it("forwards AppError 403 for unverified account", async () => {
     (authService.loginUser as any).mockRejectedValue(
       new AppError(
         "Your email address has not been verified. Please check your inbox and click the verification link.",
@@ -222,12 +230,10 @@ describe("login", () => {
     const req = makeReq({ email: "alice@example.com", password: "secret" });
     const res = makeRes();
 
-    await login(req, res);
+    const { nextError } = await callHandler(login, req, res);
 
-    expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ status: "error", code: 403 }),
-    );
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(403);
   });
 });
 
@@ -237,27 +243,26 @@ describe("logout", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("returns 200 with a success message for an authenticated user", async () => {
+    (authService.revokeAllRefreshTokens as any).mockResolvedValue(undefined);
     const req = makeReq({}, { id: "user-1", role: "user" });
     const res = makeRes();
 
-    await logout(req, res);
+    const { nextError } = await callHandler(logout, req, res);
 
+    expect(nextError).toBeUndefined();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "success",
-        message: "Logged out",
-        code: 200,
-      }),
+      expect.objectContaining({ status: "success", message: "Logged out", code: 200 }),
     );
   });
 
-  it("returns 200 even without an authenticated user (auth enforced by middleware, not controller)", async () => {
+  it("returns 200 even without an authenticated user (auth enforced by middleware)", async () => {
     const req = makeReq();
     const res = makeRes();
 
-    await logout(req, res);
+    const { nextError } = await callHandler(logout, req, res);
 
+    expect(nextError).toBeUndefined();
     expect(res.status).toHaveBeenCalledWith(200);
   });
 });
@@ -272,26 +277,24 @@ describe("forgotPassword", () => {
     const req = makeReq({ email: "ghost@example.com" });
     const res = makeRes();
 
-    await forgotPassword(req, res);
+    const { nextError } = await callHandler(forgotPassword, req, res);
 
+    expect(nextError).toBeUndefined();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ status: "success", code: 200 }),
     );
   });
 
-  it("calls requestPasswordReset with the provided email when user exists", async () => {
+  it("calls requestPasswordReset with the provided email", async () => {
     (authService.requestPasswordReset as any).mockResolvedValue(undefined);
     const req = makeReq({ email: "alice@example.com" });
     const res = makeRes();
 
-    await forgotPassword(req, res);
+    await callHandler(forgotPassword, req, res);
 
     expect(authService.requestPasswordReset).toHaveBeenCalledOnce();
-    expect(authService.requestPasswordReset).toHaveBeenCalledWith(
-      "alice@example.com",
-    );
-    expect(res.status).toHaveBeenCalledWith(200);
+    expect(authService.requestPasswordReset).toHaveBeenCalledWith("alice@example.com");
   });
 });
 
@@ -302,54 +305,135 @@ describe("resetPassword", () => {
 
   it("returns 200 on a successful password reset", async () => {
     (authService.resetPassword as any).mockResolvedValue(undefined);
-    const req = makeReq({
-      token: "valid-reset-token",
-      password: "new-secure-password",
-    });
+    const req = makeReq({ token: "valid-reset-token", password: "new-secure-password" });
     const res = makeRes();
 
-    await resetPassword(req, res);
+    const { nextError } = await callHandler(resetPassword, req, res);
 
+    expect(nextError).toBeUndefined();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "success",
-        message: "Password reset successful",
-        code: 200,
-      }),
+      expect.objectContaining({ status: "success", message: "Password reset successful", code: 200 }),
     );
   });
 
-  it("returns 400 for an expired reset token", async () => {
-    (authService.resetPassword as any).mockRejectedValue(
-      new AppError("Token is invalid or has expired", 400),
-    );
-    const req = makeReq({
-      token: "expired-token",
-      password: "new-secure-password",
-    });
+  it("forwards AppError 400 when token and password are missing", async () => {
+    const req = makeReq({});
     const res = makeRes();
 
-    await resetPassword(req, res);
+    const { nextError } = await callHandler(resetPassword, req, res);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ status: "error", code: 400 }),
-    );
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(400);
+    expect((nextError as AppError).message).toBe("Token and password are required");
   });
 
-  it("returns 400 for an invalid reset token", async () => {
+  it("forwards AppError 400 for an expired reset token", async () => {
     (authService.resetPassword as any).mockRejectedValue(
       new AppError("Token is invalid or has expired", 400),
     );
-    const req = makeReq({
-      token: "tampered-token",
-      password: "new-secure-password",
-    });
+    const req = makeReq({ token: "expired-token", password: "new-secure-password" });
     const res = makeRes();
 
-    await resetPassword(req, res);
+    const { nextError } = await callHandler(resetPassword, req, res);
 
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(400);
+  });
+
+  it("forwards AppError 400 for an invalid reset token", async () => {
+    (authService.resetPassword as any).mockRejectedValue(
+      new AppError("Token is invalid or has expired", 400),
+    );
+    const req = makeReq({ token: "tampered-token", password: "new-secure-password" });
+    const res = makeRes();
+
+    const { nextError } = await callHandler(resetPassword, req, res);
+
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(400);
+  });
+});
+
+// ─── refresh ─────────────────────────────────────────────────────────────────
+
+describe("refresh", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 200 with new tokens on success", async () => {
+    (authService.rotateRefreshToken as any).mockResolvedValue({
+      token: "new-access-token",
+      refreshToken: "new-refresh-token",
+    });
+    const req = makeReq({ refreshToken: "old-refresh-token" });
+    const res = makeRes();
+
+    const { nextError } = await callHandler(refresh, req, res);
+
+    expect(nextError).toBeUndefined();
+    const body = res.json.mock.calls[0][0];
+    expect(body.status).toBe("success");
+    expect(body.token).toBe("new-access-token");
+  });
+
+  it("forwards AppError 400 when refreshToken is missing", async () => {
+    const req = makeReq({});
+    const res = makeRes();
+
+    const { nextError } = await callHandler(refresh, req, res);
+
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(400);
+    expect((nextError as AppError).message).toBe("refreshToken is required");
+  });
+});
+
+// ─── me ───────────────────────────────────────────────────────────────────────
+
+describe("me", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 200 with user data when user exists", async () => {
+    (db.user.findUnique as any).mockResolvedValue(mockUser);
+    const req = makeReq({}, { id: "user-1", role: "user" });
+    const res = makeRes();
+
+    const { nextError } = await callHandler(me, req, res);
+
+    expect(nextError).toBeUndefined();
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.status).toBe("success");
+  });
+
+  it("forwards AppError 404 when user no longer exists", async () => {
+    (db.user.findUnique as any).mockResolvedValue(null);
+    const req = makeReq({}, { id: "deleted-user", role: "user" });
+    const res = makeRes();
+
+    const { nextError } = await callHandler(me, req, res);
+
+    expect(nextError).toBeInstanceOf(AppError);
+    expect((nextError as AppError).statusCode).toBe(404);
+    expect((nextError as AppError).message).toBe("User not found");
+  });
+});
+
+// ─── resendVerification ───────────────────────────────────────────────────────
+
+describe("resendVerification", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("always returns 200 to avoid enumeration", async () => {
+    (authService.resendVerificationEmail as any).mockResolvedValue(undefined);
+    const req = makeReq({ email: "alice@example.com" });
+    const res = makeRes();
+
+    const { nextError } = await callHandler(resendVerification, req, res);
+
+    expect(nextError).toBeUndefined();
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.status).toBe("success");
   });
 });

--- a/packages/api/src/__tests__/unit/payment.controller.test.ts
+++ b/packages/api/src/__tests__/unit/payment.controller.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for the payment controller (src/controllers/payment.ts).
+ * Uses dependency injection to pass in a fake PaymentService, so no real
+ * business logic or contracts service is involved.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Request, Response } from 'express'
+import { createPaymentController } from '../../../controllers/payment.js'
+import { PaymentService } from '../../../services/payment.service.js'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRes() {
+  const res: any = {}
+  res.status = (code: number) => {
+    res.statusCode = code
+    return res
+  }
+  res.json = (body: any) => {
+    res.body = body
+    return res
+  }
+  return res
+}
+
+function makeReq(body: Record<string, any> = {}, user?: any): Request {
+  return { body, user } as Request
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Payment Controller (DI)', () => {
+  let service: PaymentService
+  let controller: ReturnType<typeof createPaymentController>
+
+  beforeEach(() => {
+    service = new PaymentService(250)
+    controller = createPaymentController(service)
+  })
+
+  // ── processTip ──────────────────────────────────────────────────────────────
+
+  describe('processTip', () => {
+    it('returns 200 with tip breakdown on success', async () => {
+      const req = makeReq({ from: 'ALICE', to: 'BOB', amount: 10_000_000 })
+      const res = makeRes()
+
+      await controller.processTip(req, res, () => {})
+
+      expect(res.statusCode).toBe(200)
+      expect(res.body.status).toBe('success')
+      expect(res.body.data.grossAmount).toBe(10_000_000)
+      expect(res.body.data.fee).toBe(250_000)
+      expect(res.body.data.netAmount).toBe(9_750_000)
+    })
+
+    it('throws 400 when "from" is missing', async () => {
+      const req = makeReq({ to: 'BOB', amount: 1_000_000 })
+      const res = makeRes()
+
+      await expect(controller.processTip(req, res, () => {})).rejects.toThrow('from, to, and amount are required')
+    })
+
+    it('throws 400 when "to" is missing', async () => {
+      const req = makeReq({ from: 'ALICE', amount: 1_000_000 })
+      const res = makeRes()
+
+      await expect(controller.processTip(req, res, () => {})).rejects.toThrow('from, to, and amount are required')
+    })
+
+    it('throws 400 when "amount" is missing', async () => {
+      const req = makeReq({ from: 'ALICE', to: 'BOB' })
+      const res = makeRes()
+
+      await expect(controller.processTip(req, res, () => {})).rejects.toThrow('from, to, and amount are required')
+    })
+
+    it('throws AppError when sender equals recipient', async () => {
+      const req = makeReq({ from: 'ALICE', to: 'ALICE', amount: 100 })
+      const res = makeRes()
+
+      await expect(controller.processTip(req, res, () => {})).rejects.toThrow('Sender and recipient must be different')
+    })
+  })
+
+  // ── createEscrow ────────────────────────────────────────────────────────────
+
+  describe('createEscrow', () => {
+    const futureDate = new Date(Date.now() + 86_400_000).toISOString()
+
+    it('returns 201 with escrow on success', async () => {
+      const req = makeReq({ from: 'A', to: 'B', amount: 1_000, expiryDate: futureDate })
+      const res = makeRes()
+
+      await controller.createEscrow(req, res, () => {})
+
+      expect(res.statusCode).toBe(201)
+      expect(res.body.status).toBe('success')
+      expect(res.body.data.amount).toBe(1_000)
+      expect(res.body.data.status).toBe('pending')
+    })
+
+    it('throws 400 when "from" is missing', async () => {
+      const req = makeReq({ to: 'B', amount: 1_000, expiryDate: futureDate })
+      const res = makeRes()
+
+      await expect(controller.createEscrow(req, res, () => {})).rejects.toThrow(
+        'from, to, amount, and expiryDate are required'
+      )
+    })
+
+    it('throws 400 when "to" is missing', async () => {
+      const req = makeReq({ from: 'A', amount: 1_000, expiryDate: futureDate })
+      const res = makeRes()
+
+      await expect(controller.createEscrow(req, res, () => {})).rejects.toThrow(
+        'from, to, amount, and expiryDate are required'
+      )
+    })
+
+    it('throws 400 when "amount" is missing', async () => {
+      const req = makeReq({ from: 'A', to: 'B', expiryDate: futureDate })
+      const res = makeRes()
+
+      await expect(controller.createEscrow(req, res, () => {})).rejects.toThrow(
+        'from, to, amount, and expiryDate are required'
+      )
+    })
+
+    it('throws 400 when "expiryDate" is missing', async () => {
+      const req = makeReq({ from: 'A', to: 'B', amount: 1_000 })
+      const res = makeRes()
+
+      await expect(controller.createEscrow(req, res, () => {})).rejects.toThrow(
+        'from, to, amount, and expiryDate are required'
+      )
+    })
+
+    it('throws when expiry is in the past', async () => {
+      const pastDate = new Date(Date.now() - 1_000).toISOString()
+      const req = makeReq({ from: 'A', to: 'B', amount: 100, expiryDate: pastDate })
+      const res = makeRes()
+
+      await expect(controller.createEscrow(req, res, () => {})).rejects.toThrow('Escrow expiry must be in the future')
+    })
+  })
+
+  // ── getFee ──────────────────────────────────────────────────────────────────
+
+  describe('getFee', () => {
+    it('returns 200 with current fee in basis points', () => {
+      const req = makeReq()
+      const res = makeRes()
+
+      controller.getFee(req, res, () => {})
+
+      expect(res.statusCode).toBe(200)
+      expect(res.body.status).toBe('success')
+      expect(res.body.data.fee_bps).toBe(250)
+    })
+  })
+
+  // ── updateFee ───────────────────────────────────────────────────────────────
+
+  describe('updateFee', () => {
+    it('returns 200 with updated fee when admin', async () => {
+      const req = makeReq({ fee_bps: 100 }, { id: 'admin-1', role: 'admin' })
+      const res = makeRes()
+
+      await controller.updateFee(req, res, () => {})
+
+      expect(res.statusCode).toBe(200)
+      expect(res.body.status).toBe('success')
+      expect(res.body.data.fee_bps).toBe(100)
+    })
+
+    it('throws 400 when fee_bps is missing', async () => {
+      const req = makeReq({}, { id: 'admin-1', role: 'admin' })
+      const res = makeRes()
+
+      await expect(controller.updateFee(req, res, () => {})).rejects.toThrow('fee_bps is required')
+    })
+
+    it('throws 403 when user is not admin', async () => {
+      const req = makeReq({ fee_bps: 100 }, { id: 'user-1', role: 'user' })
+      const res = makeRes()
+
+      await expect(controller.updateFee(req, res, () => {})).rejects.toThrow('Only admins can update the fee')
+    })
+
+    it('throws 400 when fee_bps is out of range', async () => {
+      const req = makeReq({ fee_bps: 10_001 }, { id: 'admin-1', role: 'admin' })
+      const res = makeRes()
+
+      await expect(controller.updateFee(req, res, () => {})).rejects.toThrow('fee_bps must be between 0 and 10000')
+    })
+  })
+})

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -1,394 +1,243 @@
-import type { Request, Response } from "express";
-import jwt from "jsonwebtoken";
-import { env } from "../config/env.js";
-import * as authService from "../services/auth.service.js";
-import { handleError } from "../utils/handleError.js";
-import { db } from "../db.js";
-import { sanitizeUser } from "../models/user.model.js";
-import { UserResource } from "../resources/index.js";
-import { AppError } from "../services/AppError.js";
-import { catchAsync } from "../utils/catchAsync.js";
-import type { Request, Response } from "express";
+/**
+ * Auth controller — thin HTTP layer for authentication endpoints.
+ *
+ * Error-handling convention: every handler either uses `catchAsync` (so
+ * thrown `AppError` instances propagate to the global `errorHandler`
+ * middleware) or throws `AppError` directly inside a `catchAsync` wrapper.
+ * No handler calls `handleError(res, err)` directly; all errors flow through
+ * the central error handler so every error response is guaranteed to include
+ * `{ status, message, code, errorCode, traceId }`.
+ *
+ * Removed (deprecated legacy endpoints — see #1012):
+ *   - enrollTwoFactor  (superseded by twoFactor.ts → POST /2fa/setup)
+ *   - verifyTwoFactor  (superseded by twoFactor.ts → POST /2fa/verify)
+ *   - disableTwoFactor (superseded by twoFactor.ts → DELETE /2fa)
+ *   - listDevices      (moved to devices.ts controller)
+ *   - revokeDevice     (moved to devices.ts controller)
+ *   - revokeAllOtherDevices (moved to devices.ts controller)
+ *
+ * These functions were never wired into routes/auth.ts; routes/auth.ts
+ * imports 2FA handlers from controllers/twoFactor.ts and device handlers
+ * from routes/devices.ts.
+ */
+import type { Request, Response } from 'express'
+import jwt from 'jsonwebtoken'
+import { env } from '../config/env.js'
+import * as authService from '../services/auth.service.js'
+import { db } from '../db.js'
+import { sanitizeUser } from '../models/user.model.js'
+import { UserResource } from '../resources/index.js'
+import { AppError, ErrorCode } from '../utils/AppError.js'
+import { catchAsync } from '../utils/catchAsync.js'
+import { ErrorMessages } from '../constants/errors.js'
 import type {
   LoginBody,
   RegisterBody,
   ForgotPasswordBody,
   ResetPasswordBody,
-} from "../interfaces/index.js";
+} from '../interfaces/index.js'
 
 /**
  * POST /api/auth/login
  * Authenticate a user with email and password.
  *
- * @param req - Body: `{ email, password }`.
- * @param res - JSON `{ data: User, token, status, code: 202 }`.
  * @throws AppError 401 if credentials are invalid.
  * @throws AppError 403 if the account is not yet verified.
  */
-export async function login(req: Request<{}, {}, LoginBody>, res: Response) {
-  try {
-    const userAgent = req.get('user-agent')
-    const ipAddress = (req.get('x-forwarded-for') || req.ip || '').split(',')[0].trim()
-    
-    // Parse device name from user agent (basic heuristic)
-    let deviceName = 'Unknown Device'
-    if (userAgent) {
-      if (userAgent.includes('Chrome')) deviceName = 'Chrome'
-      else if (userAgent.includes('Firefox')) deviceName = 'Firefox'
-      else if (userAgent.includes('Safari')) deviceName = 'Safari'
-      else if (userAgent.includes('Mobile')) deviceName = 'Mobile'
-      
-      if (userAgent.includes('Windows')) deviceName += ' on Windows'
-      else if (userAgent.includes('Macintosh')) deviceName += ' on Mac'
-      else if (userAgent.includes('Linux')) deviceName += ' on Linux'
-    }
+export const login = catchAsync(async (req: Request<{}, {}, LoginBody>, res: Response) => {
+  const userAgent = req.get('user-agent')
+  const ipAddress = (req.get('x-forwarded-for') || req.ip || '').split(',')[0].trim()
 
-    const { data, token, refreshToken, deviceId } = await authService.loginUser(
-      req.body,
-      deviceName,
-      userAgent,
-      ipAddress,
-    )
-    return res.status(202).json({
-      data: UserResource(data as any),
-      status: "success",
-      message: "Login successful",
-      code: 202,
-      token,
-      refreshToken,
-      deviceId,
-    })
-  } catch (err) {
-    return handleError(res, err)
+  // Parse device name from user agent (basic heuristic)
+  let deviceName = 'Unknown Device'
+  if (userAgent) {
+    if (userAgent.includes('Chrome')) deviceName = 'Chrome'
+    else if (userAgent.includes('Firefox')) deviceName = 'Firefox'
+    else if (userAgent.includes('Safari')) deviceName = 'Safari'
+    else if (userAgent.includes('Mobile')) deviceName = 'Mobile'
+
+    if (userAgent.includes('Windows')) deviceName += ' on Windows'
+    else if (userAgent.includes('Macintosh')) deviceName += ' on Mac'
+    else if (userAgent.includes('Linux')) deviceName += ' on Linux'
   }
-}
+
+  const { data, token, refreshToken, deviceId } = await authService.loginUser(
+    req.body,
+    deviceName,
+    userAgent,
+    ipAddress,
+  )
+  return res.status(202).json({
+    data: UserResource(data as any),
+    status: 'success',
+    message: 'Login successful',
+    code: 202,
+    token,
+    refreshToken,
+    deviceId,
+  })
+})
 
 /**
  * POST /api/auth/register
  * Create a new user account and send a verification email.
  *
- * @param req - Body: `{ email, password, firstName, lastName }`.
- * @param res - JSON `{ data: User, status, code: 201 }`.
  * @throws AppError 409 if the email is already in use.
  */
-export async function register(
-  req: Request<{}, {}, RegisterBody>,
-  res: Response,
-) {
-  try {
-    const data = await authService.registerUser(req.body);
-    return res.status(201).json({
-      data: UserResource(data as any),
-      status: "success",
-      message:
-        "Registration successful. Please check your email to verify your account.",
-      code: 201,
-    });
-  } catch (err) {
-    return handleError(res, err);
-  }
-}
+export const register = catchAsync(async (req: Request<{}, {}, RegisterBody>, res: Response) => {
+  const data = await authService.registerUser(req.body)
+  return res.status(201).json({
+    data: UserResource(data as any),
+    status: 'success',
+    message: 'Registration successful. Please check your email to verify your account.',
+    code: 201,
+  })
+})
 
 /**
  * PUT /api/auth/verify-account
  * Verify a user's email address using the token sent in the verification email.
  *
- * @param req - Query param or body field `token`.
- * @param res - JSON `{ status, message, code: 200 }`.
  * @throws AppError 400 if the token is missing, invalid, or expired.
  */
 export const verifyAccount = catchAsync(async (req: Request, res: Response) => {
-  const token = (req.query.token ?? req.body.token) as string | undefined;
+  const token = (req.query.token ?? req.body.token) as string | undefined
   if (!token) {
-    throw new AppError("Verification token is required", 400);
+    throw new AppError(
+      ErrorMessages.VERIFICATION_TOKEN_REQUIRED,
+      400,
+      true,
+      ErrorCode.VALIDATION_ERROR,
+    )
   }
-  try {
-    const verified = await authService.verifyAccount(token);
-    const message = verified
-      ? "Email verified successfully"
-      : "Email already verified";
-    return res.status(200).json({ status: "success", message, code: 200 });
-  } catch (err) {
-    return handleError(res, err);
-  }
-});
+  const verified = await authService.verifyAccount(token)
+  const message = verified ? 'Email verified successfully' : 'Email already verified'
+  return res.status(200).json({ status: 'success', message, code: 200 })
+})
 
 /**
  * GET /api/auth/google/callback
  * Handle the Google OAuth callback. Issues a JWT and redirects to the frontend.
- *
- * @param req - `req.user` is populated by Passport's Google strategy.
- * @param res - Redirects to `APP_URL/auth-callback?token=<jwt>` on success,
- *              or `APP_URL/login?error=oauth-failed` on failure.
  */
-export async function googleAuthCallback(req: Request, res: Response) {
-  const user = req.user as any;
-  if (!user) return res.redirect(`${env.APP_URL}/login?error=oauth-failed`);
+export const googleAuthCallback = catchAsync(async (req: Request, res: Response) => {
+  const user = req.user as any
+  if (!user) return res.redirect(`${env.APP_URL}/login?error=oauth-failed`)
   const token = jwt.sign({ id: user.id, role: user.role }, env.JWT_SECRET, {
-    expiresIn: "7d",
-  });
-  return res.redirect(`${env.APP_URL}/auth-callback?token=${token}`);
-}
+    expiresIn: '7d',
+  })
+  return res.redirect(`${env.APP_URL}/auth-callback?token=${token}`)
+})
 
 /**
  * DELETE /api/auth/logout
  * Revokes all refresh tokens for the authenticated user.
  */
-export async function logout(req: Request, res: Response) {
-  try {
-    if (req.user?.id) {
-      await authService.revokeAllRefreshTokens(req.user.id)
-    }
-    return res
-      .status(200)
-      .json({ status: "success", message: "Logged out", code: 200 });
-  } catch (err) {
-    return handleError(res, err)
+export const logout = catchAsync(async (req: Request, res: Response) => {
+  if (req.user?.id) {
+    await authService.revokeAllRefreshTokens(req.user.id)
   }
-}
+  return res.status(200).json({ status: 'success', message: 'Logged out', code: 200 })
+})
 
 /**
  * POST /api/auth/refresh
  * Exchange a valid refresh token for a new access token + refresh token pair.
  *
  * Body: { refreshToken: string }
+ *
+ * @throws AppError 400 if refreshToken is missing.
+ * @throws AppError 401 if the refresh token is invalid or expired.
  */
-export async function refresh(req: Request<{}, {}, { refreshToken?: string }>, res: Response) {
+export const refresh = catchAsync(async (req: Request<{}, {}, { refreshToken?: string }>, res: Response) => {
   const { refreshToken } = req.body
   if (!refreshToken) {
-    return res.status(400).json({ status: 'error', message: 'refreshToken is required', code: 400 })
+    throw new AppError(
+      ErrorMessages.REFRESH_TOKEN_REQUIRED,
+      400,
+      true,
+      ErrorCode.VALIDATION_ERROR,
+    )
   }
-  try {
-    const tokens = await authService.rotateRefreshToken(refreshToken)
-    return res.json({ status: 'success', ...tokens, code: 200 })
-  } catch (err) {
-    return handleError(res, err)
-  }
-}
+  const tokens = await authService.rotateRefreshToken(refreshToken)
+  return res.json({ status: 'success', ...tokens, code: 200 })
+})
 
 /**
  * GET /api/auth/me
  * Return the currently authenticated user's profile.
  *
- * @param req - `req.user` must be set by the `authenticate` middleware.
- * @param res - JSON `{ data: User, status, code: 200 }`.
- * @throws 404 if the user record no longer exists.
+ * @throws AppError 404 if the user record no longer exists.
  */
-export async function me(req: Request, res: Response) {
-  try {
-    const { id } = req.user!;
-    const user = await db.user.findUnique({ where: { id } });
-    if (!user)
-      return res
-        .status(404)
-        .json({ status: "error", message: "User not found", code: 404 });
-    return res
-      .status(200)
-      .json({ data: sanitizeUser(user), status: "success", code: 200 });
-  } catch (err) {
-    return handleError(res, err);
+export const me = catchAsync(async (req: Request, res: Response) => {
+  const { id } = req.user!
+  const user = await db.user.findUnique({ where: { id } })
+  if (!user) {
+    throw new AppError(ErrorMessages.USER_NOT_FOUND, 404, true, ErrorCode.NOT_FOUND)
   }
-}
+  return res.status(200).json({ data: sanitizeUser(user), status: 'success', code: 200 })
+})
 
 /**
  * POST /api/auth/forgot-password
  * Send a password reset email. Always returns 200 to prevent email enumeration.
- *
- * @param req - Body: `{ email }`.
- * @param res - JSON `{ status, message, code: 200 }`.
  */
-export async function forgotPassword(
-  req: Request<{}, {}, ForgotPasswordBody>,
-  res: Response,
-) {
-  try {
-    await authService.requestPasswordReset(req.body.email);
-    return res.status(200).json({
-      status: "success",
-      message:
-        "If an account exists with that email, a password reset link has been sent.",
-      code: 200,
-    });
-  } catch (err) {
-    return handleError(res, err);
-  }
-}
+export const forgotPassword = catchAsync(async (req: Request<{}, {}, ForgotPasswordBody>, res: Response) => {
+  await authService.requestPasswordReset(req.body.email)
+  return res.status(200).json({
+    status: 'success',
+    message: 'If an account exists with that email, a password reset link has been sent.',
+    code: 200,
+  })
+})
 
 /**
  * PUT /api/auth/reset-password
  * Reset a user's password using the token from the reset email.
  *
- * @param req - Body: `{ token, password }`.
- * @param res - JSON `{ status, message, code: 200 }`.
  * @throws AppError 400 if `token` or `password` is missing, or if the token is invalid/expired.
  */
-export async function resetPassword(
-  req: Request<{}, {}, ResetPasswordBody>,
-  res: Response,
-) {
-  const { token, password } = req.body;
+export const resetPassword = catchAsync(async (req: Request<{}, {}, ResetPasswordBody>, res: Response) => {
+  const { token, password } = req.body
   if (!token || !password) {
-    throw new AppError("Token and password are required", 400);
+    throw new AppError('Token and password are required', 400, true, ErrorCode.VALIDATION_ERROR)
   }
-  try {
-    await authService.resetPassword(token, password);
-    return res
-      .status(200)
-      .json({
-        status: "success",
-        message: "Password reset successful",
-        code: 200,
-      });
-  } catch (err) {
-    return handleError(res, err);
-  }
-}
+  await authService.resetPassword(token, password)
+  return res.status(200).json({ status: 'success', message: 'Password reset successful', code: 200 })
+})
 
 /**
  * POST /api/auth/resend-verification
  * Resend the verification email. Always returns 200 to prevent enumeration.
  */
-export async function resendVerification(
-  req: Request<{}, {}, { email: string }>,
-  res: Response,
-) {
-  try {
-    await authService.resendVerificationEmail(req.body.email)
-    return res.status(200).json({
-      status: 'success',
-      message: 'If your account exists and is unverified, a new verification email has been sent.',
-      code: 200,
-    })
-  } catch (err) {
-    return handleError(res, err)
-  }
-}
+export const resendVerification = catchAsync(async (req: Request<{}, {}, { email: string }>, res: Response) => {
+  await authService.resendVerificationEmail(req.body.email)
+  return res.status(200).json({
+    status: 'success',
+    message: 'If your account exists and is unverified, a new verification email has been sent.',
+    code: 200,
+  })
+})
 
 /**
  * GET /api/auth/unsubscribe-reminders?token=<jwt>
  * Opt a user out of verification reminder emails.
+ *
+ * @throws AppError 400 if the token is missing, invalid, or expired.
  */
-export async function unsubscribeReminders(req: Request, res: Response) {
+export const unsubscribeReminders = catchAsync(async (req: Request, res: Response) => {
   const { token } = req.query
   if (!token || typeof token !== 'string') {
-    return res.status(400).json({ status: 'error', message: 'Token is required', code: 400 })
+    throw new AppError(ErrorMessages.TOKEN_REQUIRED, 400, true, ErrorCode.VALIDATION_ERROR)
   }
+  let payload: { id?: string; purpose?: string }
   try {
-    const payload = jwt.verify(token, env.JWT_SECRET) as { id?: string; purpose?: string }
-    if (payload.purpose !== 'unsubscribe-reminders' || !payload.id) {
-      return res.status(400).json({ status: 'error', message: 'Invalid token', code: 400 })
-    }
-    await db.user.update({ where: { id: payload.id }, data: { unsubscribedReminders: true } })
-    return res.json({ status: 'success', message: 'You have been unsubscribed from reminder emails', code: 200 })
+    payload = jwt.verify(token, env.JWT_SECRET) as { id?: string; purpose?: string }
   } catch {
-    return res.status(400).json({ status: 'error', message: 'Invalid or expired token', code: 400 })
+    throw new AppError(ErrorMessages.TOKEN_EXPIRED, 400, true, ErrorCode.TOKEN_INVALID)
   }
-}
-
-/**
- * GET /api/auth/devices
- * List all active devices/sessions for the authenticated user.
- */
-export async function listDevices(req: Request, res: Response) {
-  try {
-    const { id: userId } = req.user!
-    const devices = await db.device.findMany({
-      where: { userId, revokedAt: null },
-      orderBy: { lastUsedAt: 'desc' },
-    })
-    return res.json({ data: devices, status: 'success', code: 200 })
-  } catch (err) {
-    return handleError(res, err)
+  if (payload.purpose !== 'unsubscribe-reminders' || !payload.id) {
+    throw new AppError(ErrorMessages.TOKEN_INVALID, 400, true, ErrorCode.TOKEN_INVALID)
   }
-}
-
-/**
- * DELETE /api/auth/devices/:deviceId
- * Revoke a specific device session.
- */
-export async function revokeDevice(req: Request<{ deviceId: string }>, res: Response) {
-  try {
-    const { id: userId } = req.user!
-    const { deviceId } = req.params
-
-    const device = await db.device.findUnique({ where: { id: deviceId } })
-    if (!device || device.userId !== userId) {
-      return res.status(404).json({ status: 'error', message: 'Device not found', code: 404 })
-    }
-
-    await db.device.update({ where: { id: deviceId }, data: { revokedAt: new Date() } })
-    return res.json({ status: 'success', message: 'Device revoked', code: 200 })
-  } catch (err) {
-    return handleError(res, err)
-  }
-}
-
-/**
- * DELETE /api/auth/devices
- * Revoke all other devices (remote logout all but current device).
- */
-export async function revokeAllOtherDevices(req: Request, res: Response) {
-  try {
-    const { id: userId } = req.user!
-    const { currentDeviceId } = req.body
-
-    await db.device.updateMany({
-      where: { userId, id: { not: currentDeviceId }, revokedAt: null },
-      data: { revokedAt: new Date() },
-    })
-
-    return res.json({ status: 'success', message: 'All other devices revoked', code: 200 })
-  } catch (err) {
-    return handleError(res, err)
-  }
-}
-
-/**
- * POST /api/auth/2fa/enroll
- * Generate a TOTP secret for 2FA enrollment.
- */
-export async function enrollTwoFactor(req: Request, res: Response) {
-  try {
-    const { id: userId } = req.user!
-    const { secret, qrCode } = await authService.generateTOTPSecret(userId)
-    return res.json({ data: { secret, qrCode }, status: 'success', code: 200 })
-  } catch (err) {
-    return handleError(res, err)
-  }
-}
-
-/**
- * POST /api/auth/2fa/verify
- * Verify TOTP code and enable 2FA.
- * Body: { code, secret }
- */
-export async function verifyTwoFactor(
-  req: Request<{}, {}, { code: string; secret: string }>,
-  res: Response,
-) {
-  try {
-    const { id: userId } = req.user!
-    const { code, secret } = req.body
-    if (!code || !secret) {
-      return res.status(400).json({ status: 'error', message: 'Code and secret are required', code: 400 })
-    }
-    const { backupCodes } = await authService.enableTwoFactorAuth(userId, code, secret)
-    return res.json({ data: { backupCodes }, status: 'success', message: '2FA enabled successfully', code: 200 })
-  } catch (err) {
-    return handleError(res, err)
-  }
-}
-
-/**
- * DELETE /api/auth/2fa
- * Disable 2FA for the authenticated user.
- */
-export async function disableTwoFactor(req: Request, res: Response) {
-  try {
-    const { id: userId } = req.user!
-    await authService.disableTwoFactorAuth(userId)
-    return res.json({ status: 'success', message: '2FA disabled', code: 200 })
-  } catch (err) {
-    return handleError(res, err)
-  }
-}
+  await db.user.update({ where: { id: payload.id }, data: { unsubscribedReminders: true } })
+  return res.json({ status: 'success', message: 'You have been unsubscribed from reminder emails', code: 200 })
+})

--- a/packages/api/src/controllers/jobs.ts
+++ b/packages/api/src/controllers/jobs.ts
@@ -1,5 +1,7 @@
 import type { Request, Response } from 'express'
 import { catchAsync } from '../utils/catchAsync.js'
+import { AppError, ErrorCode } from '../utils/AppError.js'
+import { ErrorMessages } from '../constants/errors.js'
 import * as jobService from '../services/job.service.js'
 import { validate } from '../middleware/validate.js'
 import {
@@ -83,7 +85,9 @@ export function createJobsController(service: JobsService = jobService) {
       const { page, limit } = req.query as any
       // workerId comes from query — worker must pass their worker profile id
       const { workerId } = req.query as any
-      if (!workerId) return res.status(400).json({ status: 'error', message: 'workerId is required', code: 400 })
+      if (!workerId) {
+        throw new AppError(ErrorMessages.WORKER_ID_REQUIRED, 400, true, ErrorCode.VALIDATION_ERROR)
+      }
       const result = await service.myApplications(String(workerId), Number(page ?? 1), Number(limit ?? 20))
       return res.json({ ...result, status: 'success', code: 200 })
     }),
@@ -112,7 +116,9 @@ export function createJobsController(service: JobsService = jobService) {
 
     withdrawApplication: catchAsync(async (req: Request, res: Response) => {
       const { workerId } = req.body
-      if (!workerId) return res.status(400).json({ status: 'error', message: 'workerId is required', code: 400 })
+      if (!workerId) {
+        throw new AppError(ErrorMessages.WORKER_ID_REQUIRED, 400, true, ErrorCode.VALIDATION_ERROR)
+      }
       const application = await service.withdrawApplication(req.params.id, String(workerId))
       return res.json({ data: application, status: 'success', code: 200 })
     }),

--- a/packages/api/src/controllers/payment.ts
+++ b/packages/api/src/controllers/payment.ts
@@ -1,55 +1,95 @@
 /**
  * Payment controller — thin HTTP layer.
- * Parses request input, delegates to the contracts service, and formats responses.
- * All business logic and validation lives in contracts.service / payment.service.
+ *
+ * Parses request input, delegates to the injected PaymentService, and formats
+ * responses.  All business logic lives exclusively in PaymentService; this
+ * controller is responsible only for parse → validate → respond.
+ *
+ * Dependency injection: pass a PaymentService instance to
+ * `createPaymentController()`.  The module-level exports use the shared
+ * singleton so existing route wiring requires no changes.
  */
 import type { Request, Response } from 'express'
 import { catchAsync } from '../utils/catchAsync.js'
-import * as contractsService from '../services/contracts.service.js'
+import { AppError, ErrorCode } from '../utils/AppError.js'
+import { paymentService as defaultPaymentService, PaymentService } from '../services/payment.service.js'
 import { HttpStatus } from '../constants/index.js'
+import { ErrorMessages } from '../constants/errors.js'
 
-/**
- * POST /api/payments/tip
- * Body: { from, to, amount }
- */
-export const processTip = catchAsync(async (req: Request, res: Response) => {
-  const { from, to, amount } = req.body
-  const result = contractsService.processTip({ from, to, amount })
-  return res.status(HttpStatus.OK).json({ data: result, status: 'success', code: HttpStatus.OK })
-})
+// ── Controller factory (enables dependency injection) ─────────────────────────
 
-/**
- * POST /api/payments/escrow
- * Body: { from, to, amount, expiryDate }
- */
-export const createEscrow = catchAsync(async (req: Request, res: Response) => {
-  const { from, to, amount, expiryDate } = req.body
-  const result = contractsService.createPaymentEscrow({ from, to, amount, expiryDate })
-  return res.status(HttpStatus.CREATED).json({ data: result, status: 'success', code: HttpStatus.CREATED })
-})
-
-/**
- * GET /api/payments/fee
- */
-export function getFee(_req: Request, res: Response) {
-  return res.status(HttpStatus.OK).json({
-    data: { fee_bps: contractsService.getPaymentFee() },
-    status: 'success',
-    code: HttpStatus.OK,
+export function createPaymentController(service: PaymentService = defaultPaymentService) {
+  /**
+   * POST /api/payments/tip
+   * Body: { from, to, amount }
+   */
+  const processTip = catchAsync(async (req: Request, res: Response) => {
+    const { from, to, amount } = req.body
+    if (!from || !to || amount === undefined) {
+      throw new AppError(ErrorMessages.TIP_FIELDS_REQUIRED, HttpStatus.BAD_REQUEST, true, ErrorCode.VALIDATION_ERROR)
+    }
+    const result = service.tip({ from: String(from), to: String(to), amount: Number(amount) })
+    return res.status(HttpStatus.OK).json({ data: result, status: 'success', code: HttpStatus.OK })
   })
+
+  /**
+   * POST /api/payments/escrow
+   * Body: { from, to, amount, expiryDate }
+   */
+  const createEscrow = catchAsync(async (req: Request, res: Response) => {
+    const { from, to, amount, expiryDate } = req.body
+    if (!from || !to || amount === undefined || !expiryDate) {
+      throw new AppError(
+        ErrorMessages.ESCROW_FIELDS_REQUIRED,
+        HttpStatus.BAD_REQUEST,
+        true,
+        ErrorCode.VALIDATION_ERROR,
+      )
+    }
+    const result = service.createEscrow({
+      from: String(from),
+      to: String(to),
+      amount: Number(amount),
+      expiryDate: new Date(expiryDate),
+    })
+    return res.status(HttpStatus.CREATED).json({ data: result, status: 'success', code: HttpStatus.CREATED })
+  })
+
+  /**
+   * GET /api/payments/fee
+   */
+  const getFee = (_req: Request, res: Response) => {
+    return res.status(HttpStatus.OK).json({
+      data: { fee_bps: service.getFeeBps() },
+      status: 'success',
+      code: HttpStatus.OK,
+    })
+  }
+
+  /**
+   * PATCH /api/payments/fee
+   * Body: { fee_bps }
+   * Requires admin role.
+   */
+  const updateFee = catchAsync(async (req: Request, res: Response) => {
+    const { fee_bps } = req.body
+    if (fee_bps === undefined) {
+      throw new AppError(ErrorMessages.FEE_BPS_REQUIRED, HttpStatus.BAD_REQUEST, true, ErrorCode.VALIDATION_ERROR)
+    }
+    service.setFeeBps(req.user?.role ?? '', Number(fee_bps))
+    return res.status(HttpStatus.OK).json({
+      data: { fee_bps: service.getFeeBps() },
+      status: 'success',
+      code: HttpStatus.OK,
+    })
+  })
+
+  return { processTip, createEscrow, getFee, updateFee }
 }
 
-/**
- * PATCH /api/payments/fee
- * Body: { fee_bps }
- * Requires admin role.
- */
-export const updateFee = catchAsync(async (req: Request, res: Response) => {
-  const { fee_bps } = req.body
-  const updatedFee = contractsService.updatePaymentFee(req.user?.role ?? '', fee_bps)
-  return res.status(HttpStatus.OK).json({
-    data: { fee_bps: updatedFee },
-    status: 'success',
-    code: HttpStatus.OK,
-  })
-})
+// ── Default exports backed by the shared singleton ────────────────────────────
+// Route files import these directly; tests inject a custom service via the factory.
+
+const defaultController = createPaymentController()
+
+export const { processTip, createEscrow, getFee, updateFee } = defaultController

--- a/packages/api/src/routes/payments.ts
+++ b/packages/api/src/routes/payments.ts
@@ -1,8 +1,13 @@
 import { Router } from 'express'
 import { authenticate, authorize } from '../middleware/auth.js'
-import { processTip, createEscrow, getFee, updateFee } from '../controllers/payment.js'
+import { createPaymentController } from '../controllers/payment.js'
+import { paymentService } from '../services/payment.service.js'
 
 const router = Router()
+
+// Wire the controller with the shared paymentService singleton.
+// To inject a test double, swap the service passed here.
+const { processTip, createEscrow, getFee, updateFee } = createPaymentController(paymentService)
 
 router.get('/fee', getFee)
 router.patch('/fee', authenticate, authorize('admin'), updateFee)


### PR DESCRIPTION
## Summary

closes #1009 
closes #1010 
closes #1011 
closes #1012 
Addresses four backend issues in a single cohesive refactor of the payments, auth, and jobs layers.

---

## Closes

- **#1011** `[Backend] Refactor payments route handlers to use service layer`
- **#1012** `[Backend] Remove deprecated legacy auth endpoints`
- **#1009** `[Backend] Standardize error handling in auth endpoints`
- **#1010** `[Backend] Standardize error handling in jobs endpoints`

---

## Changes

### #1011 — Payments service layer & DI

- **`controllers/payment.ts`**: introduced `createPaymentController(service)` factory that accepts an injected `PaymentService`. The controller no longer proxies through `contracts.service` — it calls `PaymentService` methods directly. Default export still uses the shared singleton so existing route wiring is unchanged.
- **`routes/payments.ts`**: explicitly passes `paymentService` singleton into `createPaymentController()`.
- All missing-field guards now `throw new AppError()` instead of returning raw JSON.
- **New: `src/__tests__/unit/payment.controller.test.ts`** — 16 unit tests covering all four handlers via dependency injection.

### #1012 — Remove deprecated auth endpoints

Removed six dead-code functions from `controllers/auth.ts` that were never wired into `routes/auth.ts`:

| Removed function | Superseded by |
|---|---|
| `enrollTwoFactor` | `controllers/twoFactor.ts` → `POST /2fa/setup` |
| `verifyTwoFactor` | `controllers/twoFactor.ts` → `POST /2fa/verify` |
| `disableTwoFactor` | `controllers/twoFactor.ts` → `DELETE /2fa` |
| `listDevices` | `controllers/devices.ts` |
| `revokeDevice` | `controllers/devices.ts` |
| `revokeAllOtherDevices` | `controllers/devices.ts` |

### #1009 — Standardize auth error handling

- Every handler in `controllers/auth.ts` now uses `catchAsync` + `throw new AppError(...)`.
- Removed all `try/catch + handleError(res, err)` blocks.
- All error responses carry the full shape: `{ status, message, code, errorCode, traceId }`.
- `AppError` import unified to `utils/AppError.ts` (canonical).
- `src/__tests__/auth.test.ts` updated: error assertions now capture `next(err)`; added coverage for `refresh`, `me`, and `resendVerification`.

### #1010 — Standardize jobs error handling

- Replaced two inline `res.status(400).json({...})` calls in `createJobsController`:
  - `myApplications`: missing `workerId` → `throw new AppError(ErrorMessages.WORKER_ID_REQUIRED, 400, true, ErrorCode.VALIDATION_ERROR)`
  - `withdrawApplication`: same pattern
- Both errors now go through `errorHandler` and include `errorCode` + `traceId`.

---

## Testing

| Area | Tests |
|---|---|
| Payment controller | 16 new unit tests (DI factory, all 4 handlers, success + error paths) |
| Auth controller | Existing tests migrated to `next(err)` pattern; 6 new handler tests added |
| Jobs controller | Covered by existing integration tests (assert HTTP 400 status) |
