### PR TITLE
test: add unit test suite for job posting flow

### DIFF
--- a/packages/api/src/controllers/jobs.test.ts
+++ b/packages/api/src/controllers/jobs.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for the jobs controller (closes #1042).
+ *
+ * The jobs controller is built via `createJobsController(service)`, which
+ * accepts an injected service — this lets us exercise the HTTP-shaping logic
+ * (query parsing, status codes, response envelopes) with a fake service,
+ * without touching the database.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Request, Response } from 'express'
+import { createJobsController, type JobsService } from './jobs.js'
+import { AppError } from '../services/AppError.js'
+
+function makeRes() {
+  const res: Partial<Response> = {}
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  res.send = vi.fn().mockReturnValue(res)
+  return res as Response & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi.fn> }
+}
+
+function makeReq(overrides: Partial<Request> = {}) {
+  return { query: {}, params: {}, body: {}, user: { id: 'user-1', role: 'user' }, ...overrides } as unknown as Request
+}
+
+function makeFakeService(overrides: Partial<JobsService> = {}): JobsService {
+  return {
+    listJobs: vi.fn(),
+    getJob: vi.fn(),
+    createJob: vi.fn(),
+    updateJob: vi.fn(),
+    deleteJob: vi.fn(),
+    renewJob: vi.fn(),
+    recommendedJobs: vi.fn(),
+    myPostedJobs: vi.fn(),
+    myApplications: vi.fn(),
+    applyToJob: vi.fn(),
+    listApplications: vi.fn(),
+    updateApplicationStatus: vi.fn(),
+    withdrawApplication: vi.fn(),
+    sendMessage: vi.fn(),
+    listMessages: vi.fn(),
+    ...overrides,
+  } as unknown as JobsService
+}
+
+const next = vi.fn()
+
+// `catchAsync` fires the handler without awaiting it (Express doesn't need
+// the promise back), so tests must flush the microtask queue after invoking
+// a controller method before asserting on res/next side effects.
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+beforeEach(() => {
+  next.mockClear()
+})
+
+describe('listJobs', () => {
+  it('parses comma-separated skills and numeric pagination from the query string', async () => {
+    const listJobsMock = vi.fn().mockResolvedValue({ data: [], meta: { total: 0, page: 2, limit: 10, pages: 0 } })
+    const controller = createJobsController(makeFakeService({ listJobs: listJobsMock }))
+    const req = makeReq({ query: { skills: 'plumbing, electrical', page: '2', limit: '10' } as any })
+    const res = makeRes()
+
+    await controller.listJobs(req, res, next)
+    await flush()
+
+    expect(listJobsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ skills: ['plumbing', 'electrical'], page: 2, limit: 10 }),
+    )
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'success', code: 200 }))
+  })
+
+  it('defaults page/limit when not provided', async () => {
+    const listJobsMock = vi.fn().mockResolvedValue({ data: [], meta: {} })
+    const controller = createJobsController(makeFakeService({ listJobs: listJobsMock }))
+    const res = makeRes()
+
+    await controller.listJobs(makeReq(), res, next)
+    await flush()
+
+    expect(listJobsMock).toHaveBeenCalledWith(expect.objectContaining({ page: 1, limit: 20 }))
+  })
+})
+
+describe('showJob', () => {
+  it('returns the job wrapped in a success envelope', async () => {
+    const getJobMock = vi.fn().mockResolvedValue({ id: 'job-1' })
+    const controller = createJobsController(makeFakeService({ getJob: getJobMock }))
+    const res = makeRes()
+
+    await controller.showJob(makeReq({ params: { id: 'job-1' } as any }), res, next)
+    await flush()
+
+    expect(res.json).toHaveBeenCalledWith({ data: { id: 'job-1' }, status: 'success', code: 200 })
+  })
+
+  it('forwards service errors to next() via catchAsync', async () => {
+    const getJobMock = vi.fn().mockRejectedValue(new AppError('Job not found', 404))
+    const controller = createJobsController(makeFakeService({ getJob: getJobMock }))
+    const res = makeRes()
+
+    await controller.showJob(makeReq({ params: { id: 'missing' } as any }), res, next)
+    await flush()
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 404 }))
+  })
+})
+
+describe('createJob', () => {
+  it('creates a job for the authenticated user and returns 201', async () => {
+    const createJobMock = vi.fn().mockResolvedValue({ id: 'job-1', title: 'New job' })
+    const controller = createJobsController(makeFakeService({ createJob: createJobMock }))
+    const req = makeReq({ body: { title: 'New job' } as any, user: { id: 'poster-1', role: 'user' } as any })
+    const res = makeRes()
+
+    await controller.createJob(req, res, next)
+    await flush()
+
+    expect(createJobMock).toHaveBeenCalledWith({ title: 'New job' }, 'poster-1')
+    expect(res.status).toHaveBeenCalledWith(201)
+  })
+})
+
+describe('deleteJob', () => {
+  it('returns 204 with no body on success', async () => {
+    const deleteJobMock = vi.fn().mockResolvedValue(undefined)
+    const controller = createJobsController(makeFakeService({ deleteJob: deleteJobMock }))
+    const res = makeRes()
+
+    await controller.deleteJob(makeReq({ params: { id: 'job-1' } as any }), res, next)
+    await flush()
+
+    expect(res.status).toHaveBeenCalledWith(204)
+    expect(res.send).toHaveBeenCalled()
+  })
+
+  it('forwards a 403 when the service rejects a non-owner', async () => {
+    const deleteJobMock = vi.fn().mockRejectedValue(new AppError('Forbidden', 403))
+    const controller = createJobsController(makeFakeService({ deleteJob: deleteJobMock }))
+    const res = makeRes()
+
+    await controller.deleteJob(makeReq({ params: { id: 'job-1' } as any }), res, next)
+    await flush()
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }))
+  })
+})
+
+describe('renewJob', () => {
+  it('defaults to 30 days when body.days is not provided', async () => {
+    const renewJobMock = vi.fn().mockResolvedValue({ id: 'job-1', status: 'open' })
+    const controller = createJobsController(makeFakeService({ renewJob: renewJobMock }))
+    const res = makeRes()
+
+    await controller.renewJob(makeReq({ params: { id: 'job-1' } as any }), res, next)
+    await flush()
+
+    expect(renewJobMock).toHaveBeenCalledWith('job-1', 'user-1', 30)
+  })
+
+  it('uses the provided body.days', async () => {
+    const renewJobMock = vi.fn().mockResolvedValue({ id: 'job-1', status: 'open' })
+    const controller = createJobsController(makeFakeService({ renewJob: renewJobMock }))
+    const req = makeReq({ params: { id: 'job-1' } as any, body: { days: 60 } as any })
+    const res = makeRes()
+
+    await controller.renewJob(req, res, next)
+    await flush()
+
+    expect(renewJobMock).toHaveBeenCalledWith('job-1', 'user-1', 60)
+  })
+})
+
+describe('myApplications', () => {
+  it('returns 400 when workerId query param is missing', async () => {
+    const controller = createJobsController(makeFakeService())
+    const res = makeRes()
+
+    await controller.myApplications(makeReq(), res, next)
+    await flush()
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'error' }))
+  })
+
+  it('passes workerId and pagination through to the service', async () => {
+    const myApplicationsMock = vi.fn().mockResolvedValue({ data: [], meta: {} })
+    const controller = createJobsController(makeFakeService({ myApplications: myApplicationsMock }))
+    const req = makeReq({ query: { workerId: 'worker-1', page: '3', limit: '5' } as any })
+    const res = makeRes()
+
+    await controller.myApplications(req, res, next)
+    await flush()
+
+    expect(myApplicationsMock).toHaveBeenCalledWith('worker-1', 3, 5)
+  })
+})
+
+describe('applyToJob', () => {
+  it('creates an application and returns 201', async () => {
+    const applyToJobMock = vi.fn().mockResolvedValue({ id: 'app-1' })
+    const controller = createJobsController(makeFakeService({ applyToJob: applyToJobMock }))
+    const req = makeReq({
+      params: { id: 'job-1' } as any,
+      body: { workerId: 'worker-1', coverLetter: 'Hi', proposedRate: 100 } as any,
+    })
+    const res = makeRes()
+
+    await controller.applyToJob(req, res, next)
+    await flush()
+
+    expect(applyToJobMock).toHaveBeenCalledWith('job-1', 'worker-1', 'Hi', 100)
+    expect(res.status).toHaveBeenCalledWith(201)
+  })
+
+  it('forwards a 409 conflict when the service rejects a duplicate application', async () => {
+    const applyToJobMock = vi.fn().mockRejectedValue(new AppError('Already applied to this job', 409))
+    const controller = createJobsController(makeFakeService({ applyToJob: applyToJobMock }))
+    const req = makeReq({ params: { id: 'job-1' } as any, body: { workerId: 'worker-1' } as any })
+    const res = makeRes()
+
+    await controller.applyToJob(req, res, next)
+    await flush()
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 409 }))
+  })
+})
+
+describe('withdrawApplication', () => {
+  it('returns 400 when workerId is missing from the body', async () => {
+    const controller = createJobsController(makeFakeService())
+    const res = makeRes()
+
+    await controller.withdrawApplication(makeReq({ params: { id: 'job-1' } as any }), res, next)
+    await flush()
+
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('withdraws the application when workerId is provided', async () => {
+    const withdrawApplicationMock = vi.fn().mockResolvedValue({ id: 'app-1', status: 'withdrawn' })
+    const controller = createJobsController(makeFakeService({ withdrawApplication: withdrawApplicationMock }))
+    const req = makeReq({ params: { id: 'job-1' } as any, body: { workerId: 'worker-1' } as any })
+    const res = makeRes()
+
+    await controller.withdrawApplication(req, res, next)
+    await flush()
+
+    expect(withdrawApplicationMock).toHaveBeenCalledWith('job-1', 'worker-1')
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: { id: 'app-1', status: 'withdrawn' } }))
+  })
+})
+
+describe('sendMessage / listMessages', () => {
+  it('sendMessage creates a message and returns 201', async () => {
+    const sendMessageMock = vi.fn().mockResolvedValue({ id: 'msg-1' })
+    const controller = createJobsController(makeFakeService({ sendMessage: sendMessageMock }))
+    const req = makeReq({
+      params: { id: 'job-1' } as any,
+      user: { id: 'sender-1', role: 'user' } as any,
+      body: { recipientId: 'recipient-1', body: 'Hello' } as any,
+    })
+    const res = makeRes()
+
+    await controller.sendMessage(req, res, next)
+    await flush()
+
+    expect(sendMessageMock).toHaveBeenCalledWith('job-1', 'sender-1', 'recipient-1', 'Hello')
+    expect(res.status).toHaveBeenCalledWith(201)
+  })
+
+  it('listMessages returns the thread for the authenticated user', async () => {
+    const listMessagesMock = vi.fn().mockResolvedValue([{ id: 'msg-1' }])
+    const controller = createJobsController(makeFakeService({ listMessages: listMessagesMock }))
+    const req = makeReq({ params: { id: 'job-1' } as any, user: { id: 'user-1', role: 'user' } as any })
+    const res = makeRes()
+
+    await controller.listMessages(req, res, next)
+    await flush()
+
+    expect(listMessagesMock).toHaveBeenCalledWith('job-1', 'user-1')
+    expect(res.json).toHaveBeenCalledWith({ data: [{ id: 'msg-1' }], status: 'success', code: 200 })
+  })
+})

