### PR TITLE
test(api): add E2E coverage for curator moderation, search, and on-chain sync

### DIFF
--- a/packages/api/src/__tests__/e2e/curator-moderation.e2e.test.ts
+++ b/packages/api/src/__tests__/e2e/curator-moderation.e2e.test.ts
@@ -1,0 +1,210 @@
+/**
+ * E2E tests for the curator listing → admin moderation workflow — issue #1162.
+ *
+ * Covers the full loop that today only has admin RBAC coverage in
+ * admin.integration.test.ts: a curator creates a worker listing
+ * (POST /api/workers), and an admin approves or rejects it
+ * (PATCH /api/admin/workers/:id/moderate), asserting the resulting
+ * isActive/isVerified state and the audit trail it leaves behind.
+ *
+ * Requires a live test database (TEST_DATABASE_URL env var).
+ * Database is seeded/cleaned by testSetup.ts.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import request from 'supertest';
+import { db } from '../../db.js';
+import app from '../../app.js';
+
+vi.mock('../../mailer/transport.js', () => ({
+  transporter: { sendMail: vi.fn().mockResolvedValue({ messageId: 'mock' }) },
+}));
+
+import { vi } from 'vitest';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function createVerifiedUser(email: string, role: 'user' | 'curator' | 'admin' = 'user') {
+  const argon2 = await import('argon2');
+  return db.user.create({
+    data: {
+      email,
+      password: await argon2.hash('Password123!'),
+      firstName: 'Test',
+      lastName: 'User',
+      role,
+      verified: true,
+    },
+  });
+}
+
+async function loginAs(email: string): Promise<string> {
+  const res = await request(app).post('/api/auth/login').send({ email, password: 'Password123!' });
+  return res.body.token as string;
+}
+
+async function createWorkerAsCurator(name: string, token: string, categoryId: string) {
+  const res = await request(app)
+    .post('/api/workers')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ name, categoryId, phone: '+15551234567' });
+  return res.body.data.id as string;
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+let categoryId: string;
+let curatorToken: string;
+let userToken: string;
+let adminToken: string;
+let adminId: string;
+let approvedWorkerId: string;
+let rejectedWorkerId: string;
+
+describe('Curator Moderation E2E', () => {
+  beforeAll(async () => {
+    const cat = await db.category.create({ data: { name: 'HVAC Technician' } });
+    categoryId = cat.id;
+
+    await createVerifiedUser('moderation-curator@e2e.com', 'curator');
+    await createVerifiedUser('moderation-user@e2e.com', 'user');
+    const admin = await createVerifiedUser('moderation-admin@e2e.com', 'admin');
+    adminId = admin.id;
+
+    curatorToken = await loginAs('moderation-curator@e2e.com');
+    userToken = await loginAs('moderation-user@e2e.com');
+    adminToken = await loginAs('moderation-admin@e2e.com');
+  });
+
+  // ── Curator creates a listing pending moderation ───────────────────────────
+  describe('POST /api/workers (curator submits a listing)', () => {
+    it('creates a worker as curator, starting isActive=true and isVerified=false', async () => {
+      const res = await request(app)
+        .post('/api/workers')
+        .set('Authorization', `Bearer ${curatorToken}`)
+        .send({ name: 'Frosty HVAC Repair', categoryId, phone: '+15551234567' });
+      expect(res.status).toBe(201);
+      expect(res.body.data.isActive).toBe(true);
+      expect(res.body.data.isVerified).toBe(false);
+      approvedWorkerId = res.body.data.id;
+    });
+  });
+
+  // ── RBAC on the moderation endpoint ────────────────────────────────────────
+  describe('PATCH /api/admin/workers/:id/moderate — access control', () => {
+    it('returns 401 without auth', async () => {
+      const res = await request(app)
+        .patch(`/api/admin/workers/${approvedWorkerId}/moderate`)
+        .send({ action: 'approve' });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 for the curator who owns the listing (can't self-moderate)", async () => {
+      const res = await request(app)
+        .patch(`/api/admin/workers/${approvedWorkerId}/moderate`)
+        .set('Authorization', `Bearer ${curatorToken}`)
+        .send({ action: 'approve' });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 for a plain user', async () => {
+      const res = await request(app)
+        .patch(`/api/admin/workers/${approvedWorkerId}/moderate`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({ action: 'approve' });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ── Approval path ───────────────────────────────────────────────────────────
+  describe('PATCH /api/admin/workers/:id/moderate — approve', () => {
+    it('rejects an invalid action', async () => {
+      const res = await request(app)
+        .patch(`/api/admin/workers/${approvedWorkerId}/moderate`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ action: 'launch-to-moon' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for a nonexistent worker', async () => {
+      const res = await request(app)
+        .patch('/api/admin/workers/nonexistent-worker-id/moderate')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ action: 'approve' });
+      expect(res.status).toBe(404);
+    });
+
+    it('approves the listing as admin: isActive and isVerified both become true', async () => {
+      const res = await request(app)
+        .patch(`/api/admin/workers/${approvedWorkerId}/moderate`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ action: 'approve', reason: 'Meets listing standards' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.isActive).toBe(true);
+      expect(res.body.data.isVerified).toBe(true);
+
+      const stored = await db.worker.findUnique({ where: { id: approvedWorkerId } });
+      expect(stored?.isActive).toBe(true);
+      expect(stored?.isVerified).toBe(true);
+    });
+
+    it('records an audit log entry for the approval', async () => {
+      const entry = await db.auditLog.findFirst({
+        where: { resource: 'worker', resourceId: approvedWorkerId, action: 'worker.approve' },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(entry).toBeDefined();
+      expect(entry?.userId).toBe(adminId);
+      expect((entry?.meta as unknown as { reason?: string } | null)?.reason).toBe('Meets listing standards');
+    });
+
+    it('shows up in GET /api/admin/audit for the admin', async () => {
+      const res = await request(app)
+        .get('/api/admin/audit')
+        .query({ resource: 'worker', action: 'worker.approve' })
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+      expect(
+        res.body.data.some((entry: { resourceId: string }) => entry.resourceId === approvedWorkerId),
+      ).toBe(true);
+    });
+  });
+
+  // ── Rejection path ──────────────────────────────────────────────────────────
+  describe('PATCH /api/admin/workers/:id/moderate — reject', () => {
+    beforeAll(async () => {
+      rejectedWorkerId = await createWorkerAsCurator('Sketchy Duct Cleaners', curatorToken, categoryId);
+    });
+
+    it('rejects the listing as admin: isActive and isVerified both become false', async () => {
+      const res = await request(app)
+        .patch(`/api/admin/workers/${rejectedWorkerId}/moderate`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ action: 'reject', reason: 'Unverifiable business address' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.isActive).toBe(false);
+      expect(res.body.data.isVerified).toBe(false);
+
+      const stored = await db.worker.findUnique({ where: { id: rejectedWorkerId } });
+      expect(stored?.isActive).toBe(false);
+      expect(stored?.isVerified).toBe(false);
+    });
+
+    it('records an audit log entry for the rejection', async () => {
+      const entry = await db.auditLog.findFirst({
+        where: { resource: 'worker', resourceId: rejectedWorkerId, action: 'worker.reject' },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(entry).toBeDefined();
+      expect(entry?.userId).toBe(adminId);
+    });
+
+    it('a rejected listing no longer appears in public search/browse results', async () => {
+      const res = await request(app).get('/api/workers');
+      expect(res.status).toBe(200);
+      expect(
+        res.body.data.some((w: { id: string }) => w.id === rejectedWorkerId),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/__tests__/e2e/search.e2e.test.ts
+++ b/packages/api/src/__tests__/e2e/search.e2e.test.ts
@@ -1,0 +1,187 @@
+/**
+ * E2E tests for full-text worker search — issue #1162.
+ *
+ * search.integration.test.ts already covers the controller/param-passing
+ * contract with a mocked search service. This file exercises the real thing:
+ * GET /api/workers/search against the real Express app, a real Postgres
+ * full-text search (searchVector tsvector column, GIN index, ts_rank), and
+ * real filters — asserting an actual query → ranked-results flow, not just
+ * a 200 with a mocked payload.
+ *
+ * Requires a live test database (TEST_DATABASE_URL env var).
+ * Database is seeded/cleaned by testSetup.ts.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import request from 'supertest';
+import { db } from '../../db.js';
+import app from '../../app.js';
+
+vi.mock('../../mailer/transport.js', () => ({
+  transporter: { sendMail: vi.fn().mockResolvedValue({ messageId: 'mock' }) },
+}));
+
+import { vi } from 'vitest';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function createVerifiedUser(email: string, role: 'user' | 'curator' | 'admin' = 'user') {
+  const argon2 = await import('argon2');
+  return db.user.create({
+    data: {
+      email,
+      password: await argon2.hash('Password123!'),
+      firstName: 'Test',
+      lastName: 'User',
+      role,
+      verified: true,
+    },
+  });
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+// Search terms deliberately avoid overlap with worker fixtures created by
+// sibling e2e test files (they run against the same seeded database).
+
+let plumbingCategoryId: string;
+let electricalCategoryId: string;
+let curatorId: string;
+let heavyMatchWorkerId: string; // "plumberzorp" many times — top rank
+let lightMatchWorkerId: string; // "plumberzorp" once, different category
+let noMatchWorkerId: string; // shares the category but no text match
+
+describe('Search E2E', () => {
+  beforeAll(async () => {
+    const plumbing = await db.category.create({ data: { name: 'Plumberzorp Category' } });
+    const electrical = await db.category.create({ data: { name: 'Electrical (search e2e)' } });
+    plumbingCategoryId = plumbing.id;
+    electricalCategoryId = electrical.id;
+
+    const curator = await createVerifiedUser('search-curator@e2e.com', 'curator');
+    curatorId = curator.id;
+
+    const heavy = await db.worker.create({
+      data: {
+        name: 'Alice the Plumberzorp',
+        bio: 'Professional plumberzorp offering plumberzorp emergency plumberzorp repairs and plumberzorp inspections.',
+        categoryId: plumbingCategoryId,
+        curatorId,
+        isVerified: true,
+      },
+    });
+    heavyMatchWorkerId = heavy.id;
+
+    const light = await db.worker.create({
+      data: {
+        name: 'Bob the Electrician',
+        bio: 'Occasionally takes plumberzorp referrals when asked.',
+        categoryId: electricalCategoryId,
+        curatorId,
+        isVerified: false,
+      },
+    });
+    lightMatchWorkerId = light.id;
+
+    const none = await db.worker.create({
+      data: {
+        name: 'Carol the Painter',
+        bio: 'Interior and exterior painting specialist. No pipework at all.',
+        categoryId: plumbingCategoryId,
+        curatorId,
+        isVerified: false,
+      },
+    });
+    noMatchWorkerId = none.id;
+
+    await db.review.create({
+      data: { workerId: heavyMatchWorkerId, authorId: curatorId, rating: 5, body: 'Fantastic work.' },
+    });
+    await db.review.create({
+      data: { workerId: lightMatchWorkerId, authorId: curatorId, rating: 2, body: 'Not great.' },
+    });
+  });
+
+  // ── Real ranked full-text search ───────────────────────────────────────────
+  describe('GET /api/workers/search?q=... — real ranking', () => {
+    it('ranks the worker with denser term matches first, and excludes non-matches entirely', async () => {
+      const res = await request(app).get('/api/workers/search?q=plumberzorp');
+      expect(res.status).toBe(200);
+
+      const ids = res.body.data.map((w: { id: string }) => w.id);
+      expect(ids).toContain(heavyMatchWorkerId);
+      expect(ids).toContain(lightMatchWorkerId);
+      expect(ids).not.toContain(noMatchWorkerId); // no literal "plumberzorp" token at all
+
+      expect(res.body.data[0].id).toBe(heavyMatchWorkerId);
+      const [top, second] = res.body.data;
+      expect(typeof top.rank).toBe('number');
+      expect(top.rank).toBeGreaterThan(second.rank); // real ts_rank, not a mocked score
+    });
+
+    it('returns ts_headline highlights with <mark> around the matched term', async () => {
+      const res = await request(app).get('/api/workers/search?q=plumberzorp');
+      const top = res.body.data.find((w: { id: string }) => w.id === heavyMatchWorkerId);
+      expect(top.highlight.name).toContain('<mark>');
+      expect(top.highlight.name.toLowerCase()).toContain('plumberzorp');
+    });
+
+    it('applies the category filter on top of the text query', async () => {
+      const res = await request(app).get(
+        `/api/workers/search?q=plumberzorp&categories=${electricalCategoryId}`,
+      );
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((w: { id: string }) => w.id);
+      expect(ids).toContain(lightMatchWorkerId);
+      expect(ids).not.toContain(heavyMatchWorkerId); // right category excluded despite stronger text match
+    });
+
+    it('applies the isVerified filter', async () => {
+      const res = await request(app).get('/api/workers/search?q=plumberzorp&isVerified=true');
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((w: { id: string }) => w.id);
+      expect(ids).toEqual([heavyMatchWorkerId]);
+    });
+
+    it('applies the minRating filter using real aggregated review data', async () => {
+      const res = await request(app).get('/api/workers/search?q=plumberzorp&minRating=4');
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((w: { id: string }) => w.id);
+      expect(ids).toContain(heavyMatchWorkerId); // avg rating 5
+      expect(ids).not.toContain(lightMatchWorkerId); // avg rating 2
+    });
+
+    it('paginates results deterministically', async () => {
+      const res = await request(app).get('/api/workers/search?q=plumberzorp&limit=1&page=1');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].id).toBe(heavyMatchWorkerId);
+      expect(res.body.meta.total).toBe(2);
+      expect(res.body.meta.pages).toBe(2);
+    });
+
+    it('returns an empty result set for a query matching nothing', async () => {
+      const res = await request(app).get('/api/workers/search?q=zzznonexistentqueryzzz');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.meta.total).toBe(0);
+    });
+
+    it('browse mode (no query) returns workers without full-text ranking', async () => {
+      // Scoped to this file's own categories so results are deterministic
+      // regardless of what sibling e2e files have seeded into the shared DB.
+      const res = await request(app).get(
+        `/api/workers/search?categories=${plumbingCategoryId},${electricalCategoryId}`,
+      );
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((w: { id: string }) => w.id);
+      expect(ids).toContain(heavyMatchWorkerId);
+      expect(ids).toContain(noMatchWorkerId);
+      expect(res.body.data.every((w: { rank?: number }) => w.rank === 0)).toBe(true);
+    });
+
+    it('is publicly accessible without authentication', async () => {
+      const res = await request(app).get('/api/workers/search?q=plumberzorp');
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/packages/api/src/__tests__/integration/onchain-sync.integration.test.ts
+++ b/packages/api/src/__tests__/integration/onchain-sync.integration.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Integration tests for the on-chain sync path — issue #1162.
+ *
+ * Covers: horizon-poller.service.ts → indexer.service.ts → webhook.service.ts
+ *
+ * A live Horizon/Soroban dependency makes true E2E impractical (per #1162's
+ * acceptance criteria), so this is a documented integration test instead: the
+ * database is mocked (same convention as admin.integration.test.ts /
+ * search.integration.test.ts) and global `fetch` is stubbed with a realistic
+ * Horizon `/contracts/:id/events` response plus a mocked webhook subscriber
+ * endpoint. This exercises the real, unmocked service code — cursor lookup,
+ * ledger/txIndex/eventIndex parsing from the paging token, idempotent event
+ * upsert, topic → webhook-event mapping, and signed webhook delivery — and
+ * asserts that a single on-chain event correctly updates API-side state:
+ * the indexed ContractEvent row, the advanced EventIndexerCursor, and a
+ * delivered + HMAC-signed WebhookLog entry.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ─── Env (read at module-load time by horizon-poller.service.ts) ─────────────
+process.env.REGISTRY_CONTRACT_ID = 'CREGISTRYCONTRACTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+process.env.MARKET_CONTRACT_ID = 'CMARKETCONTRACTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+process.env.HORIZON_URL = 'https://horizon-testnet.stellar.org'
+
+const REGISTRY_CONTRACT_ID = process.env.REGISTRY_CONTRACT_ID
+const MARKET_CONTRACT_ID = process.env.MARKET_CONTRACT_ID
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../db.js', () => ({
+  db: {
+    eventIndexerCursor: { upsert: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
+    contractEvent: { upsert: vi.fn() },
+    webhookSubscription: { findMany: vi.fn() },
+    webhookLog: { create: vi.fn(), update: vi.fn() },
+  },
+}))
+
+// ─── Imports (after mocks/env) ─────────────────────────────────────────────────
+
+import { db } from '../../db.js'
+import { startHorizonPoller, stopHorizonPoller } from '../../services/horizon-poller.service.js'
+import { verifySignature } from '../../services/webhook.service.js'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SUBSCRIBER = {
+  id: 'sub-1',
+  userId: 'curator-1',
+  url: 'https://partner.example.com/webhook',
+  secret: 'whsec_test_integration_secret_0123456789',
+  events: ['worker.registered'],
+  isActive: true,
+}
+
+function makeCursor(contractId: string, ledger = BigInt(0), txIndex = 0) {
+  return { id: `cursor-${contractId}`, contractId, ledger, txIndex, updatedAt: new Date() }
+}
+
+/** A realistic Horizon `/contracts/:id/events` record for a `register` topic. */
+function registerEventRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'horizon-event-1',
+    type: 'contract',
+    contract_id: REGISTRY_CONTRACT_ID,
+    topic: ['register'],
+    value: { owner: 'GABCXYZ0000000000000000000000000000000000000000000000', workerId: 'onchain-worker-1' },
+    paging_token: '12345-1-0',
+    ledger_close_time: '2026-08-22T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function horizonEventsResponse(records: unknown[]) {
+  return { ok: true, status: 200, json: async () => ({ _embedded: { records } }) }
+}
+
+/** Stubs global fetch: Horizon events endpoints (by contract) + the webhook subscriber URL. */
+type FetchOpts = { method?: string; headers?: Record<string, string>; body?: string }
+
+function installFetchStub(registryRecords: unknown[]) {
+  const fetchMock = vi.fn(async (url: unknown, _opts?: FetchOpts) => {
+    const href = String(url)
+    if (href.includes(`/contracts/${REGISTRY_CONTRACT_ID}/events`)) return horizonEventsResponse(registryRecords)
+    if (href.includes(`/contracts/${MARKET_CONTRACT_ID}/events`)) return horizonEventsResponse([])
+    if (href === SUBSCRIBER.url) return { ok: true, status: 200, json: async () => ({}) }
+    throw new Error(`Unexpected fetch call in test: ${href}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+async function waitUntil(check: () => boolean, timeoutMs = 2000, intervalMs = 20) {
+  const start = Date.now()
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitUntil: condition was not met in time')
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+}
+
+function resetDbMocks() {
+  vi.mocked(db.eventIndexerCursor.upsert).mockImplementation(async ({ where }: any) => makeCursor(where.contractId))
+  vi.mocked(db.eventIndexerCursor.findUnique).mockImplementation(async ({ where }: any) => makeCursor(where.contractId))
+  vi.mocked(db.eventIndexerCursor.update).mockImplementation(async ({ where, data }: any) => ({
+    ...makeCursor(where.contractId),
+    ...data,
+  }))
+  vi.mocked(db.contractEvent.upsert).mockResolvedValue({ id: 'evt-1' } as any)
+  vi.mocked(db.webhookSubscription.findMany).mockResolvedValue([SUBSCRIBER] as any)
+  vi.mocked(db.webhookLog.create).mockResolvedValue({ id: 'log-1' } as any)
+  vi.mocked(db.webhookLog.update).mockResolvedValue({} as any)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('On-chain sync: Horizon poller → indexer → webhook (mocked Horizon event stream)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbMocks()
+  })
+
+  afterEach(() => {
+    stopHorizonPoller()
+    vi.unstubAllGlobals()
+  })
+
+  it('ingests a Horizon contract event, advances the cursor, and delivers a signed webhook', async () => {
+    const fetchMock = installFetchStub([registerEventRecord()])
+
+    startHorizonPoller()
+    await waitUntil(() => vi.mocked(db.webhookLog.update).mock.calls.length > 0)
+
+    // Both configured contracts are polled every cycle.
+    expect(db.eventIndexerCursor.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { contractId: REGISTRY_CONTRACT_ID } }),
+    )
+    expect(db.eventIndexerCursor.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { contractId: MARKET_CONTRACT_ID } }),
+    )
+
+    // Indexer: event persisted idempotently, keyed by (contractId, ledger, txIndex, eventIndex)
+    // parsed from the Horizon paging token "12345-1-0".
+    expect(db.contractEvent.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          contractId_ledger_txIndex_eventIndex: {
+            contractId: REGISTRY_CONTRACT_ID,
+            ledger: BigInt(12345),
+            txIndex: 1,
+            eventIndex: 0,
+          },
+        },
+        create: expect.objectContaining({
+          eventName: 'register',
+          ledger: BigInt(12345),
+          txIndex: 1,
+          eventIndex: 0,
+          indexed: { topic: ['register'] },
+          data: registerEventRecord().value,
+        }),
+      }),
+    )
+
+    // Cursor advances past the processed event for the registry contract only
+    // (the market contract saw zero records this cycle).
+    expect(db.eventIndexerCursor.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { contractId: REGISTRY_CONTRACT_ID },
+        data: expect.objectContaining({ ledger: BigInt(12345), txIndex: 1 }),
+      }),
+    )
+    expect(db.eventIndexerCursor.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ where: { contractId: MARKET_CONTRACT_ID } }),
+    )
+
+    // Webhook fan-out: the `register` topic maps to `worker.registered`, so only
+    // subscriptions for that event are queried and notified.
+    expect(db.webhookSubscription.findMany).toHaveBeenCalledWith({
+      where: { isActive: true, events: { has: 'worker.registered' } },
+    })
+    expect(db.webhookLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ subscriptionId: SUBSCRIBER.id, event: 'worker.registered' }) }),
+    )
+
+    // Delivery: the signed payload actually reaches the subscriber URL, and the
+    // signature verifies against the subscription's own secret.
+    const deliveryCall = fetchMock.mock.calls.find(([url]) => url === SUBSCRIBER.url)
+    expect(deliveryCall).toBeDefined()
+    const deliveryOpts = deliveryCall![1]!
+    const signature = deliveryOpts.headers!['X-BlueCollar-Signature']
+    expect(verifySignature(SUBSCRIBER.secret, deliveryOpts.body!, signature)).toBe(true)
+    expect(JSON.parse(deliveryOpts.body!)).toMatchObject({ contractId: REGISTRY_CONTRACT_ID, topic: ['register'] })
+
+    // Delivery outcome is recorded back onto the log — proving the full
+    // on-chain-event → API-state loop closes.
+    expect(db.webhookLog.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'log-1' },
+        data: expect.objectContaining({ statusCode: 200, success: true }),
+      }),
+    )
+  })
+
+  it('does not fan out a webhook when no subscription is registered for the mapped event', async () => {
+    vi.mocked(db.webhookSubscription.findMany).mockResolvedValue([])
+    installFetchStub([registerEventRecord()])
+
+    startHorizonPoller()
+    await waitUntil(() => vi.mocked(db.webhookSubscription.findMany).mock.calls.length > 0)
+    await new Promise((resolve) => setTimeout(resolve, 100)) // let any stray delivery attempt surface
+
+    expect(db.contractEvent.upsert).toHaveBeenCalled() // raw event is still indexed
+    expect(db.webhookLog.create).not.toHaveBeenCalled()
+  })
+
+  it('indexes an event with an unmapped topic without publishing a webhook', async () => {
+    // 'unrecognized_event' has no mapping in resolveEventName for either contract.
+    installFetchStub([registerEventRecord({ topic: ['unrecognized_event'], paging_token: '12346-0-0' })])
+
+    startHorizonPoller()
+    await waitUntil(() => vi.mocked(db.contractEvent.upsert).mock.calls.length > 0)
+    await new Promise((resolve) => setTimeout(resolve, 100)) // let any stray delivery attempt surface
+
+    expect(db.contractEvent.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ create: expect.objectContaining({ eventName: 'unrecognized_event' }) }),
+    )
+    expect(db.webhookSubscription.findMany).not.toHaveBeenCalled()
+    expect(db.webhookLog.create).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
Closes #1162.

Adds the three test files called for in the issue's acceptance criteria:

- **`curator-moderation.e2e.test.ts`** — exercises the full curator listing → admin approve/reject workflow end-to-end against a live DB via Supertest: RBAC (curator can't self-moderate, plain user 403, unauthenticated 401), invalid-action/404 handling, the resulting `isActive`/`isVerified` state after approve vs. reject, the audit log entry each leaves behind, and that a rejected listing drops out of public browse results. `admin.integration.test.ts` only covered RBAC on this endpoint in isolation with a fully mocked DB — this adds the missing curator-specific, real-DB coverage.
- **`search.e2e.test.ts`** — exercises real query → ranked results against a live Postgres full-text search (tsvector/GIN/`ts_rank`), not just a 200 against a mocked search service (that's what `search.integration.test.ts` already covers). Verifies real relevance ordering, `ts_headline` highlight markup, category/isVerified/minRating filtering against real aggregated data, pagination, and the no-match/browse-mode paths.
- **`onchain-sync.integration.test.ts`** — covers the webhook/indexer/horizon-poller sync path. Per the issue's own fallback clause ("if a live Horizon/Soroban dependency makes true E2E impractical, a documented integration test with a realistic mocked event stream"), this mocks the DB and stubs `fetch` with a realistic Horizon `/contracts/:id/events` payload, then exercises the real, unmocked service code end-to-end: cursor lookup, ledger/txIndex/eventIndex parsing from the paging token, idempotent event upsert, topic→webhook-event mapping, and HMAC-signed webhook delivery — asserting the on-chain event correctly lands as an indexed `ContractEvent`, advances the `EventIndexerCursor`, and reaches the subscriber as a signature-verifiable webhook.

## Test plan
- [ ] `curator-moderation.e2e.test.ts` and `search.e2e.test.ts` require a live `TEST_DATABASE_URL`, consistent with the existing `src/__tests__/e2e/*.e2e.test.ts` files in this repo (excluded from the default `vitest` run via `vitest.config.ts`, same as `disputes.e2e.test.ts` / `workers.e2e.test.ts`) — run against a seeded Postgres instance to verify.
- [ ] `onchain-sync.integration.test.ts` mocks the DB and `fetch` (no live DB needed) and lives under `__tests__/integration/`, so it runs under the existing `pnpm test --run` / API Integration Tests CI job like `admin.integration.test.ts` and `search.integration.test.ts`.

Note: I could not run `pnpm install` / `tsc --noEmit` locally to double-check compilation — `pnpm-lock.yaml` currently has a duplicate-key YAML error around the `winston-transport` entry (pre-existing on `main`, predates this branch — `git blame` traces it to a March commit) that trips `ERR_PNPM_BROKEN_LOCKFILE` on install. Worth a maintainer's attention separately since it would block `--frozen-lockfile` installs generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)