### PR TITLE
refactor(app): decompose dashboard/page.tsx and reuse shared Table/MetricCard (#1164)

### DIFF
--- a/packages/app/src/app/[locale]/dashboard/admin/page.tsx
+++ b/packages/app/src/app/[locale]/dashboard/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -10,8 +10,6 @@ import {
   Eye,
   MessageSquare,
   Star,
-  TrendingUp,
-  TrendingDown,
   Download,
   DollarSign,
   Shield,
@@ -21,6 +19,7 @@ import {
   Search,
   ExternalLink,
 } from "lucide-react";
+import { MetricCard } from "@/components/Dashboard";
 import { useAuth } from "@/context/AuthContext";
 import { useToast } from "@/hooks/useToast";
 import { formatDate } from "@/lib/utils";
@@ -147,25 +146,25 @@ export default function AdminDashboard() {
 
       {/* Overview Cards */}
       <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <StatCard
+        <MetricCard
           icon={<Briefcase size={20} />}
           label="Total Workers"
           value={data.overview.totalWorkers}
           sub={`${data.overview.activeWorkers} active`}
         />
-        <StatCard
+        <MetricCard
           icon={<Users size={20} />}
           label="Total Users"
           value={data.overview.totalUsers}
           sub={`${data.overview.totalCurators} curators`}
         />
-        <StatCard
+        <MetricCard
           icon={<Eye size={20} />}
           label="Profile Views"
           value={data.engagement.totalViews}
           sub={`${data.engagement.viewsThisMonth.toLocaleString()} this month`}
         />
-        <StatCard
+        <MetricCard
           icon={<DollarSign size={20} />}
           label="Total Tips"
           value={`${data.revenue.totalTips.toLocaleString()} XLM`}
@@ -175,23 +174,23 @@ export default function AdminDashboard() {
 
       {/* Growth Cards */}
       <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <GrowthCard
+        <MetricCard
           label="Workers This Month"
           value={data.growth.workersThisMonth}
-          pct={data.growth.workerGrowthPct}
+          trend={data.growth.workerGrowthPct}
         />
-        <GrowthCard
+        <MetricCard
           label="Users This Month"
           value={data.growth.usersThisMonth}
-          pct={data.growth.userGrowthPct}
+          trend={data.growth.userGrowthPct}
         />
-        <StatCard
+        <MetricCard
           icon={<Star size={20} />}
           label="Reviews"
           value={data.engagement.totalReviews}
           sub={`${data.engagement.reviewsThisMonth} this month`}
         />
-        <StatCard
+        <MetricCard
           icon={<MessageSquare size={20} />}
           label="Contact Requests"
           value={data.engagement.totalContacts}
@@ -265,57 +264,8 @@ export default function AdminDashboard() {
   );
 }
 
-function StatCard({
-  icon,
-  label,
-  value,
-  sub,
-}: {
-  icon: ReactNode;
-  label: string;
-  value: string | number;
-  sub?: string;
-}) {
-  return (
-    <div className="rounded-lg border bg-white p-6 dark:border-gray-800 dark:bg-gray-900">
-      <div className="flex items-center gap-2 text-gray-400 mb-2">
-        {icon}
-        <p className="text-sm font-medium text-gray-600 dark:text-gray-400">{label}</p>
-      </div>
-      <p className="text-3xl font-bold text-gray-900 dark:text-gray-100 mt-1">{typeof value === "number" ? value.toLocaleString() : value}</p>
-      {sub && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
-    </div>
-  );
-}
-
-function GrowthCard({
-  label,
-  value,
-  pct,
-}: {
-  label: string;
-  value: number;
-  pct: number;
-}) {
-  const isPositive = pct >= 0;
-  return (
-    <div className="rounded-lg border bg-white p-6 dark:border-gray-800 dark:bg-gray-900">
-      <p className="text-sm font-medium text-gray-600 dark:text-gray-400">{label}</p>
-      <div className="flex items-end gap-2 mt-2">
-        <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">{value}</p>
-        <span
-          className={`flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium ${
-            isPositive ? "bg-green-50 text-green-600" : "bg-red-50 text-red-600"
-          }`}
-        >
-          {isPositive ? <TrendingUp size={12} /> : <TrendingDown size={12} />}
-          {Math.abs(pct)}%
-        </span>
-      </div>
-      <p className="text-xs text-gray-400 mt-1">vs last month</p>
-    </div>
-  );
-}
+// StatCard → use shared MetricCard from @/components/Dashboard
+// GrowthCard → use shared MetricCard with `trend` prop from @/components/Dashboard
 
 function RoleBadge({ role }: { role: string }) {
   const colors: Record<string, string> = {

--- a/packages/app/src/app/[locale]/dashboard/page.tsx
+++ b/packages/app/src/app/[locale]/dashboard/page.tsx
@@ -1,81 +1,65 @@
 "use client";
 
-import { useEffect, useState, useCallback, type ReactNode } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import dynamic from "next/dynamic";
-import * as Dialog from "@radix-ui/react-dialog";
-import {
-  Plus,
-  Pencil,
-  Trash2,
-  ToggleLeft,
-  ToggleRight,
-  Loader2,
-  X,
-  AlertTriangle,
-  Settings,
-  Eye,
-  Heart,
-  Star,
-  MessageSquare,
-  TrendingUp,
-  Download,
-  BarChart3,
-} from "lucide-react";
+import { Plus, Settings, BarChart3 } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { useWallet } from "@/hooks/useWallet";
 import { cn } from "@/lib/utils";
 import FriendbotBanner from "@/components/FriendbotBanner";
 import { DashboardTableSkeleton } from "@/components/Skeleton";
+import {
+  WorkersPanel,
+  AnalyticsPanel,
+  DeleteWorkerDialog,
+  type DashboardWorker,
+} from "@/components/Dashboard";
 import type { CuratorAnalytics, ViewTrend } from "@/types";
-
-// ── Dynamic imports (code splitting: recharts is ~200KB) ─────────────────────
-const CuratorCharts = dynamic(
-  () => import("@/components/charts/CuratorCharts"),
-  { ssr: false, loading: () => <div className="h-[250px] rounded-lg bg-gray-50 animate-pulse" /> }
-);
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000/api";
 const HORIZON_TESTNET = "https://horizon-testnet.stellar.org";
-const IS_STELLAR_TESTNET = process.env.NEXT_PUBLIC_STELLAR_NETWORK?.toLowerCase() === "testnet";
-
-interface DashboardWorker {
-  id: string;
-  name: string;
-  isActive: boolean;
-  createdAt: string;
-  category: { id: string; name: string };
-}
+const IS_STELLAR_TESTNET =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK?.toLowerCase() === "testnet";
 
 export default function DashboardPage() {
   const { user, token, isLoading: authLoading } = useAuth();
   const { publicKey } = useWallet();
   const router = useRouter();
 
+  // ── Workers state ────────────────────────────────────────────────────────
   const [workers, setWorkers] = useState<DashboardWorker[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // ── Wallet balance ───────────────────────────────────────────────────────
   const [xlmBalance, setXlmBalance] = useState<number | null>(null);
 
-  // Analytics state
+  // ── Analytics state ──────────────────────────────────────────────────────
   const [analytics, setAnalytics] = useState<CuratorAnalytics | null>(null);
   const [analyticsLoading, setAnalyticsLoading] = useState(true);
+
+  // ── Per-worker view trends ───────────────────────────────────────────────
   const [selectedWorkerTrends, setSelectedWorkerTrends] = useState<ViewTrend[] | null>(null);
   const [selectedWorkerName, setSelectedWorkerName] = useState<string>("");
   const [trendsLoading, setTrendsLoading] = useState(false);
-  const [activeTab, setActiveTab] = useState<"workers" | "analytics">("workers");
 
-  // Delete confirmation state
+  // ── Tab + delete state ───────────────────────────────────────────────────
+  const [activeTab, setActiveTab] = useState<"workers" | "analytics">("workers");
   const [deleteTarget, setDeleteTarget] = useState<DashboardWorker | null>(null);
   const [deleting, setDeleting] = useState(false);
 
+  // ── Auth guard ───────────────────────────────────────────────────────────
   useEffect(() => {
-    if (!authLoading && (!user || (user.role !== "curator" && user.role !== "admin"))) {
+    if (
+      !authLoading &&
+      (!user || (user.role !== "curator" && user.role !== "admin"))
+    ) {
       router.replace("/auth/login");
     }
   }, [user, authLoading, router]);
 
+  // ── Data fetching ────────────────────────────────────────────────────────
   const fetchWorkers = useCallback(async () => {
     if (!token) return;
     setLoading(true);
@@ -105,7 +89,7 @@ export default function DashboardPage() {
       const json = await res.json();
       setAnalytics(json.data);
     } catch {
-      // analytics is supplementary — don't block the page
+      // Analytics is supplementary — don't block the page on failure.
     } finally {
       setAnalyticsLoading(false);
     }
@@ -116,9 +100,10 @@ export default function DashboardPage() {
     setTrendsLoading(true);
     setSelectedWorkerName(workerName);
     try {
-      const res = await fetch(`${API}/workers/${workerId}/analytics/trends?days=30`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await fetch(
+        `${API}/workers/${workerId}/analytics/trends?days=30`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       if (!res.ok) throw new Error("Failed to load trends");
       const json = await res.json();
       setSelectedWorkerTrends(json.data);
@@ -136,6 +121,7 @@ export default function DashboardPage() {
     }
   }, [authLoading, token, fetchWorkers, fetchAnalytics]);
 
+  // ── Wallet balance polling ───────────────────────────────────────────────
   useEffect(() => {
     if (!IS_STELLAR_TESTNET || !publicKey) {
       setXlmBalance(null);
@@ -150,17 +136,19 @@ export default function DashboardPage() {
       })
       .then((account) => {
         const nativeBalance = account?.balances?.find(
-          (balance: { asset_type: string }) => balance.asset_type === "native"
+          (b: { asset_type: string }) => b.asset_type === "native"
         );
         setXlmBalance(nativeBalance ? Number(nativeBalance.balance) : 0);
       })
       .catch(() => setXlmBalance(null));
   }, [publicKey]);
 
-  // ── Toggle active/inactive (optimistic) ──────────────────────────────────
+  // ── Handlers ─────────────────────────────────────────────────────────────
+
+  /** Optimistic toggle of a worker's active state. */
   const handleToggle = async (worker: DashboardWorker) => {
-    setWorkers((prev: DashboardWorker[]) =>
-      prev.map((w: DashboardWorker) => (w.id === worker.id ? { ...w, isActive: !w.isActive } : w))
+    setWorkers((prev) =>
+      prev.map((w) => (w.id === worker.id ? { ...w, isActive: !w.isActive } : w))
     );
     try {
       const res = await fetch(`${API}/workers/${worker.id}/toggle`, {
@@ -169,19 +157,20 @@ export default function DashboardPage() {
       });
       if (!res.ok) throw new Error("Toggle failed");
     } catch {
-      setWorkers((prev: DashboardWorker[]) =>
-        prev.map((w: DashboardWorker) => (w.id === worker.id ? { ...w, isActive: worker.isActive } : w))
+      // Roll back on failure.
+      setWorkers((prev) =>
+        prev.map((w) => (w.id === worker.id ? { ...w, isActive: worker.isActive } : w))
       );
     }
   };
 
-  // ── Delete (optimistic) ───────────────────────────────────────────────────
+  /** Optimistic delete — removes immediately, restores on failure. */
   const handleDelete = async () => {
     if (!deleteTarget) return;
     const target = deleteTarget;
     setDeleting(true);
 
-    setWorkers((prev: DashboardWorker[]) => prev.filter((w: DashboardWorker) => w.id !== target.id));
+    setWorkers((prev) => prev.filter((w) => w.id !== target.id));
     setDeleteTarget(null);
 
     try {
@@ -191,7 +180,7 @@ export default function DashboardPage() {
       });
       if (!res.ok) throw new Error("Delete failed");
     } catch {
-      setWorkers((prev: DashboardWorker[]) => [target, ...prev]);
+      setWorkers((prev) => [target, ...prev]);
     } finally {
       setDeleting(false);
     }
@@ -277,334 +266,44 @@ export default function DashboardPage() {
         </button>
       </div>
 
-      {/* Error */}
+      {/* Error banner */}
       {error && (
         <div className="mb-6 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">
           {error}
         </div>
       )}
 
+      {/* Tab panels */}
       {activeTab === "workers" && (
-        <>
-          {/* Workers Table */}
-          <div className="rounded-xl border bg-white shadow-sm overflow-hidden">
-            {loading ? (
-              <DashboardTableSkeleton />
-            ) : workers.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-20 text-center">
-                <p className="text-gray-500 font-medium">No workers yet</p>
-                <p className="mt-1 text-sm text-gray-400">
-                  Create your first worker listing to get started.
-                </p>
-                <Link
-                  href="/dashboard/workers/new"
-                  className="mt-4 flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
-                >
-                  <Plus size={15} />
-                  Create Worker
-                </Link>
-              </div>
-            ) : (
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                    <th className="px-5 py-3.5">Name</th>
-                    <th className="px-5 py-3.5">Category</th>
-                    <th className="px-5 py-3.5">Status</th>
-                    <th className="px-5 py-3.5">Created</th>
-                    <th className="px-5 py-3.5 text-right">Actions</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {workers.map((worker: DashboardWorker) => (
-                    <tr key={worker.id} className="hover:bg-gray-50 transition-colors">
-                      <td className="px-5 py-4 font-medium text-gray-800">
-                        {worker.name}
-                      </td>
-                      <td className="px-5 py-4 text-gray-500">
-                        <span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-600">
-                          {worker.category.name}
-                        </span>
-                      </td>
-                      <td className="px-5 py-4">
-                        <span
-                          className={cn(
-                            "rounded-full px-2.5 py-0.5 text-xs font-medium",
-                            worker.isActive
-                              ? "bg-green-50 text-green-600"
-                              : "bg-gray-100 text-gray-500"
-                          )}
-                        >
-                          {worker.isActive ? "Active" : "Inactive"}
-                        </span>
-                      </td>
-                      <td className="px-5 py-4 text-gray-400">
-                        {new Date(worker.createdAt).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                          year: "numeric",
-                        })}
-                      </td>
-                      <td className="px-5 py-4">
-                        <div className="flex items-center justify-end gap-1">
-                          <button
-                            onClick={() => fetchWorkerTrends(worker.id, worker.name)}
-                            className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-blue-600 transition-colors"
-                            title="View Trends"
-                          >
-                            <TrendingUp size={15} />
-                          </button>
-                          <Link
-                            href={`/dashboard/workers/${worker.id}/edit`}
-                            className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-blue-600 transition-colors"
-                            title="Edit"
-                          >
-                            <Pencil size={15} />
-                          </Link>
-                          <button
-                            onClick={() => handleToggle(worker)}
-                            className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-blue-600 transition-colors"
-                            title={worker.isActive ? "Deactivate" : "Activate"}
-                          >
-                            {worker.isActive ? (
-                              <ToggleRight size={17} className="text-green-500" />
-                            ) : (
-                              <ToggleLeft size={17} />
-                            )}
-                          </button>
-                          <button
-                            onClick={() => setDeleteTarget(worker)}
-                            className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-red-500 transition-colors"
-                            title="Delete"
-                          >
-                            <Trash2 size={15} />
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-          </div>
-
-          {/* View Trends Panel */}
-          {selectedWorkerTrends && (
-            <div className="mt-6 rounded-xl border bg-white p-6 shadow-sm">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-semibold text-gray-900">
-                  Views — {selectedWorkerName} (Last 30 days)
-                </h3>
-                <button
-                  onClick={() => setSelectedWorkerTrends(null)}
-                  className="rounded-md p-1 text-gray-400 hover:text-gray-600"
-                >
-                  <X size={16} />
-                </button>
-              </div>
-              <CuratorCharts.ViewTrendsChart
-                trends={selectedWorkerTrends}
-                trendsLoading={trendsLoading}
-                workerName={selectedWorkerName}
-              />
-            </div>
-          )}
-        </>
+        <WorkersPanel
+          workers={workers}
+          loading={loading}
+          selectedWorkerTrends={selectedWorkerTrends}
+          selectedWorkerName={selectedWorkerName}
+          trendsLoading={trendsLoading}
+          onToggle={handleToggle}
+          onDeleteRequest={setDeleteTarget}
+          onViewTrends={fetchWorkerTrends}
+          onCloseTrends={() => setSelectedWorkerTrends(null)}
+        />
       )}
 
       {activeTab === "analytics" && (
-        <div className="space-y-6">
-          {analyticsLoading ? (
-            <DashboardTableSkeleton />
-          ) : analytics ? (
-            <>
-              {/* Summary Cards */}
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <MetricCard
-                  icon={<Eye size={18} />}
-                  label="Total Views"
-                  value={analytics.totals.views}
-                  sub={`${analytics.totals.viewsThisMonth} this month`}
-                />
-                <MetricCard
-                  icon={<Heart size={18} />}
-                  label="Bookmarks"
-                  value={analytics.totals.bookmarks}
-                />
-                <MetricCard
-                  icon={<Star size={18} />}
-                  label="Avg Rating"
-                  value={analytics.totals.avgRating?.toFixed(1) ?? "—"}
-                  sub={`${analytics.totals.reviewCount ?? 0} reviews`}
-                />
-                <MetricCard
-                  icon={<MessageSquare size={18} />}
-                  label="Contacts"
-                  value={analytics.totals.contacts}
-                  sub={`${analytics.totals.contactsThisMonth} this month`}
-                />
-              </div>
-
-              {/* Revenue */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="rounded-xl border bg-white p-6 shadow-sm">
-                  <p className="text-sm font-medium text-gray-500">Total Tips Received</p>
-                  <p className="mt-1 text-2xl font-bold text-gray-900">
-                    {analytics.totals.tips.toLocaleString()} XLM
-                  </p>
-                  <p className="mt-0.5 text-xs text-gray-400">
-                    {analytics.totals.tipCount} transactions
-                  </p>
-                </div>
-                <div className="rounded-xl border bg-white p-6 shadow-sm">
-                  <p className="text-sm font-medium text-gray-500">Workers Overview</p>
-                  <p className="mt-1 text-2xl font-bold text-gray-900">
-                    {analytics.activeWorkers}{" "}
-                    <span className="text-base font-normal text-gray-400">
-                      / {analytics.totalWorkers} active
-                    </span>
-                  </p>
-                </div>
-              </div>
-
-              {/* Per-Worker Breakdown */}
-              <div className="rounded-xl border bg-white shadow-sm overflow-hidden">
-                <div className="flex items-center justify-between px-5 py-4 border-b">
-                  <h3 className="font-semibold text-gray-900">Worker Performance</h3>
-                  <button
-                    onClick={handleExportCsv}
-                    className="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
-                  >
-                    <Download size={13} />
-                    Export CSV
-                  </button>
-                </div>
-                {analytics.workers.length === 0 ? (
-                  <div className="py-12 text-center text-sm text-gray-400">
-                    No worker data yet
-                  </div>
-                ) : (
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                          <th className="px-5 py-3">Worker</th>
-                          <th className="px-5 py-3">Category</th>
-                          <th className="px-5 py-3 text-right">Views</th>
-                          <th className="px-5 py-3 text-right">Bookmarks</th>
-                          <th className="px-5 py-3 text-right">Tips</th>
-                          <th className="px-5 py-3 text-right">Contacts</th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
-                        {analytics.workers.map((w) => (
-                          <tr key={w.id} className="hover:bg-gray-50 transition-colors">
-                            <td className="px-5 py-3.5 font-medium text-gray-800">
-                              <div className="flex items-center gap-2">
-                                {w.name}
-                                {!w.isActive && (
-                                  <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-400">
-                                    Inactive
-                                  </span>
-                                )}
-                              </div>
-                            </td>
-                            <td className="px-5 py-3.5 text-gray-500">{w.category}</td>
-                            <td className="px-5 py-3.5 text-right tabular-nums text-gray-700">{w.views.toLocaleString()}</td>
-                            <td className="px-5 py-3.5 text-right tabular-nums text-gray-700">{w.bookmarks}</td>
-                            <td className="px-5 py-3.5 text-right tabular-nums text-gray-700">{w.tips.toLocaleString()}</td>
-                            <td className="px-5 py-3.5 text-right tabular-nums text-gray-700">{w.contacts}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </div>
-
-              {/* Worker Views Bar Chart */}
-              {analytics.workers.length > 0 && (
-                <div className="rounded-xl border bg-white p-6 shadow-sm">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-4">Views by Worker</h3>
-                  <CuratorCharts.WorkersBarChart workers={analytics.workers} />
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="rounded-xl border bg-white py-16 text-center">
-              <p className="text-gray-500">Unable to load analytics</p>
-            </div>
-          )}
-        </div>
+        <AnalyticsPanel
+          analytics={analytics}
+          loading={analyticsLoading}
+          onExportCsv={handleExportCsv}
+        />
       )}
 
       {/* Delete confirmation dialog */}
-      <Dialog.Root
+      <DeleteWorkerDialog
+        workerName={deleteTarget?.name}
         open={!!deleteTarget}
-        onOpenChange={(open: boolean) => { if (!open) setDeleteTarget(null); }}
-      >
-        <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
-          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-6 shadow-xl">
-            <div className="flex items-start justify-between">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-50">
-                  <AlertTriangle size={18} className="text-red-500" />
-                </div>
-                <div>
-                  <Dialog.Title className="font-semibold text-gray-900">
-                    Delete worker?
-                  </Dialog.Title>
-                  <Dialog.Description className="mt-0.5 text-sm text-gray-500">
-                    This will permanently remove{" "}
-                    <span className="font-medium text-gray-700">
-                      {deleteTarget?.name}
-                    </span>
-                    . This action cannot be undone.
-                  </Dialog.Description>
-                </div>
-              </div>
-              <Dialog.Close className="rounded-md p-1 text-gray-400 hover:text-gray-600">
-                <X size={16} />
-              </Dialog.Close>
-            </div>
-
-            <div className="mt-5 flex gap-3">
-              <Dialog.Close className="flex-1 rounded-lg border py-2.5 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors">
-                Cancel
-              </Dialog.Close>
-              <button
-                onClick={handleDelete}
-                disabled={deleting}
-                className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-600 py-2.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-60 transition-colors"
-              >
-                {deleting && <Loader2 size={14} className="animate-spin" />}
-                Delete
-              </button>
-            </div>
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
-    </div>
-  );
-}
-
-function MetricCard({
-  icon,
-  label,
-  value,
-  sub,
-}: {
-  icon: ReactNode;
-  label: string;
-  value: string | number;
-  sub?: string;
-}) {
-  return (
-    <div className="rounded-xl border bg-white p-5 shadow-sm">
-      <div className="flex items-center gap-2 text-gray-400 mb-2">{icon}<span className="text-xs font-medium uppercase tracking-wide">{label}</span></div>
-      <p className="text-2xl font-bold text-gray-900">{value}</p>
-      {sub && <p className="mt-0.5 text-xs text-gray-400">{sub}</p>}
+        onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+        onConfirm={handleDelete}
+        isDeleting={deleting}
+      />
     </div>
   );
 }

--- a/packages/app/src/components/Dashboard/AnalyticsPanel.tsx
+++ b/packages/app/src/components/Dashboard/AnalyticsPanel.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Eye, Heart, Star, MessageSquare, Download } from "lucide-react";
+import { Table, type ColumnDef } from "@/components/Table";
+import { MetricCard } from "./MetricCard";
+import { DashboardTableSkeleton } from "@/components/Skeleton";
+import { cn } from "@/lib/utils";
+import type { CuratorAnalytics } from "@/types";
+
+// ── Dynamic import (code splitting) ─────────────────────────────────────────
+const CuratorCharts = dynamic(
+  () => import("@/components/charts/CuratorCharts"),
+  { ssr: false, loading: () => <div className="h-[250px] rounded-lg bg-gray-50 animate-pulse" /> }
+);
+
+// Shape of a per-worker analytics row returned by the API.
+// Mirrors the type used inside CuratorAnalytics['workers'].
+interface WorkerAnalyticsRow {
+  id: string;
+  name: string;
+  category: string;
+  isActive: boolean;
+  views: number;
+  bookmarks: number;
+  tips: number;
+  contacts: number;
+}
+
+interface AnalyticsPanelProps {
+  analytics: CuratorAnalytics | null;
+  loading: boolean;
+  onExportCsv: () => void;
+}
+
+/**
+ * Analytics tab panel — summary metric cards, per-worker breakdown table,
+ * and views-by-worker bar chart.
+ */
+export function AnalyticsPanel({ analytics, loading, onExportCsv }: AnalyticsPanelProps) {
+  const workerColumns: ColumnDef<WorkerAnalyticsRow>[] = [
+    {
+      key: "name",
+      header: "Worker",
+      cell: (w) => (
+        <div className="flex items-center gap-2 font-medium text-gray-800">
+          {w.name}
+          {!w.isActive && (
+            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-400">
+              Inactive
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: "category",
+      header: "Category",
+      cell: (w) => <span className="text-gray-500">{w.category}</span>,
+      hideOnMobile: true,
+    },
+    {
+      key: "views",
+      header: "Views",
+      className: "text-right",
+      cell: (w) => (
+        <span className="tabular-nums text-gray-700">{w.views.toLocaleString()}</span>
+      ),
+    },
+    {
+      key: "bookmarks",
+      header: "Bookmarks",
+      className: "text-right",
+      cell: (w) => <span className="tabular-nums text-gray-700">{w.bookmarks}</span>,
+      hideOnMobile: true,
+    },
+    {
+      key: "tips",
+      header: "Tips",
+      className: "text-right",
+      cell: (w) => (
+        <span className="tabular-nums text-gray-700">{w.tips.toLocaleString()}</span>
+      ),
+      hideOnMobile: true,
+    },
+    {
+      key: "contacts",
+      header: "Contacts",
+      className: "text-right",
+      cell: (w) => <span className="tabular-nums text-gray-700">{w.contacts}</span>,
+    },
+  ];
+
+  if (loading) {
+    return <DashboardTableSkeleton />;
+  }
+
+  if (!analytics) {
+    return (
+      <div className="rounded-xl border bg-white py-16 text-center">
+        <p className="text-gray-500">Unable to load analytics</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Summary metric cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricCard
+          icon={<Eye size={18} />}
+          label="Total Views"
+          value={analytics.totals.views}
+          sub={`${analytics.totals.viewsThisMonth} this month`}
+        />
+        <MetricCard
+          icon={<Heart size={18} />}
+          label="Bookmarks"
+          value={analytics.totals.bookmarks}
+        />
+        <MetricCard
+          icon={<Star size={18} />}
+          label="Avg Rating"
+          value={analytics.totals.avgRating?.toFixed(1) ?? "—"}
+          sub={`${analytics.totals.reviewCount ?? 0} reviews`}
+        />
+        <MetricCard
+          icon={<MessageSquare size={18} />}
+          label="Contacts"
+          value={analytics.totals.contacts}
+          sub={`${analytics.totals.contactsThisMonth} this month`}
+        />
+      </div>
+
+      {/* Revenue / workers overview */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="rounded-xl border bg-white p-6 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">Total Tips Received</p>
+          <p className="mt-1 text-2xl font-bold text-gray-900">
+            {analytics.totals.tips.toLocaleString()} XLM
+          </p>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {analytics.totals.tipCount} transactions
+          </p>
+        </div>
+        <div className="rounded-xl border bg-white p-6 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">Workers Overview</p>
+          <p className="mt-1 text-2xl font-bold text-gray-900">
+            {analytics.activeWorkers}{" "}
+            <span className="text-base font-normal text-gray-400">
+              / {analytics.totalWorkers} active
+            </span>
+          </p>
+        </div>
+      </div>
+
+      {/* Per-worker breakdown */}
+      <div className="rounded-xl border bg-white shadow-sm overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-4 border-b">
+          <h3 className="font-semibold text-gray-900">Worker Performance</h3>
+          <button
+            onClick={onExportCsv}
+            className="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+          >
+            <Download size={13} />
+            Export CSV
+          </button>
+        </div>
+        <Table
+          columns={workerColumns}
+          data={analytics.workers as WorkerAnalyticsRow[]}
+          emptyMessage="No worker data yet"
+          aria-label="Worker performance breakdown"
+          className="rounded-none border-0"
+        />
+      </div>
+
+      {/* Views by worker chart */}
+      {analytics.workers.length > 0 && (
+        <div className="rounded-xl border bg-white p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Views by Worker</h3>
+          <CuratorCharts.WorkersBarChart workers={analytics.workers} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/Dashboard/DeleteWorkerDialog.tsx
+++ b/packages/app/src/components/Dashboard/DeleteWorkerDialog.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { AlertTriangle, Loader2, X } from "lucide-react";
+
+interface DeleteWorkerDialogProps {
+  workerName: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isDeleting: boolean;
+}
+
+/**
+ * Confirmation dialog shown before permanently deleting a worker listing.
+ */
+export function DeleteWorkerDialog({
+  workerName,
+  open,
+  onOpenChange,
+  onConfirm,
+  isDeleting,
+}: DeleteWorkerDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-900">
+          <div className="flex items-start justify-between">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-50">
+                <AlertTriangle size={18} className="text-red-500" />
+              </div>
+              <div>
+                <Dialog.Title className="font-semibold text-gray-900 dark:text-gray-100">
+                  Delete worker?
+                </Dialog.Title>
+                <Dialog.Description className="mt-0.5 text-sm text-gray-500">
+                  This will permanently remove{" "}
+                  <span className="font-medium text-gray-700 dark:text-gray-300">
+                    {workerName}
+                  </span>
+                  . This action cannot be undone.
+                </Dialog.Description>
+              </div>
+            </div>
+            <Dialog.Close className="rounded-md p-1 text-gray-400 hover:text-gray-600">
+              <X size={16} />
+            </Dialog.Close>
+          </div>
+
+          <div className="mt-5 flex gap-3">
+            <Dialog.Close className="flex-1 rounded-lg border py-2.5 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800">
+              Cancel
+            </Dialog.Close>
+            <button
+              onClick={onConfirm}
+              disabled={isDeleting}
+              className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-600 py-2.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-60 transition-colors"
+            >
+              {isDeleting && <Loader2 size={14} className="animate-spin" />}
+              Delete
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/app/src/components/Dashboard/MetricCard.tsx
+++ b/packages/app/src/components/Dashboard/MetricCard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { TrendingUp, TrendingDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface MetricCardProps {
+  icon?: ReactNode;
+  label: string;
+  value: string | number;
+  sub?: string;
+  /** Optional percentage change — shows a trend badge when provided. */
+  trend?: number;
+  className?: string;
+}
+
+/**
+ * Shared metric/stat card used across the curator dashboard and admin dashboard.
+ *
+ * When `trend` is provided a coloured badge with a directional arrow is shown
+ * beneath the value (mirrors the former GrowthCard in admin/page.tsx).
+ */
+export function MetricCard({ icon, label, value, sub, trend, className }: MetricCardProps) {
+  const isPositive = trend !== undefined && trend >= 0;
+
+  return (
+    <div className={cn("rounded-xl border bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900", className)}>
+      <div className="flex items-center gap-2 text-gray-400 mb-2">
+        {icon}
+        <span className="text-xs font-medium uppercase tracking-wide text-gray-600 dark:text-gray-400">
+          {label}
+        </span>
+      </div>
+
+      {trend !== undefined ? (
+        <div className="flex items-end gap-2 mt-1">
+          <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {typeof value === "number" ? value.toLocaleString() : value}
+          </p>
+          <span
+            className={cn(
+              "flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium",
+              isPositive ? "bg-green-50 text-green-600" : "bg-red-50 text-red-600"
+            )}
+          >
+            {isPositive ? <TrendingUp size={12} /> : <TrendingDown size={12} />}
+            {Math.abs(trend)}%
+          </span>
+        </div>
+      ) : (
+        <p className="text-2xl font-bold text-gray-900 dark:text-gray-100 mt-1">
+          {typeof value === "number" ? value.toLocaleString() : value}
+        </p>
+      )}
+
+      {sub && <p className="mt-0.5 text-xs text-gray-400">{sub}</p>}
+      {trend !== undefined && !sub && (
+        <p className="mt-0.5 text-xs text-gray-400">vs last month</p>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/Dashboard/WorkersPanel.tsx
+++ b/packages/app/src/components/Dashboard/WorkersPanel.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import Link from "next/link";
+import dynamic from "next/dynamic";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  ToggleLeft,
+  ToggleRight,
+  TrendingUp,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Table, type ColumnDef, type RowAction } from "@/components/Table";
+import { DashboardTableSkeleton } from "@/components/Skeleton";
+import type { ViewTrend } from "@/types";
+
+// ── Dynamic import (code splitting) ─────────────────────────────────────────
+const CuratorCharts = dynamic(
+  () => import("@/components/charts/CuratorCharts"),
+  { ssr: false, loading: () => <div className="h-[250px] rounded-lg bg-gray-50 animate-pulse" /> }
+);
+
+export interface DashboardWorker {
+  id: string;
+  name: string;
+  isActive: boolean;
+  createdAt: string;
+  category: { id: string; name: string };
+}
+
+interface WorkersPanelProps {
+  workers: DashboardWorker[];
+  loading: boolean;
+  selectedWorkerTrends: ViewTrend[] | null;
+  selectedWorkerName: string;
+  trendsLoading: boolean;
+  onToggle: (worker: DashboardWorker) => void;
+  onDeleteRequest: (worker: DashboardWorker) => void;
+  onViewTrends: (workerId: string, workerName: string) => void;
+  onCloseTrends: () => void;
+}
+
+/**
+ * Workers tab panel — renders a Table of the curator's worker listings
+ * plus an inline view-trends chart panel.
+ */
+export function WorkersPanel({
+  workers,
+  loading,
+  selectedWorkerTrends,
+  selectedWorkerName,
+  trendsLoading,
+  onToggle,
+  onDeleteRequest,
+  onViewTrends,
+  onCloseTrends,
+}: WorkersPanelProps) {
+  const columns: ColumnDef<DashboardWorker>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cell: (w) => <span className="font-medium text-gray-800">{w.name}</span>,
+    },
+    {
+      key: "category",
+      header: "Category",
+      cell: (w) => (
+        <span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-600">
+          {w.category.name}
+        </span>
+      ),
+    },
+    {
+      key: "isActive",
+      header: "Status",
+      cell: (w) => (
+        <span
+          className={cn(
+            "rounded-full px-2.5 py-0.5 text-xs font-medium",
+            w.isActive ? "bg-green-50 text-green-600" : "bg-gray-100 text-gray-500"
+          )}
+        >
+          {w.isActive ? "Active" : "Inactive"}
+        </span>
+      ),
+    },
+    {
+      key: "createdAt",
+      header: "Created",
+      cell: (w) => (
+        <span className="text-gray-400">
+          {new Date(w.createdAt).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })}
+        </span>
+      ),
+      hideOnMobile: true,
+    },
+  ];
+
+  const rowActions: RowAction<DashboardWorker>[] = [
+    {
+      label: "View Trends",
+      icon: <TrendingUp size={15} />,
+      onClick: (w) => onViewTrends(w.id, w.name),
+    },
+    {
+      label: "Edit",
+      icon: (
+        <Link
+          href="#"
+          onClick={(e) => e.stopPropagation()}
+          className="contents"
+        >
+          <Pencil size={15} />
+        </Link>
+      ),
+      // Navigate via link — the action button wraps the icon; we use onClick too
+      onClick: () => {},
+    },
+    {
+      label: "Toggle",
+      icon: null, // rendered dynamically below
+      onClick: (w) => onToggle(w),
+    },
+    {
+      label: "Delete",
+      icon: <Trash2 size={15} />,
+      onClick: (w) => onDeleteRequest(w),
+      variant: "danger",
+    },
+  ];
+
+  // rowActions doesn't give us per-row icon customisation for the toggle button,
+  // so we use a custom cell-based column for actions instead of rowActions prop.
+  const actionsColumn: ColumnDef<DashboardWorker> = {
+    key: "_actions",
+    header: "Actions",
+    className: "text-right",
+    cell: (w) => (
+      <div className="flex items-center justify-end gap-1">
+        <button
+          onClick={() => onViewTrends(w.id, w.name)}
+          className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-blue-600 transition-colors"
+          title="View Trends"
+        >
+          <TrendingUp size={15} />
+        </button>
+        <Link
+          href={`/dashboard/workers/${w.id}/edit`}
+          className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-blue-600 transition-colors"
+          title="Edit"
+        >
+          <Pencil size={15} />
+        </Link>
+        <button
+          onClick={() => onToggle(w)}
+          className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-blue-600 transition-colors"
+          title={w.isActive ? "Deactivate" : "Activate"}
+        >
+          {w.isActive ? (
+            <ToggleRight size={17} className="text-green-500" />
+          ) : (
+            <ToggleLeft size={17} />
+          )}
+        </button>
+        <button
+          onClick={() => onDeleteRequest(w)}
+          className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-red-500 transition-colors"
+          title="Delete"
+        >
+          <Trash2 size={15} />
+        </button>
+      </div>
+    ),
+  };
+
+  if (loading) {
+    return <DashboardTableSkeleton />;
+  }
+
+  return (
+    <>
+      <Table
+        columns={[...columns, actionsColumn]}
+        data={workers}
+        loading={false}
+        emptyMessage="No workers yet. Create your first worker listing to get started."
+        aria-label="Worker listings"
+        className="bg-white"
+      />
+
+      {/* Empty-state CTA (Table renders text, but we want a richer prompt) */}
+      {workers.length === 0 && (
+        <div className="mt-4 flex justify-center">
+          <Link
+            href="/dashboard/workers/new"
+            className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          >
+            <Plus size={15} />
+            Create Worker
+          </Link>
+        </div>
+      )}
+
+      {/* View Trends Panel */}
+      {selectedWorkerTrends && (
+        <div className="mt-6 rounded-xl border bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-gray-900">
+              Views — {selectedWorkerName} (Last 30 days)
+            </h3>
+            <button
+              onClick={onCloseTrends}
+              className="rounded-md p-1 text-gray-400 hover:text-gray-600"
+            >
+              <X size={16} />
+            </button>
+          </div>
+          <CuratorCharts.ViewTrendsChart
+            trends={selectedWorkerTrends}
+            trendsLoading={trendsLoading}
+            workerName={selectedWorkerName}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/app/src/components/Dashboard/index.ts
+++ b/packages/app/src/components/Dashboard/index.ts
@@ -4,3 +4,12 @@ export type { ActivityItem, ActivityType } from "./ActivityTimeline";
 export { SavedWorkers } from "./SavedWorkers";
 export { MessagesPreview } from "./MessagesPreview";
 export { QuickProfileEdit } from "./QuickProfileEdit";
+
+export { MetricCard } from "./MetricCard";
+export type { MetricCardProps } from "./MetricCard";
+
+export { WorkersPanel } from "./WorkersPanel";
+export type { DashboardWorker } from "./WorkersPanel";
+
+export { AnalyticsPanel } from "./AnalyticsPanel";
+export { DeleteWorkerDialog } from "./DeleteWorkerDialog";


### PR DESCRIPTION
## Summary

Closes #1164

`dashboard/page.tsx` was a 610-line client component handling auth-guard redirects, worker CRUD, analytics fetching, wallet-balance polling, CSV export, and a delete-confirmation dialog — all in a single file. It also hand-rolled two separate `<table>` blocks with identical styling despite a shared `Table` component already existing in the design system, and defined `MetricCard` inline instead of in `components/`.

This PR splits the file into focused, composable components and connects everything through the existing shared primitives.

---

## Changes

### New components in `components/Dashboard/`

| File | Purpose |
|---|---|
| `MetricCard.tsx` | Shared stat card consolidating the inline `MetricCard` from `dashboard/page.tsx` **and** the inline `StatCard` + `GrowthCard` from `admin/page.tsx`. Supports an optional `trend` prop for the percentage-change badge. |
| `WorkersPanel.tsx` | Workers tab — renders worker listings via the shared `Table` component with `ColumnDef` cells for name, category, status, date, and a custom actions column (edit, toggle, delete, view trends). |
| `AnalyticsPanel.tsx` | Analytics tab — metric cards, revenue/workers overview panels, per-worker breakdown table (shared `Table`), and a views-by-worker bar chart. |
| `DeleteWorkerDialog.tsx` | Standalone Radix `Dialog` for the delete-confirmation flow, decoupled from page state. |

### Modified files

- **`dashboard/page.tsx`** — shrinks from **610 → 309 lines**. Now only owns state, data-fetching, handlers, and tab chrome; composes `WorkersPanel`, `AnalyticsPanel`, and `DeleteWorkerDialog`.
- **`dashboard/admin/page.tsx`** — removes the two duplicate local components (`StatCard`, `GrowthCard`) and imports the shared `MetricCard` instead.
- **`components/Dashboard/index.ts`** — exports all four new components.

---

## Acceptance criteria

- [x] `dashboard/page.tsx` split into focused components composed from the page
- [x] Both hand-rolled `<table>` blocks replaced with the shared `Table` component
- [x] `MetricCard` moved into `components/`, near-duplicate cards in Dashboard/Admin consolidated into one
- [x] No new type errors introduced (pre-existing `packages/types` parse errors are unrelated to this PR)

---

## Testing

- Manual review of all component files for correctness
- Confirmed the pre-existing type errors in `packages/types/src/index.ts` exist on `main` independently of this branch
- All business logic (toggle, delete, CSV export, trends fetch, wallet balance) is preserved verbatim — only moved to the appropriate component

---

## Notes

- `AdminAnalyticsDashboard.tsx` uses the shadcn `Card` primitive directly and has a different layout pattern; it was intentionally left unchanged as it is not a near-duplicate of `MetricCard`.
- This PR can be sequenced before or alongside Issue #11 (data-fetching migration) without conflict.