--- a/packages/api/src/controllers/jobs.test.ts
+++ b/packages/api/src/controllers/jobs.test.ts
@@ -181,8 +181,7 @@ describe('myApplications', () => {
     await controller.myApplications(makeReq(), res, next)
     await flush()
 
-    expect(res.status).toHaveBeenCalledWith(400)
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'error' }))
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }))
   })
 
   it('passes workerId and pagination through to the service', async () => {
@@ -236,7 +235,7 @@ describe('withdrawApplication', () => {
     await controller.withdrawApplication(makeReq({ params: { id: 'job-1' } as any }), res, next)
     await flush()
 
-    expect(res.status).toHaveBeenCalledWith(400)
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }))
   })
 
   it('withdraws the application when workerId is provided', async () => {

--- a/packages/api/src/services/job.service.test.ts
+++ b/packages/api/src/services/job.service.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Unit tests for the job posting flow (closes #1042).
+ *
+ * Covers packages/api/src/services/job.service.ts at the unit level by
+ * mocking the Prisma DB client and the notification dispatcher.
+ *
+ * Scenarios tested:
+ *  - listJobs: filtering by category/search/skills/budget, pagination meta
+ *  - getJob: returns job, throws 404 when missing
+ *  - createJob: persists with defaults applied
+ *  - updateJob: owner can update, non-owner gets 403, missing job gets 404
+ *  - deleteJob: owner can delete, non-owner gets 403
+ *  - renewJob: extends expiry, rejects invalid states, enforces ownership
+ *  - applyToJob: creates application, rejects duplicate/non-open jobs, notifies poster
+ *  - listApplications / updateApplicationStatus / withdrawApplication: ownership + state guards
+ *  - sendMessage / listMessages: marks unread messages read for the recipient
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const mockJobFindMany = vi.fn()
+const mockJobFindUnique = vi.fn()
+const mockJobCount = vi.fn()
+const mockJobCreate = vi.fn()
+const mockJobUpdate = vi.fn()
+const mockJobUpdateMany = vi.fn()
+const mockJobDelete = vi.fn()
+const mockApplicationFindUnique = vi.fn()
+const mockApplicationFindFirst = vi.fn()
+const mockApplicationFindMany = vi.fn()
+const mockApplicationCreate = vi.fn()
+const mockApplicationUpdate = vi.fn()
+const mockWorkerFindUnique = vi.fn()
+const mockMessageCreate = vi.fn()
+const mockMessageFindMany = vi.fn()
+const mockMessageUpdateMany = vi.fn()
+
+vi.mock('../db.js', () => ({
+  db: {
+    job: {
+      findMany: (...a: unknown[]) => mockJobFindMany(...a),
+      findUnique: (...a: unknown[]) => mockJobFindUnique(...a),
+      count: (...a: unknown[]) => mockJobCount(...a),
+      create: (...a: unknown[]) => mockJobCreate(...a),
+      update: (...a: unknown[]) => mockJobUpdate(...a),
+      updateMany: (...a: unknown[]) => mockJobUpdateMany(...a),
+      delete: (...a: unknown[]) => mockJobDelete(...a),
+    },
+    jobApplication: {
+      findUnique: (...a: unknown[]) => mockApplicationFindUnique(...a),
+      findFirst: (...a: unknown[]) => mockApplicationFindFirst(...a),
+      findMany: (...a: unknown[]) => mockApplicationFindMany(...a),
+      create: (...a: unknown[]) => mockApplicationCreate(...a),
+      update: (...a: unknown[]) => mockApplicationUpdate(...a),
+      count: vi.fn(),
+    },
+    worker: {
+      findUnique: (...a: unknown[]) => mockWorkerFindUnique(...a),
+    },
+    jobMessage: {
+      create: (...a: unknown[]) => mockMessageCreate(...a),
+      findMany: (...a: unknown[]) => mockMessageFindMany(...a),
+      updateMany: (...a: unknown[]) => mockMessageUpdateMany(...a),
+    },
+  },
+}))
+
+// ── Notification dispatch mock ────────────────────────────────────────────────
+
+const mockDispatchNotification = vi.fn()
+
+vi.mock('../services/notification.service.js', () => ({
+  dispatchNotification: (...a: unknown[]) => mockDispatchNotification(...a),
+}))
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import {
+  listJobs,
+  getJob,
+  createJob,
+  updateJob,
+  deleteJob,
+  renewJob,
+  applyToJob,
+  listApplications,
+  updateApplicationStatus,
+  withdrawApplication,
+  sendMessage,
+  listMessages,
+} from './job.service.js'
+
+const JOB_ID = 'job-001'
+const POSTER_ID = 'user-poster-001'
+const OTHER_USER_ID = 'user-other-001'
+const WORKER_ID = 'worker-001'
+
+function makeJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: JOB_ID,
+    title: 'Fix leaking faucet',
+    description: 'Kitchen faucet is leaking, needs a plumber.',
+    status: 'open',
+    postedById: POSTER_ID,
+    categoryId: 'cat-1',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockDispatchNotification.mockResolvedValue(undefined)
+  // expireJobs() runs at the top of several service calls — default to a no-op.
+  mockJobFindMany.mockResolvedValue([])
+  mockJobUpdateMany.mockResolvedValue({ count: 0 })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// listJobs
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('listJobs', () => {
+  it('returns paginated data with meta', async () => {
+    mockJobFindMany.mockResolvedValueOnce([]) // expireJobs lookup
+    mockJobFindMany.mockResolvedValueOnce([makeJob()])
+    mockJobCount.mockResolvedValue(1)
+
+    const result = await listJobs({ page: 1, limit: 20 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.meta).toMatchObject({ total: 1, page: 1, limit: 20, pages: 1 })
+  })
+
+  it('applies a case-insensitive search filter across title and description', async () => {
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobCount.mockResolvedValue(0)
+
+    await listJobs({ search: 'faucet' })
+
+    const [{ where }] = mockJobFindMany.mock.calls[1]
+    expect(where.OR).toEqual([
+      { title: { contains: 'faucet', mode: 'insensitive' } },
+      { description: { contains: 'faucet', mode: 'insensitive' } },
+    ])
+  })
+
+  it('filters by budget range when minBudget/maxBudget are provided', async () => {
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobCount.mockResolvedValue(0)
+
+    await listJobs({ minBudget: 50, maxBudget: 200 })
+
+    const [{ where }] = mockJobFindMany.mock.calls[1]
+    expect(where.budget).toEqual({ gte: 50, lte: 200 })
+  })
+
+  it('filters by skills using hasSome', async () => {
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobCount.mockResolvedValue(0)
+
+    await listJobs({ skills: ['plumbing', 'electrical'] })
+
+    const [{ where }] = mockJobFindMany.mock.calls[1]
+    expect(where.skills).toEqual({ hasSome: ['plumbing', 'electrical'] })
+  })
+
+  it('omits the status filter when status is "all"', async () => {
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobCount.mockResolvedValue(0)
+
+    await listJobs({ status: 'all' })
+
+    const [{ where }] = mockJobFindMany.mock.calls[1]
+    expect(where.status).toBeUndefined()
+  })
+
+  it('defaults to status "open" when no status is given', async () => {
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobCount.mockResolvedValue(0)
+
+    await listJobs({})
+
+    const [{ where }] = mockJobFindMany.mock.calls[1]
+    expect(where.status).toBe('open')
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// getJob
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('getJob', () => {
+  it('returns the job when it exists', async () => {
+    mockJobFindMany.mockResolvedValueOnce([]) // expireJobs
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+
+    const job = await getJob(JOB_ID)
+    expect(job.id).toBe(JOB_ID)
+  })
+
+  it('throws AppError 404 when the job does not exist', async () => {
+    mockJobFindMany.mockResolvedValueOnce([])
+    mockJobFindUnique.mockResolvedValueOnce(null)
+
+    await expect(getJob('missing')).rejects.toMatchObject({ statusCode: 404 })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// createJob
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('createJob', () => {
+  it('applies defaults for skills and urgency when omitted', async () => {
+    mockJobCreate.mockResolvedValue(makeJob())
+
+    await createJob({ title: 'Paint fence', description: 'Needs a fresh coat', categoryId: 'cat-1' }, POSTER_ID)
+
+    const [{ data }] = mockJobCreate.mock.calls[0]
+    expect(data.skills).toEqual([])
+    expect(data.urgency).toBe('normal')
+    expect(data.postedById).toBe(POSTER_ID)
+  })
+
+  it('parses expiresAt into a Date when provided', async () => {
+    mockJobCreate.mockResolvedValue(makeJob())
+
+    await createJob(
+      { title: 'Mow lawn', description: 'Weekly mowing', categoryId: 'cat-1', expiresAt: '2030-01-01T00:00:00.000Z' },
+      POSTER_ID,
+    )
+
+    const [{ data }] = mockJobCreate.mock.calls[0]
+    expect(data.expiresAt).toBeInstanceOf(Date)
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// updateJob
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('updateJob', () => {
+  it('updates the job when the caller is the poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockJobUpdate.mockResolvedValueOnce(makeJob({ title: 'Updated title' }))
+
+    const result = await updateJob(JOB_ID, POSTER_ID, { title: 'Updated title' })
+    expect(result.title).toBe('Updated title')
+  })
+
+  it('throws AppError 404 when the job does not exist', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(null)
+    await expect(updateJob('missing', POSTER_ID, { title: 'x' })).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('throws AppError 403 when the caller is not the poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    await expect(updateJob(JOB_ID, OTHER_USER_ID, { title: 'x' })).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// deleteJob
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('deleteJob', () => {
+  it('deletes the job when the caller is the poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockJobDelete.mockResolvedValueOnce(undefined)
+
+    await deleteJob(JOB_ID, POSTER_ID)
+    expect(mockJobDelete).toHaveBeenCalledWith({ where: { id: JOB_ID } })
+  })
+
+  it('throws AppError 403 when the caller is not the poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    await expect(deleteJob(JOB_ID, OTHER_USER_ID)).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('throws AppError 404 when the job does not exist', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(null)
+    await expect(deleteJob('missing', POSTER_ID)).rejects.toMatchObject({ statusCode: 404 })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// renewJob
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('renewJob', () => {
+  it('extends the expiry and reopens an expired job', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob({ status: 'expired' }))
+    mockJobUpdate.mockResolvedValueOnce(makeJob({ status: 'open' }))
+
+    const result = await renewJob(JOB_ID, POSTER_ID, 30)
+    expect(result.status).toBe('open')
+
+    const [{ data }] = mockJobUpdate.mock.calls[0]
+    expect(data.status).toBe('open')
+    expect(data.expiresAt).toBeInstanceOf(Date)
+  })
+
+  it('throws AppError 400 when the job is not open or expired', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob({ status: 'filled' }))
+    await expect(renewJob(JOB_ID, POSTER_ID)).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('throws AppError 403 when the caller is not the poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    await expect(renewJob(JOB_ID, OTHER_USER_ID)).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('throws AppError 404 when the job does not exist', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(null)
+    await expect(renewJob('missing', POSTER_ID)).rejects.toMatchObject({ statusCode: 404 })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// applyToJob
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('applyToJob', () => {
+  it('creates an application and notifies the job poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockApplicationFindUnique.mockResolvedValueOnce(null)
+    mockApplicationCreate.mockResolvedValueOnce({ id: 'app-1', jobId: JOB_ID, workerId: WORKER_ID })
+
+    const app = await applyToJob(JOB_ID, WORKER_ID, 'I can do this', 100)
+
+    expect(app.id).toBe('app-1')
+    expect(mockDispatchNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: POSTER_ID, channels: ['inapp'] }),
+    )
+  })
+
+  it('throws AppError 404 when the job does not exist', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(null)
+    await expect(applyToJob('missing', WORKER_ID)).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('throws AppError 400 when the job is not open', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob({ status: 'filled' }))
+    await expect(applyToJob(JOB_ID, WORKER_ID)).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('throws AppError 409 when the worker already applied', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockApplicationFindUnique.mockResolvedValueOnce({ id: 'existing-app' })
+    await expect(applyToJob(JOB_ID, WORKER_ID)).rejects.toMatchObject({ statusCode: 409 })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// listApplications
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('listApplications', () => {
+  it('returns applications for the job poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockApplicationFindMany.mockResolvedValueOnce([{ id: 'app-1' }])
+
+    const apps = await listApplications(JOB_ID, POSTER_ID)
+    expect(apps).toHaveLength(1)
+  })
+
+  it('throws AppError 403 for a non-poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    await expect(listApplications(JOB_ID, OTHER_USER_ID)).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// updateApplicationStatus
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('updateApplicationStatus', () => {
+  it('accepts an application, marks the job filled, and notifies the worker curator', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockApplicationFindFirst.mockResolvedValueOnce({ id: 'app-1', jobId: JOB_ID, workerId: WORKER_ID })
+    mockApplicationUpdate.mockResolvedValueOnce({ id: 'app-1', status: 'accepted', job: { title: 'Fix leaking faucet' } })
+    mockJobUpdate.mockResolvedValueOnce(makeJob({ status: 'filled' }))
+    mockWorkerFindUnique.mockResolvedValueOnce({ curatorId: 'curator-1' })
+
+    const result = await updateApplicationStatus(JOB_ID, 'app-1', POSTER_ID, 'accepted')
+
+    expect(result.status).toBe('accepted')
+    expect(mockJobUpdate).toHaveBeenCalledWith({ where: { id: JOB_ID }, data: { status: 'filled' } })
+    expect(mockDispatchNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'curator-1' }),
+    )
+  })
+
+  it('does not mark the job filled when rejecting', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockApplicationFindFirst.mockResolvedValueOnce({ id: 'app-1', jobId: JOB_ID, workerId: WORKER_ID })
+    mockApplicationUpdate.mockResolvedValueOnce({ id: 'app-1', status: 'rejected', job: { title: 'Fix leaking faucet' } })
+    mockWorkerFindUnique.mockResolvedValueOnce(null)
+
+    await updateApplicationStatus(JOB_ID, 'app-1', POSTER_ID, 'rejected')
+    expect(mockJobUpdate).not.toHaveBeenCalled()
+  })
+
+  it('throws AppError 403 for a non-poster', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    await expect(updateApplicationStatus(JOB_ID, 'app-1', OTHER_USER_ID, 'accepted')).rejects.toMatchObject({
+      statusCode: 403,
+    })
+  })
+
+  it('throws AppError 404 when the application does not exist', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockApplicationFindFirst.mockResolvedValueOnce(null)
+    await expect(updateApplicationStatus(JOB_ID, 'missing-app', POSTER_ID, 'accepted')).rejects.toMatchObject({
+      statusCode: 404,
+    })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// withdrawApplication
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('withdrawApplication', () => {
+  it('withdraws a pending application', async () => {
+    mockApplicationFindUnique.mockResolvedValueOnce({ id: 'app-1', status: 'pending' })
+    mockApplicationUpdate.mockResolvedValueOnce({ id: 'app-1', status: 'withdrawn' })
+
+    const result = await withdrawApplication(JOB_ID, WORKER_ID)
+    expect(result.status).toBe('withdrawn')
+  })
+
+  it('throws AppError 404 when no application exists', async () => {
+    mockApplicationFindUnique.mockResolvedValueOnce(null)
+    await expect(withdrawApplication(JOB_ID, WORKER_ID)).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('throws AppError 400 when the application is not pending', async () => {
+    mockApplicationFindUnique.mockResolvedValueOnce({ id: 'app-1', status: 'accepted' })
+    await expect(withdrawApplication(JOB_ID, WORKER_ID)).rejects.toMatchObject({ statusCode: 400 })
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// sendMessage / listMessages
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('sendMessage', () => {
+  it('creates a message tied to the job', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockMessageCreate.mockResolvedValueOnce({ id: 'msg-1', body: 'Hello' })
+
+    const message = await sendMessage(JOB_ID, POSTER_ID, WORKER_ID, 'Hello')
+    expect(message.id).toBe('msg-1')
+  })
+
+  it('throws AppError 404 when the job does not exist', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(null)
+    await expect(sendMessage('missing', POSTER_ID, WORKER_ID, 'Hi')).rejects.toMatchObject({ statusCode: 404 })
+  })
+})
+
+describe('listMessages', () => {
+  it('marks unread messages addressed to the caller as read, then returns the thread', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(makeJob())
+    mockMessageUpdateMany.mockResolvedValueOnce({ count: 2 })
+    mockMessageFindMany.mockResolvedValueOnce([{ id: 'msg-1' }])
+
+    const messages = await listMessages(JOB_ID, WORKER_ID)
+
+    expect(mockMessageUpdateMany).toHaveBeenCalledWith({
+      where: { jobId: JOB_ID, recipientId: WORKER_ID, readAt: null },
+      data: { readAt: expect.any(Date) },
+    })
+    expect(messages).toHaveLength(1)
+  })
+
+  it('throws AppError 404 when the job does not exist', async () => {
+    mockJobFindUnique.mockResolvedValueOnce(null)
+    await expect(listMessages('missing', WORKER_ID)).rejects.toMatchObject({ statusCode: 404 })
+  })
+})

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -26,5 +26,3 @@
   ],
   "license": "MIT"
 }
-  "license": "MIT"
-}


### PR DESCRIPTION
## Summary
- Adds `packages/api/src/services/job.service.test.ts` covering listing/filtering, CRUD, ownership guards, renewal, applications, application status transitions, withdrawals, and messaging (37 tests).
- Adds `packages/api/src/controllers/jobs.test.ts` covering the HTTP-shaping layer (query parsing, pagination defaults, status codes, error forwarding) via the controller's injectable service (17 tests).
- The job posting flow previously had zero automated test coverage.

## Test plan
- [x] `npx vitest run src/services/job.service.test.ts src/controllers/jobs.test.ts` — 54/54 passing
- [x] `npx tsc --noEmit` — no new type errors

Closes #1042