### PR TITLE
test(api): add job-lifecycle and payment e2e coverage for the core bu…

### DIFF
--- a/packages/api/src/__tests__/e2e/job-lifecycle.e2e.test.ts
+++ b/packages/api/src/__tests__/e2e/job-lifecycle.e2e.test.ts
@@ -1,0 +1,238 @@
+/**
+ * E2E test for the core business flow of the product, chained end-to-end.
+ * Requires a live test database (TEST_DATABASE_URL env var).
+ *
+ * Every other e2e suite (bookings, escrow, reviews, ...) tests its own slice in
+ * isolation. This suite chains the full user journey in one continuous run and
+ * asserts state after every transition, not just the final outcome:
+ *
+ *   post job → worker applies → hire → escrow funded → work completed →
+ *   review submitted → payout confirmed
+ *
+ * Run: pnpm --filter @bluecollar/api exec vitest run src/__tests__/e2e/job-lifecycle.e2e.test.ts
+ */
+
+import { describe, it, expect, beforeAll, vi } from 'vitest'
+import request from 'supertest'
+import { db } from '../../db.js'
+import app from '../../app.js'
+
+vi.mock('../../mailer/transport.js', () => ({
+  transporter: { sendMail: vi.fn().mockResolvedValue({ messageId: 'mock' }) },
+}))
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function createVerifiedUser(email: string, role: 'user' | 'curator' | 'admin' = 'user') {
+  const argon2 = await import('argon2')
+  return db.user.create({
+    data: {
+      email,
+      password: await argon2.hash('Password123!'),
+      firstName: 'Test',
+      lastName: 'User',
+      role,
+      verified: true,
+    },
+  })
+}
+
+async function loginAs(email: string): Promise<string> {
+  const res = await request(app).post('/api/auth/login').send({ email, password: 'Password123!' })
+  return res.body.token as string
+}
+
+function futureIso(msFromNow = 60 * 60 * 1000): string {
+  return new Date(Date.now() + msFromNow).toISOString()
+}
+
+// ── State shared across the chained journey ─────────────────────────────────
+
+let categoryId: string
+let posterId: string
+let posterToken: string
+let curatorId: string
+let curatorToken: string
+let workerId: string
+let jobId: string
+let applicationId: string
+let escrowId: string
+let reviewId: string
+
+describe('Job Lifecycle E2E — full user journey', () => {
+  beforeAll(async () => {
+    const cat = await db.category.create({ data: { name: 'Electrician' } })
+    categoryId = cat.id
+
+    const poster = await createVerifiedUser('lifecycle-poster@e2e.com', 'user')
+    const curator = await createVerifiedUser('lifecycle-curator@e2e.com', 'curator')
+    posterId = poster.id
+    curatorId = curator.id
+
+    posterToken = await loginAs('lifecycle-poster@e2e.com')
+    curatorToken = await loginAs('lifecycle-curator@e2e.com')
+
+    const worker = await db.worker.create({
+      data: { name: 'Lifecycle Electrician', categoryId, curatorId: curator.id },
+    })
+    workerId = worker.id
+  })
+
+  // ── 1. Post job ──────────────────────────────────────────────────────────
+  it('poster creates a job → 201, status=open', async () => {
+    const res = await request(app)
+      .post('/api/jobs')
+      .set('Authorization', `Bearer ${posterToken}`)
+      .send({
+        title: 'Rewire kitchen outlets',
+        description: 'Need a licensed electrician to safely rewire three kitchen outlets.',
+        budget: 400,
+        categoryId,
+        escrowAmount: 400,
+      })
+
+    expect(res.status).toBe(201)
+    expect(res.body.data.status).toBe('open')
+    expect(res.body.data.postedBy.id).toBe(posterId)
+    jobId = res.body.data.id
+  })
+
+  it('the job is visible in the public open-jobs listing', async () => {
+    const res = await request(app).get('/api/jobs')
+    expect(res.status).toBe(200)
+    const ids = res.body.data.map((j: any) => j.id)
+    expect(ids).toContain(jobId)
+  })
+
+  // ── 2. Submit application ────────────────────────────────────────────────
+  it('worker submits an application → 201, status=pending, job stays open', async () => {
+    const res = await request(app)
+      .post(`/api/jobs/${jobId}/apply`)
+      .set('Authorization', `Bearer ${curatorToken}`)
+      .send({
+        workerId,
+        coverLetter: 'I have ten years of residential electrical experience.',
+        proposedRate: 380,
+      })
+
+    expect(res.status).toBe(201)
+    expect(res.body.data.status).toBe('pending')
+    expect(res.body.data.workerId).toBe(workerId)
+    applicationId = res.body.data.id
+
+    const jobRes = await request(app).get(`/api/jobs/${jobId}`)
+    expect(jobRes.body.data.status).toBe('open')
+  })
+
+  it('a duplicate application for the same worker is rejected → 409', async () => {
+    const res = await request(app)
+      .post(`/api/jobs/${jobId}/apply`)
+      .set('Authorization', `Bearer ${curatorToken}`)
+      .send({ workerId, coverLetter: 'Reapplying just in case, this cover letter is long enough.' })
+    expect(res.status).toBe(409)
+  })
+
+  // ── 3. Hire ──────────────────────────────────────────────────────────────
+  it('poster accepts the application → application accepted, job transitions to filled', async () => {
+    const res = await request(app)
+      .patch(`/api/jobs/${jobId}/applications/${applicationId}`)
+      .set('Authorization', `Bearer ${posterToken}`)
+      .send({ status: 'accepted' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('accepted')
+
+    const jobRes = await request(app).get(`/api/jobs/${jobId}`)
+    expect(jobRes.body.data.status).toBe('filled')
+  })
+
+  // ── 4. Fund escrow ───────────────────────────────────────────────────────
+  it('poster creates an escrow for the job → 201, status=pending', async () => {
+    const res = await request(app)
+      .post('/api/escrow')
+      .set('Authorization', `Bearer ${posterToken}`)
+      .send({ jobId, payeeId: curatorId, amountXlm: 380, expiresAt: futureIso() })
+
+    expect(res.status).toBe(201)
+    expect(res.body.data.status).toBe('pending')
+    expect(res.body.data.jobId).toBe(jobId)
+    escrowId = res.body.data.id
+  })
+
+  it('poster activates (funds) the escrow → status=active', async () => {
+    const res = await request(app)
+      .patch(`/api/escrow/${escrowId}/activate`)
+      .set('Authorization', `Bearer ${posterToken}`)
+      .send({ txId: `tx-lifecycle-${escrowId}` })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('active')
+
+    const record = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+    expect(record!.status).toBe('active')
+  })
+
+  // ── 5. Mark work complete ────────────────────────────────────────────────
+  it('poster marks the job complete → status=closed', async () => {
+    const res = await request(app)
+      .put(`/api/jobs/${jobId}`)
+      .set('Authorization', `Bearer ${posterToken}`)
+      .send({ status: 'closed' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('closed')
+
+    const jobRes = await request(app).get(`/api/jobs/${jobId}`)
+    expect(jobRes.body.data.status).toBe('closed')
+  })
+
+  // ── 6. Submit review ─────────────────────────────────────────────────────
+  it('poster submits a review for the worker → 201, status=pending moderation', async () => {
+    const res = await request(app)
+      .post(`/api/workers/${workerId}/reviews`)
+      .set('Authorization', `Bearer ${posterToken}`)
+      .send({ rating: 5, comment: 'Rewired the kitchen perfectly, on time and tidy.' })
+
+    expect(res.status).toBe(201)
+    expect(res.body.data.rating).toBe(5)
+    expect(res.body.data.status).toBe('pending')
+    reviewId = res.body.data.id
+  })
+
+  it('the escrow is unaffected by review submission — still active', async () => {
+    const record = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+    expect(record!.status).toBe('active')
+  })
+
+  // ── 7. Confirm payout ────────────────────────────────────────────────────
+  it('poster releases the escrow → payout confirmed, status=released', async () => {
+    const res = await request(app)
+      .patch(`/api/escrow/${escrowId}/release`)
+      .set('Authorization', `Bearer ${posterToken}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('released')
+    expect(res.body.data.releasedAt).toBeTruthy()
+
+    const record = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+    expect(record!.status).toBe('released')
+    expect(record!.jobId).toBe(jobId)
+  })
+
+  // ── Final state check across the whole chain ─────────────────────────────
+  it('reflects the fully completed journey across job, application, escrow, and review', async () => {
+    const [job, application, escrow, review] = await Promise.all([
+      db.job.findUnique({ where: { id: jobId } }),
+      db.jobApplication.findUnique({ where: { id: applicationId } }),
+      db.escrowRecord.findUnique({ where: { id: escrowId } }),
+      db.review.findUnique({ where: { id: reviewId } }),
+    ])
+
+    expect(job!.status).toBe('closed')
+    expect(application!.status).toBe('accepted')
+    expect(escrow!.status).toBe('released')
+    expect(escrow!.jobId).toBe(jobId)
+    expect(review!.rating).toBe(5)
+    expect(review!.workerId).toBe(workerId)
+  })
+})

--- a/packages/api/src/__tests__/e2e/payment.e2e.test.ts
+++ b/packages/api/src/__tests__/e2e/payment.e2e.test.ts
@@ -1,0 +1,296 @@
+/**
+ * E2E tests for the payment lifecycle using Supertest against the real Express app.
+ *
+ * Covers two layers of "payment" in this codebase:
+ *
+ *  1. The stateless payment utilities exposed at /api/payments — tip fee
+ *     deduction and platform fee configuration
+ *     (services/payment.service.ts + controllers/payment.ts).
+ *
+ *  2. The persisted, stateful payment record that actually moves funds through a
+ *     capture → release → refund cycle: an escrow, exposed at /api/escrow
+ *     (services/escrow.service.ts via contracts.service.ts). This codebase has
+ *     no separate "payments" table with its own release/refund routes — the
+ *     escrow record IS the stateful payment resource — so the capture/release/
+ *     refund cycle required for this suite is exercised through it:
+ *       capture = create + activate (funds locked)
+ *       release = pay out to the payee
+ *       refund  = cancel back to the payer
+ *
+ * Complements escrow.e2e.test.ts (which drills into the dispute flow in
+ * isolation) by chaining the payment side of a transaction end-to-end and
+ * explicitly asserting the failure paths a payment API must reject: releasing
+ * or refunding a payment twice must error, never silently succeed.
+ *
+ * Requires a live test database (TEST_DATABASE_URL env var).
+ * Run: pnpm --filter @bluecollar/api exec vitest run src/__tests__/e2e/payment.e2e.test.ts
+ */
+
+import { describe, it, expect, beforeAll, vi } from 'vitest'
+import request from 'supertest'
+import { db } from '../../db.js'
+import app from '../../app.js'
+
+vi.mock('../../mailer/transport.js', () => ({
+  transporter: { sendMail: vi.fn().mockResolvedValue({ messageId: 'mock' }) },
+}))
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function createVerifiedUser(email: string, role: 'user' | 'curator' | 'admin' = 'user') {
+  const argon2 = await import('argon2')
+  return db.user.create({
+    data: {
+      email,
+      password: await argon2.hash('Password123!'),
+      firstName: 'Test',
+      lastName: 'User',
+      role,
+      verified: true,
+    },
+  })
+}
+
+async function loginAs(email: string): Promise<string> {
+  const res = await request(app).post('/api/auth/login').send({ email, password: 'Password123!' })
+  return res.body.token as string
+}
+
+function futureIso(msFromNow = 60 * 60 * 1000): string {
+  return new Date(Date.now() + msFromNow).toISOString()
+}
+
+/** Create an escrow and immediately activate it, i.e. "capture" the payment. */
+async function captureEscrow(payerToken: string, payeeId: string, amountXlm = 200) {
+  const created = await request(app)
+    .post('/api/escrow')
+    .set('Authorization', `Bearer ${payerToken}`)
+    .send({ payeeId, amountXlm, expiresAt: futureIso() })
+  const escrowId = created.body.data.id as string
+
+  await request(app)
+    .patch(`/api/escrow/${escrowId}/activate`)
+    .set('Authorization', `Bearer ${payerToken}`)
+    .send({ txId: `tx-payment-${escrowId}` })
+
+  return escrowId
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+let payerToken: string
+let payerId: string
+let payeeToken: string
+let payeeId: string
+let adminToken: string
+
+describe('Payment E2E', () => {
+  beforeAll(async () => {
+    const payer = await createVerifiedUser('payment-payer@e2e.com')
+    const payee = await createVerifiedUser('payment-payee@e2e.com')
+    const admin = await createVerifiedUser('payment-admin@e2e.com', 'admin')
+
+    payerId = payer.id
+    payeeId = payee.id
+
+    payerToken = await loginAs('payment-payer@e2e.com')
+    payeeToken = await loginAs('payment-payee@e2e.com')
+    adminToken = await loginAs('payment-admin@e2e.com')
+  })
+
+  // ── Platform fee configuration ───────────────────────────────────────────
+  describe('GET/PATCH /api/payments/fee', () => {
+    it('returns the current platform fee without auth', async () => {
+      const res = await request(app).get('/api/payments/fee')
+      expect(res.status).toBe(200)
+      expect(typeof res.body.data.fee_bps).toBe('number')
+    })
+
+    it('rejects a fee update from a non-admin → 403', async () => {
+      const res = await request(app)
+        .patch('/api/payments/fee')
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ fee_bps: 500 })
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 401 when updating the fee without auth', async () => {
+      const res = await request(app).patch('/api/payments/fee').send({ fee_bps: 500 })
+      expect(res.status).toBe(401)
+    })
+
+    it('allows an admin to update the fee, and the new rate is reflected in tip calculations', async () => {
+      const updateRes = await request(app)
+        .patch('/api/payments/fee')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ fee_bps: 1000 }) // 10%
+      expect(updateRes.status).toBe(200)
+      expect(updateRes.body.data.fee_bps).toBe(1000)
+
+      const tipRes = await request(app)
+        .post('/api/payments/tip')
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ from: payerId, to: payeeId, amount: 1000 })
+      expect(tipRes.status).toBe(200)
+      expect(tipRes.body.data.fee).toBe(100) // 10% of 1000
+      expect(tipRes.body.data.netAmount).toBe(900)
+
+      // Restore the default fee so it doesn't affect the tests below.
+      const restoreRes = await request(app)
+        .patch('/api/payments/fee')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ fee_bps: 250 })
+      expect(restoreRes.body.data.fee_bps).toBe(250)
+    })
+  })
+
+  // ── Tip capture ───────────────────────────────────────────────────────────
+  describe('POST /api/payments/tip', () => {
+    it('captures a tip and deducts the platform fee → 200 with fee breakdown', async () => {
+      const res = await request(app)
+        .post('/api/payments/tip')
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ from: payerId, to: payeeId, amount: 400 })
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.grossAmount).toBe(400)
+      expect(res.body.data.fee).toBe(10) // default 250 bps = 2.5% of 400
+      expect(res.body.data.netAmount).toBe(390)
+    })
+
+    it('returns 400 for a non-positive amount', async () => {
+      const res = await request(app)
+        .post('/api/payments/tip')
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ from: payerId, to: payeeId, amount: 0 })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when sender and recipient are the same', async () => {
+      const res = await request(app)
+        .post('/api/payments/tip')
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ from: payerId, to: payerId, amount: 100 })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 401 without auth', async () => {
+      const res = await request(app).post('/api/payments/tip').send({ from: payerId, to: payeeId, amount: 100 })
+      expect(res.status).toBe(401)
+    })
+  })
+
+  // ── Capture → release cycle ──────────────────────────────────────────────
+  describe('Payment capture → release cycle', () => {
+    it('captures funds into escrow (create + activate) → status=active', async () => {
+      const created = await request(app)
+        .post('/api/escrow')
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ payeeId, amountXlm: 250, expiresAt: futureIso() })
+      expect(created.status).toBe(201)
+      expect(created.body.data.status).toBe('pending')
+      const escrowId = created.body.data.id
+
+      const activated = await request(app)
+        .patch(`/api/escrow/${escrowId}/activate`)
+        .set('Authorization', `Bearer ${payerToken}`)
+        .send({ txId: `tx-capture-${escrowId}` })
+      expect(activated.status).toBe(200)
+      expect(activated.body.data.status).toBe('active')
+    })
+
+    it('releases a captured payment to the payee → status=released', async () => {
+      const escrowId = await captureEscrow(payerToken, payeeId)
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('released')
+      expect(res.body.data.releasedAt).toBeTruthy()
+    })
+
+    it('releasing an already-released payment errors instead of silently succeeding', async () => {
+      const escrowId = await captureEscrow(payerToken, payeeId)
+      const first = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(first.status).toBe(200)
+
+      const second = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(second.status).toBe(400)
+
+      // The underlying record must reflect exactly one release; the second
+      // call must not have silently re-applied it or cleared releasedAt.
+      const record = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+      expect(record!.status).toBe('released')
+    })
+
+    it('a non-payer cannot release a captured payment → 403', async () => {
+      const escrowId = await captureEscrow(payerToken, payeeId)
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payeeToken}`)
+      expect(res.status).toBe(403)
+    })
+  })
+
+  // ── Capture → refund cycle ───────────────────────────────────────────────
+  describe('Payment capture → refund cycle', () => {
+    it('rejects a refund attempted before the lock period elapses → 400', async () => {
+      const escrowId = await captureEscrow(payerToken, payeeId)
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('refunds a captured payment back to the payer once the lock period elapses → status=cancelled', async () => {
+      const escrowId = await captureEscrow(payerToken, payeeId)
+      await db.escrowRecord.update({ where: { id: escrowId }, data: { expiresAt: new Date(Date.now() - 60_000) } })
+
+      const res = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('cancelled')
+      expect(res.body.data.cancelledAt).toBeTruthy()
+    })
+
+    it('refunding an already-released payment errors instead of silently succeeding', async () => {
+      const escrowId = await captureEscrow(payerToken, payeeId)
+      const release = await request(app)
+        .patch(`/api/escrow/${escrowId}/release`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(release.status).toBe(200)
+
+      const refund = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(refund.status).toBe(400)
+
+      const record = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+      expect(record!.status).toBe('released')
+    })
+
+    it('refunding an already-refunded payment errors instead of silently succeeding', async () => {
+      const escrowId = await captureEscrow(payerToken, payeeId)
+      await db.escrowRecord.update({ where: { id: escrowId }, data: { expiresAt: new Date(Date.now() - 60_000) } })
+
+      const first = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(first.status).toBe(200)
+
+      const second = await request(app)
+        .patch(`/api/escrow/${escrowId}/cancel`)
+        .set('Authorization', `Bearer ${payerToken}`)
+      expect(second.status).toBe(400)
+
+      const record = await db.escrowRecord.findUnique({ where: { id: escrowId } })
+      expect(record!.status).toBe('cancelled')
+    })
+  })
+})

--- a/packages/api/src/__tests__/integration/QUARANTINE.md
+++ b/packages/api/src/__tests__/integration/QUARANTINE.md
@@ -53,6 +53,8 @@ test database via `pnpm test:e2e`.
 | `e2e/escrow.e2e.test.ts` | Timing: escrow expiry relies on wall-clock `setTimeout` |
 | `e2e/two-factor.e2e.test.ts` | TOTP window — passes if run within 30 s, fails otherwise |
 | `e2e/reviews.e2e.test.ts` | Depends on worker created in same run's prior describe |
+| `e2e/job-lifecycle.e2e.test.ts` | Chains job → application → escrow → review across sequential `it` blocks sharing outer `let` state — order-dependent by design (issue: full-journey coverage) |
+| `e2e/payment.e2e.test.ts` | Chains escrow capture → release/refund across sequential `it` blocks sharing outer `let` state; also mutates the shared `paymentService` fee singleton — order-dependent by design (issue: full-journey coverage) |
 
 These files are **not deleted** — they represent valid acceptance tests. They are quarantined
 from the unit/integration test run to prevent CI failures unrelated to code changes.


### PR DESCRIPTION
Existing API-level E2E specs cover auth, bookings, disputes, escrow, messaging,
notifications, reviews, two-factor, and workers — but each tests its own slice in
isolation. There is no single test that chains the full user journey: post job → worker
applies → hire → escrow funded → work completed → review submitted → payout confirmed. This
is the core business flow of the product and currently only exists fragmented across
bookings.e2e.test.ts / escrow.e2e.test.ts / reviews.e2e.test.ts.

Separately, only escrow.e2e.test.ts exists — there is no payment.e2e.test.ts despite
services/payment.service.ts and controllers/payment.ts existing and the frontend having
its own payment.spec.ts. The full payment capture/release/refund cycle is untested via the
API.
closes #1161 