### PR TITLE
test(contracts): add cross-contract dispute, insurance, and reputatio…

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,44 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  commits:
+    name: Lint commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.js
+
+  pr-title:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+    steps:
+      # Squash merges use the PR title as the commit subject on main, so it
+      # never passes through the commit-msg hook or the job above.
+      # Check out the base ref so the config comes from trusted code, not the PR.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli@^18.4.0 @commitlint/config-conventional@^18.4.0
+
+      - name: Lint PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s' "$PR_TITLE" | npx --no -- commitlint

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ This project uses [commitlint](https://commitlint.js.org/) to enforce the conven
 
 - **Local hook**: A `commit-msg` hook is installed via `pnpm prepare` (runs automatically after `pnpm install`). It validates every commit message against the rules in `commitlint.config.js` before allowing the commit.
 - **Manual check**: Run `pnpm commitlint` to validate the last commit message, or `npx commitlint --edit <file>` to validate a specific message file.
-- **CI**: The hook prevents malformed commits locally; CI does not need a separate commitlint step.
+- **CI**: The `Commit Lint` workflow re-checks every commit in a pull request, so messages that bypass the local hook (`--no-verify`, commits made in the GitHub web UI, or a clone where `pnpm install` was never run) still fail the PR. It is a required check, not advisory.
+- **PR title**: Pull requests are squash merged, so the PR title becomes the commit subject on `main`. It is linted by the same rules and must follow the convention too.
 
 If a commit is rejected with a commitlint error, fix the message and re-commit:
 

--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -238,6 +238,15 @@ dependencies = [
 name = "bluecollar-dispute"
 version = "0.1.0"
 dependencies = [
+ "bluecollar-types",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "bluecollar-escrow"
+version = "0.1.0"
+dependencies = [
+ "bluecollar-types",
  "soroban-sdk",
 ]
 
@@ -254,7 +263,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "bluecollar-integration"
+version = "0.1.0"
+dependencies = [
+ "bluecollar-dispute",
+ "bluecollar-escrow",
+ "bluecollar-market",
+ "bluecollar-registry",
+ "bluecollar-reputation",
+ "bluecollar_insurance_pool",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "bluecollar-job-registry"
+version = "0.1.0"
+dependencies = [
+ "bluecollar-types",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "bluecollar-market"
+version = "0.1.0"
+dependencies = [
+ "bluecollar-types",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "bluecollar-payment"
 version = "0.1.0"
 dependencies = [
  "bluecollar-types",
@@ -265,6 +303,15 @@ dependencies = [
 name = "bluecollar-registry"
 version = "0.1.0"
 dependencies = [
+ "bluecollar-types",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "bluecollar-reputation"
+version = "0.1.0"
+dependencies = [
+ "bluecollar-types",
  "soroban-sdk",
 ]
 
@@ -279,6 +326,7 @@ dependencies = [
 name = "bluecollar_fee_distribution"
 version = "0.1.0"
 dependencies = [
+ "bluecollar-types",
  "soroban-sdk",
 ]
 
@@ -286,6 +334,7 @@ dependencies = [
 name = "bluecollar_insurance_pool"
 version = "0.1.0"
 dependencies = [
+ "bluecollar-types",
  "soroban-sdk",
 ]
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -93,6 +93,29 @@ cd packages/contracts
 cargo test --workspace
 ```
 
+### Cross-Contract Integration Tests
+
+Per-contract tests live in each crate's `src/test.rs` and cover that contract alone. Tests that
+chain two or more contracts together live in `contracts/integration/tests/`, run against the
+in-process Soroban testnet, and deploy fresh instances per test. Shared deployment helpers are in
+`tests/common/mod.rs`; add new ones there rather than duplicating setup per file.
+
+| File | Flow covered |
+| --- | --- |
+| `e2e.rs` | Registry worker registration and status toggling; market tips with fee split; market escrow create and release; register a worker then tip them |
+| `dispute_flow.rs` | Dispute filed on locked funds, evidence from both parties, arbitrator decides a split, settlement pays each side its share; market escrow arbitration driven by the dispute contract's ruling; escrow contract dispute resolved against the worker refunds the depositor |
+| `insurance_flow.rs` | Escrowed job lost at arbitration, the covered party files an insurance claim, the claims manager approves and pays it, pool balance and claim totals reconcile |
+| `reputation_flow.rs` | Completed escrow jobs feed reviews that raise a worker's score and earn a badge; a dispute resolved against the worker slashes the score and revokes the badge |
+
+Run one flow at a time with:
+
+```bash
+cargo test -p bluecollar-integration --test dispute_flow
+```
+
+When adding a cross-contract scenario, extend the matching file if the flow fits an existing area,
+or add a new `*_flow.rs` file plus a row in this table.
+
 ### Fuzz Testing
 
 The `fuzz` crate includes property-based tests using `proptest` that verify critical contract invariants

--- a/packages/contracts/contracts/dispute/Cargo.toml
+++ b/packages/contracts/contracts/dispute/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+# "rlib" lets the integration test crate link this contract as a Rust dependency.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "26.1.0", features = ["alloc"] }

--- a/packages/contracts/contracts/dispute/src/storage.rs
+++ b/packages/contracts/contracts/dispute/src/storage.rs
@@ -129,7 +129,7 @@ pub fn get_arbitrators(env: &Env) -> Vec<Address> {
     env.storage()
         .persistent()
         .get(&DataKey::Arbitrators)
-        .unwrap_or_else(|_| Vec::new(env))
+        .unwrap_or_else(|| Vec::new(env))
 }
 
 /// Write arbitrators list. Optimized to avoid redundant operations.
@@ -169,7 +169,7 @@ pub fn get_dispute_list(env: &Env) -> Vec<Symbol> {
     env.storage()
         .persistent()
         .get(&DataKey::DisputeList)
-        .unwrap_or_else(|_| Vec::new(env))
+        .unwrap_or_else(|| Vec::new(env))
 }
 
 /// Append a dispute id to the ordered list and extend its TTL.
@@ -179,7 +179,7 @@ pub fn push_dispute_id(env: &Env, id: &Symbol) {
     let mut list = get_dispute_list(env);
 
     // Only push if not already present (idempotent and prevents duplicates)
-    if !list.iter().any(|x| x == id) {
+    if !list.iter().any(|x| x == *id) {
         list.push_back(id.clone());
         env.storage().persistent().set(&key, &list);
         // TTL extension immediately after write

--- a/packages/contracts/contracts/escrow/src/storage.rs
+++ b/packages/contracts/contracts/escrow/src/storage.rs
@@ -111,7 +111,7 @@ pub fn load_escrow_list(env: &Env) -> Vec<Symbol> {
     env.storage()
         .persistent()
         .get(&DataKey::EscrowList)
-        .unwrap_or_else(|_| Vec::new(env))
+        .unwrap_or_else(|| Vec::new(env))
 }
 
 /// Write the global escrow id list and extend its TTL.
@@ -146,7 +146,7 @@ pub fn load_role_members(env: &Env, role_id: u64) -> Vec<Address> {
     env.storage()
         .persistent()
         .get(&DataKey::RoleMembers(role_id))
-        .unwrap_or_else(|_| Vec::new(env))
+        .unwrap_or_else(|| Vec::new(env))
 }
 
 /// Write the role member list and extend its TTL.

--- a/packages/contracts/contracts/insurance_pool/Cargo.toml
+++ b/packages/contracts/contracts/insurance_pool/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+# "rlib" lets the integration test crate link this contract as a Rust dependency.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "26.1.0", features = ["alloc"] }

--- a/packages/contracts/contracts/integration/Cargo.toml
+++ b/packages/contracts/contracts/integration/Cargo.toml
@@ -13,6 +13,10 @@ name = "bluecollar_integration"
 soroban-sdk = { version = "26.1.0", features = ["testutils"] }
 bluecollar-registry = { path = "../registry" }
 bluecollar-market   = { path = "../market" }
+bluecollar-dispute  = { path = "../dispute" }
+bluecollar-escrow   = { path = "../escrow" }
+bluecollar-reputation = { path = "../reputation" }
+bluecollar_insurance_pool = { path = "../insurance_pool" }
 
 [dev-dependencies]
 soroban-sdk = { version = "26.1.0", features = ["testutils"] }

--- a/packages/contracts/contracts/integration/tests/common/mod.rs
+++ b/packages/contracts/contracts/integration/tests/common/mod.rs
@@ -1,0 +1,113 @@
+//! Shared deployment helpers for the integration test crate.
+//!
+//! Every test file in `tests/` deploys fresh contract instances against the
+//! in-process Soroban testnet, so helpers here only wrap `register` +
+//! `initialize`; they hold no assertions of their own.
+
+#![allow(dead_code)] // each test file uses a different subset of these helpers
+
+use soroban_sdk::{token, Address, BytesN, Env, Symbol};
+
+use bluecollar_dispute::{DisputeContract, DisputeContractClient};
+use bluecollar_escrow::{EscrowContract, EscrowContractClient};
+use bluecollar_insurance_pool::{InsurancePoolContract, InsurancePoolContractClient};
+use bluecollar_market::{MarketContract, MarketContractClient};
+use bluecollar_registry::{RegistryContract, RegistryContractClient};
+use bluecollar_reputation::{ReputationContract, ReputationContractClient};
+
+pub fn zero_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0u8; 32])
+}
+
+/// Deploy a Stellar asset contract and mint `amount` to `to`.
+pub fn deploy_token<'a>(env: &Env, admin: &Address, to: &Address, amount: i128) -> token::Client<'a> {
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    token::StellarAssetClient::new(env, &sac.address()).mint(to, &amount);
+    token::Client::new(env, &sac.address())
+}
+
+/// Mint `amount` of an existing token to `to`.
+pub fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    token::StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+pub fn deploy_registry<'a>(env: &Env, admin: &Address) -> RegistryContractClient<'a> {
+    let id = env.register_contract(None, RegistryContract);
+    let client = RegistryContractClient::new(env, &id);
+    client.initialize(admin);
+    // `initialize` only bootstraps ROLE_ADMIN; curator management is a separate role.
+    client.grant_role(
+        admin,
+        &Symbol::new(env, bluecollar_registry::ROLE_CURATOR_MGR),
+        admin,
+    );
+    client
+}
+
+pub fn deploy_market<'a>(
+    env: &Env,
+    admin: &Address,
+    fee_bps: u32,
+    fee_recipient: &Address,
+) -> MarketContractClient<'a> {
+    let id = env.register_contract(None, MarketContract);
+    let client = MarketContractClient::new(env, &id);
+    client.initialize(admin, &fee_bps, fee_recipient);
+    client
+}
+
+pub fn deploy_escrow<'a>(env: &Env, admin: &Address) -> EscrowContractClient<'a> {
+    let id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(env, &id);
+    client.initialize(admin);
+    client
+}
+
+/// Deploy the dispute contract and approve `arbitrator` to decide cases.
+pub fn deploy_dispute<'a>(
+    env: &Env,
+    admin: &Address,
+    arbitrator: &Address,
+) -> DisputeContractClient<'a> {
+    let id = env.register_contract(None, DisputeContract);
+    let client = DisputeContractClient::new(env, &id);
+    client.initialize(admin);
+    client.add_arbitrator(admin, arbitrator);
+    client
+}
+
+/// Deploy the insurance pool and grant `claims_mgr` the claims-manager role.
+pub fn deploy_insurance_pool<'a>(
+    env: &Env,
+    admin: &Address,
+    token: &Address,
+    premium_bps: u32,
+    claims_mgr: &Address,
+) -> InsurancePoolContractClient<'a> {
+    let id = env.register_contract(None, InsurancePoolContract);
+    let client = InsurancePoolContractClient::new(env, &id);
+    client.initialize(admin, token, &premium_bps);
+    client.grant_role(
+        admin,
+        &Symbol::new(env, bluecollar_insurance_pool::ROLE_CLAIMS_MGR),
+        claims_mgr,
+    );
+    client
+}
+
+/// Deploy the reputation contract and grant `rep_mgr` the reputation-manager role.
+pub fn deploy_reputation<'a>(
+    env: &Env,
+    admin: &Address,
+    rep_mgr: &Address,
+) -> ReputationContractClient<'a> {
+    let id = env.register_contract(None, ReputationContract);
+    let client = ReputationContractClient::new(env, &id);
+    client.initialize(admin);
+    client.grant_role(
+        admin,
+        &Symbol::new(env, bluecollar_reputation::ROLE_REP_MGR),
+        rep_mgr,
+    );
+    client
+}

--- a/packages/contracts/contracts/integration/tests/dispute_flow.rs
+++ b/packages/contracts/contracts/integration/tests/dispute_flow.rs
@@ -1,0 +1,159 @@
+//! Cross-contract dispute resolution flows.
+//!
+//! Covers the chain the per-contract unit tests cannot: an active escrow is
+//! disputed, evidence is attached, an arbitrator decides, and the payout that
+//! follows is checked against that decision.
+//!
+//! Run:
+//!   cargo test -p bluecollar-integration --test dispute_flow
+
+#![cfg(test)]
+
+mod common;
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
+
+use bluecollar_dispute::{DisputeOutcome, DisputeStatus};
+
+use common::{deploy_dispute, deploy_escrow, deploy_market, deploy_token};
+
+// === Dispute contract: file -> evidence -> decide -> settle
+
+#[test]
+fn dispute_split_decision_splits_locked_funds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let worker = Address::generate(&env);
+
+    let token = deploy_token(&env, &admin, &payer, 100_000);
+    let dispute = deploy_dispute(&env, &admin, &arbitrator);
+
+    let id = Symbol::new(&env, "dsp_split");
+    dispute.file_dispute(
+        &id,
+        &payer,
+        &worker,
+        &token.address,
+        &10_000,
+        &String::from_str(&env, "ipfs://payer-evidence"),
+    );
+
+    // Funds leave the payer and sit in the dispute contract until settlement.
+    assert_eq!(token.balance(&payer), 90_000);
+    assert_eq!(token.balance(&dispute.address), 10_000);
+
+    dispute.submit_evidence(&id, &worker, &String::from_str(&env, "ipfs://worker-evidence"));
+    assert_eq!(dispute.get_dispute(&id).unwrap().status, DisputeStatus::Evidence);
+
+    // 60% to the worker, remainder back to the payer.
+    dispute.decide(&id, &arbitrator, &DisputeOutcome::Split, &6_000);
+    dispute.settle(&id);
+
+    assert_eq!(token.balance(&worker), 6_000);
+    assert_eq!(token.balance(&payer), 94_000);
+    assert_eq!(token.balance(&dispute.address), 0);
+
+    let record = dispute.get_dispute(&id).unwrap();
+    assert_eq!(record.status, DisputeStatus::Settled);
+    assert_eq!(record.outcome, DisputeOutcome::Split);
+    assert_eq!(record.arbitrator, Some(arbitrator));
+    assert!(record.disputer_evidence.is_some());
+    assert!(record.respondent_evidence.is_some());
+}
+
+// === Market escrow payout driven by the dispute contract's decision
+
+#[test]
+fn market_escrow_payout_follows_arbitrator_decision() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let worker = Address::generate(&env);
+
+    let token = deploy_token(&env, &admin, &payer, 100_000);
+    let market = deploy_market(&env, &admin, 0, &admin);
+    let dispute = deploy_dispute(&env, &admin, &arbitrator);
+
+    // Job funds locked in market escrow.
+    let escrow_id = Symbol::new(&env, "job_esc");
+    let expiry = env.ledger().timestamp() + 86_400;
+    market.create_escrow(&escrow_id, &payer, &worker, &token.address, &40_000, &expiry);
+    assert_eq!(token.balance(&payer), 60_000);
+
+    // Payer raises the dispute on the active escrow and pays the arbitration fee.
+    market.add_arbitrator(&arbitrator);
+    market.request_arbitration(&escrow_id, &payer, &arbitrator, &1_000);
+    assert_eq!(token.balance(&arbitrator), 1_000);
+
+    // The dispute contract carries the evidence and the ruling; the filing
+    // bond is separate from the escrowed job funds.
+    let dispute_id = Symbol::new(&env, "job_dsp");
+    dispute.file_dispute(
+        &dispute_id,
+        &payer,
+        &worker,
+        &token.address,
+        &2_000,
+        &String::from_str(&env, "ipfs://payer-evidence"),
+    );
+    dispute.submit_evidence(
+        &dispute_id,
+        &worker,
+        &String::from_str(&env, "ipfs://worker-evidence"),
+    );
+    dispute.decide(&dispute_id, &arbitrator, &DisputeOutcome::ReleaseRespondent, &0);
+    dispute.settle(&dispute_id);
+
+    // Bond follows the ruling: worker takes it.
+    assert_eq!(token.balance(&worker), 2_000);
+
+    // The escrow payout is then adjusted to match that same ruling.
+    let outcome = dispute.get_dispute(&dispute_id).unwrap().outcome;
+    let release_to_worker = outcome == DisputeOutcome::ReleaseRespondent;
+    market.resolve_arbitration(&escrow_id, &arbitrator, &release_to_worker);
+
+    assert_eq!(token.balance(&worker), 42_000);
+    assert_eq!(token.balance(&payer), 57_000);
+    assert_eq!(token.balance(&market.address), 0);
+
+    let escrow = market.get_escrow(&escrow_id).unwrap();
+    assert!(escrow.released);
+    assert!(market.get_arbitration(&escrow_id).unwrap().resolved);
+}
+
+// === Escrow contract: dispute resolved against the worker refunds the payer
+
+#[test]
+fn escrow_dispute_resolved_against_worker_refunds_depositor() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let worker = Address::generate(&env);
+
+    let token = deploy_token(&env, &admin, &payer, 100_000);
+    let escrow = deploy_escrow(&env, &admin);
+    escrow.grant_role(&admin, &Symbol::new(&env, "arbitrator"), &arbitrator);
+
+    let id = Symbol::new(&env, "esc_dsp");
+    let expiry = env.ledger().timestamp() + 86_400;
+    escrow.create_escrow(&payer, &worker, &token.address, &id, &25_000, &expiry);
+    assert_eq!(token.balance(&payer), 75_000);
+
+    // Worker disputes, arbitrator rules for the payer.
+    escrow.dispute_escrow(&worker, &id);
+    escrow.resolve_dispute(&arbitrator, &id, &false);
+
+    assert_eq!(token.balance(&payer), 100_000);
+    assert_eq!(token.balance(&worker), 0);
+    assert_eq!(token.balance(&escrow.address), 0);
+}

--- a/packages/contracts/contracts/integration/tests/e2e.rs
+++ b/packages/contracts/contracts/integration/tests/e2e.rs
@@ -13,48 +13,11 @@
 
 #![cfg(test)]
 
-use soroban_sdk::{
-    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger},
-    token, Address, BytesN, Env, String, Symbol,
-};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
 
-use bluecollar_registry::RegistryContractClient;
-use bluecollar_market::MarketContractClient;
+mod common;
 
-// ── helpers ───────────────────────────────────────────────────────────────────
-
-fn zero_hash(env: &Env) -> BytesN<32> {
-    BytesN::from_array(env, &[0u8; 32])
-}
-
-/// Deploy and initialise a fresh Registry contract.
-fn deploy_registry(env: &Env, admin: &Address) -> RegistryContractClient {
-    let contract_id = env.register_contract(None, bluecollar_registry::RegistryContract);
-    let client = RegistryContractClient::new(env, &contract_id);
-    client.initialize(admin);
-    client
-}
-
-/// Deploy a mock token (soroban-sdk built-in) and mint `amount` to `to`.
-fn deploy_token(env: &Env, admin: &Address, to: &Address, amount: i128) -> token::Client {
-    let token_id = env.register_stellar_asset_contract(admin.clone());
-    let admin_client = token::StellarAssetClient::new(env, &token_id);
-    admin_client.mint(to, &amount);
-    token::Client::new(env, &token_id)
-}
-
-/// Deploy and initialise a fresh Market contract.
-fn deploy_market(
-    env: &Env,
-    admin: &Address,
-    fee_bps: u32,
-    fee_recipient: &Address,
-) -> MarketContractClient {
-    let contract_id = env.register_contract(None, bluecollar_market::MarketContract);
-    let client = MarketContractClient::new(env, &contract_id);
-    client.initialize(admin, &fee_bps, fee_recipient);
-    client
-}
+use common::{deploy_market, deploy_registry, deploy_token, zero_hash};
 
 // ── Registry integration tests ────────────────────────────────────────────────
 
@@ -85,7 +48,7 @@ fn registry_register_and_get_worker() {
     );
 
     // Assert worker exists and is active
-    let worker = registry.get_worker(&id);
+    let worker = registry.get_worker(&id).unwrap();
     assert_eq!(worker.id, id);
     assert!(worker.is_active);
     assert_eq!(worker.owner, owner);
@@ -116,12 +79,12 @@ fn registry_toggle_active_status() {
 
     // Toggle off
     registry.toggle(&id, &owner);
-    let w = registry.get_worker(&id);
+    let w = registry.get_worker(&id).unwrap();
     assert!(!w.is_active);
 
     // Toggle back on
     registry.toggle(&id, &owner);
-    let w2 = registry.get_worker(&id);
+    let w2 = registry.get_worker(&id).unwrap();
     assert!(w2.is_active);
 }
 
@@ -268,7 +231,7 @@ fn register_worker_then_tip_end_to_end() {
     );
 
     // Verify worker is on-chain and active
-    let w = registry.get_worker(&worker_id);
+    let w = registry.get_worker(&worker_id).unwrap();
     assert!(w.is_active);
 
     // Tip the worker's wallet address

--- a/packages/contracts/contracts/integration/tests/insurance_flow.rs
+++ b/packages/contracts/contracts/integration/tests/insurance_flow.rs
@@ -1,0 +1,97 @@
+//! Insurance pool claims tied to a real job outcome.
+//!
+//! The per-contract tests exercise contribute/claim/payout in isolation. This
+//! file drives the pool from an actual escrowed job that was lost at
+//! arbitration, and checks the payout amount against the pool's own accounting.
+//!
+//! Run:
+//!   cargo test -p bluecollar-integration --test insurance_flow
+
+#![cfg(test)]
+
+mod common;
+
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String, Symbol};
+
+use bluecollar_dispute::DisputeOutcome;
+
+use common::{deploy_dispute, deploy_escrow, deploy_insurance_pool, deploy_token, mint};
+
+#[test]
+fn job_lost_at_arbitration_pays_out_an_insurance_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    let claims_mgr = Address::generate(&env);
+    let underwriter = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let worker = Address::generate(&env);
+
+    let token = deploy_token(&env, &admin, &payer, 100_000);
+    mint(&env, &token.address, &underwriter, 100_000);
+
+    let escrow = deploy_escrow(&env, &admin);
+    escrow.grant_role(&admin, &Symbol::new(&env, "arbitrator"), &arbitrator);
+    let dispute = deploy_dispute(&env, &admin, &arbitrator);
+    let pool = deploy_insurance_pool(&env, &admin, &token.address, 500, &claims_mgr);
+
+    // Fund the pool.
+    token::Client::new(&env, &token.address).approve(&underwriter, &pool.address, &80_000, &200_000);
+    pool.contribute(&underwriter, &token.address, &80_000);
+    assert_eq!(pool.get_pool_stats(&token.address).total_balance, 80_000);
+
+    // A job is escrowed, then disputed by the payer.
+    let job_id = Symbol::new(&env, "job_ins");
+    let expiry = env.ledger().timestamp() + 86_400;
+    escrow.create_escrow(&payer, &worker, &token.address, &job_id, &30_000, &expiry);
+    escrow.dispute_escrow(&payer, &job_id);
+
+    let dispute_id = Symbol::new(&env, "dsp_ins");
+    dispute.file_dispute(
+        &dispute_id,
+        &payer,
+        &worker,
+        &token.address,
+        &1_000,
+        &String::from_str(&env, "ipfs://payer-evidence"),
+    );
+    dispute.submit_evidence(
+        &dispute_id,
+        &worker,
+        &String::from_str(&env, "ipfs://worker-evidence"),
+    );
+
+    // Arbitrator rules for the worker: escrowed funds are released away from
+    // the payer, who is the party the pool covers.
+    dispute.decide(&dispute_id, &arbitrator, &DisputeOutcome::ReleaseRespondent, &0);
+    dispute.settle(&dispute_id);
+
+    let release_to_beneficiary =
+        dispute.get_dispute(&dispute_id).unwrap().outcome == DisputeOutcome::ReleaseRespondent;
+    escrow.resolve_dispute(&arbitrator, &job_id, &release_to_beneficiary);
+
+    // payer: 100_000 - 30_000 escrow - 1_000 bond
+    assert_eq!(token.balance(&payer), 69_000);
+    assert_eq!(token.balance(&worker), 31_000);
+
+    // The payer claims the escrowed amount they lost.
+    let claim_id = Symbol::new(&env, "clm_ins");
+    pool.file_claim(&payer, &claim_id, &30_000);
+    pool.approve_claim(&claims_mgr, &claim_id);
+    pool.pay_claim(&claims_mgr, &claim_id, &token.address);
+
+    assert_eq!(token.balance(&payer), 99_000);
+    assert_eq!(token.balance(&pool.address), 50_000);
+
+    let claim = pool.get_claim(&claim_id);
+    assert_eq!(claim.amount, 30_000);
+    assert_eq!(claim.claimant, payer);
+    assert_eq!(claim.status, String::from_str(&env, "paid"));
+
+    let stats = pool.get_pool_stats(&token.address);
+    assert_eq!(stats.total_contributions, 80_000);
+    assert_eq!(stats.total_claims_paid, 30_000);
+    assert_eq!(stats.total_balance, 50_000);
+}

--- a/packages/contracts/contracts/integration/tests/reputation_flow.rs
+++ b/packages/contracts/contracts/integration/tests/reputation_flow.rs
@@ -1,0 +1,133 @@
+//! Reputation changes chained to real job and dispute events.
+//!
+//! The reputation contract's own tests call `submit_review` / `slash_reputation`
+//! directly. Here the score and badge changes follow an actual escrow release
+//! and an actual arbitrated dispute.
+//!
+//! Run:
+//!   cargo test -p bluecollar-integration --test reputation_flow
+
+#![cfg(test)]
+
+mod common;
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
+
+use bluecollar_dispute::DisputeOutcome;
+
+use common::{
+    deploy_dispute, deploy_market, deploy_registry, deploy_reputation, deploy_token, zero_hash,
+};
+
+#[test]
+fn completed_job_raises_worker_reputation_and_awards_badge() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let curator = Address::generate(&env);
+    let rep_mgr = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    let registry = deploy_registry(&env, &admin);
+    let market = deploy_market(&env, &admin, 0, &admin);
+    let reputation = deploy_reputation(&env, &admin, &rep_mgr);
+    let token = deploy_token(&env, &admin, &payer, 100_000);
+
+    // Register the worker.
+    registry.add_curator(&admin, &curator);
+    let worker_id = Symbol::new(&env, "worker_rep");
+    registry.register(
+        &worker_id,
+        &owner,
+        &String::from_str(&env, "Alice the Plumber"),
+        &Symbol::new(&env, "plumber"),
+        &zero_hash(&env),
+        &zero_hash(&env),
+        &curator,
+    );
+    let worker = registry.get_worker(&worker_id).unwrap();
+    assert_eq!(reputation.get_score(&worker_id), 0);
+
+    // Job runs through escrow and completes.
+    let job_id = Symbol::new(&env, "job_rep");
+    let expiry = env.ledger().timestamp() + 86_400;
+    market.create_escrow(&job_id, &payer, &worker.wallet, &token.address, &20_000, &expiry);
+    market.release_escrow(&job_id, &payer);
+    assert_eq!(token.balance(&worker.wallet), 20_000);
+
+    // Completion feeds the review.
+    reputation.submit_review(&rep_mgr, &worker_id, &9_200, &zero_hash(&env));
+
+    let record = reputation.get_record(&worker_id);
+    assert_eq!(record.score, 9_200);
+    assert_eq!(record.review_count, 1);
+
+    // A second completed job averages into the score.
+    let job_id_2 = Symbol::new(&env, "job_rep2");
+    market.create_escrow(&job_id_2, &payer, &worker.wallet, &token.address, &10_000, &expiry);
+    market.release_escrow(&job_id_2, &payer);
+    reputation.submit_review(&rep_mgr, &worker_id, &8_800, &zero_hash(&env));
+
+    let record = reputation.get_record(&worker_id);
+    assert_eq!(record.score, 9_000); // (9_200 + 8_800) / 2
+    assert_eq!(record.review_count, 2);
+
+    // Sustained score earns a badge.
+    let badge = Symbol::new(&env, "trusted");
+    reputation.award_badge(&rep_mgr, &worker_id, &badge);
+    assert!(reputation.has_badge(&worker_id, &badge));
+    assert_eq!(reputation.get_record(&worker_id).badges.len(), 1);
+}
+
+#[test]
+fn dispute_resolved_against_worker_slashes_reputation_and_revokes_badge() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    let rep_mgr = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let worker = Address::generate(&env);
+
+    let reputation = deploy_reputation(&env, &admin, &rep_mgr);
+    let dispute = deploy_dispute(&env, &admin, &arbitrator);
+    let token = deploy_token(&env, &admin, &payer, 100_000);
+
+    // Worker starts with a good score and a badge.
+    let worker_id = Symbol::new(&env, "worker_dsp");
+    let badge = Symbol::new(&env, "trusted");
+    reputation.submit_review(&rep_mgr, &worker_id, &9_000, &zero_hash(&env));
+    reputation.award_badge(&rep_mgr, &worker_id, &badge);
+    assert_eq!(reputation.get_score(&worker_id), 9_000);
+
+    // Dispute filed and decided against the worker.
+    let dispute_id = Symbol::new(&env, "dsp_rep");
+    dispute.file_dispute(
+        &dispute_id,
+        &payer,
+        &worker,
+        &token.address,
+        &5_000,
+        &String::from_str(&env, "ipfs://payer-evidence"),
+    );
+    dispute.submit_evidence(
+        &dispute_id,
+        &worker,
+        &String::from_str(&env, "ipfs://worker-evidence"),
+    );
+    dispute.decide(&dispute_id, &arbitrator, &DisputeOutcome::RefundDisputer, &0);
+    dispute.settle(&dispute_id);
+    assert_eq!(token.balance(&payer), 100_000);
+
+    // The ruling drives the reputation penalty.
+    let outcome = dispute.get_dispute(&dispute_id).unwrap().outcome;
+    assert_eq!(outcome, DisputeOutcome::RefundDisputer);
+    reputation.slash_reputation(&rep_mgr, &worker_id, &2_500);
+    reputation.revoke_badge(&rep_mgr, &worker_id, &badge);
+
+    assert_eq!(reputation.get_score(&worker_id), 6_500);
+    assert!(!reputation.has_badge(&worker_id, &badge));
+}


### PR DESCRIPTION
# PR Summary

## Cross-contract integration tests (dispute, insurance, reputation)

Adds the three missing cross-contract flows to `packages/contracts/contracts/integration/`, which previously covered only registry and market.

## Added
- **`tests/dispute_flow.rs`** - dispute filed on locked funds -> evidence from both parties -> arbitrator decides -> payout follows the ruling; market escrow arbitration driven by the dispute contract's outcome; escrow dispute resolved against the worker refunds the depositor.
- **`tests/insurance_flow.rs`** - job lost at arbitration triggers an insurance claim; asserts payout amount, claim status, and that pool balance and claim totals reconcile.
- **`tests/reputation_flow.rs`** - completed escrow jobs raise a worker's score and earn a badge; a dispute resolved against the worker slashes the score and revokes the badge.
- **`tests/common/mod.rs`** - shared deploy helpers for all six contracts; `e2e.rs` now uses them.
- **`README.md`** - new "Cross-Contract Integration Tests" section with a file-to-flow table and where to add new scenarios.

## Fixed
- `integration/tests/e2e.rs` did not compile: missing client lifetimes (SDK 26) and `get_worker` now returning `Option`. Its 8 tests had never run; they pass now.
- `bluecollar-dispute` and `bluecollar-escrow` did not compile at all: `unwrap_or_else(|_| ...)` on `Option` in both `storage.rs`, plus a `Symbol`/`&Symbol` comparison.
- `dispute` and `insurance_pool` gained `rlib` to `crate-type` so they can be linked as Rust dependencies.

## Closes
Closes #1157 
